### PR TITLE
feat(sdk): add isValidConnection and reactFlowProps to Root

### DIFF
--- a/.changeset/connection-validation-and-reactflow-props.md
+++ b/.changeset/connection-validation-and-reactflow-props.md
@@ -1,0 +1,5 @@
+---
+'@workflowbuilder/sdk': minor
+---
+
+feat: add `isValidConnection` and `reactFlowProps` to `<WorkflowBuilder.Root>`. `isValidConnection` validates connections as the user draws them; `reactFlowProps` forwards extra props to the underlying ReactFlow canvas (SDK-managed props excluded).

--- a/.changeset/connection-validation-and-reactflow-props.md
+++ b/.changeset/connection-validation-and-reactflow-props.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': minor
 ---
 
-feat: add `isValidConnection` and `reactFlowProps` to `<WorkflowBuilder.Root>`. `isValidConnection` validates connections as the user draws them; `reactFlowProps` forwards extra props to the underlying ReactFlow canvas (SDK-managed props excluded).
+feat: add `isValidConnection` (validate connections as the user draws them) and `reactFlowProps` (forward extra props to the ReactFlow canvas) to `<WorkflowBuilder.Root>`.

--- a/apps/demo/src/app/app.tsx
+++ b/apps/demo/src/app/app.tsx
@@ -36,12 +36,9 @@ const edgeTemplates = {
 } satisfies WorkflowBuilderEdgeTemplates;
 
 // A trigger is a workflow entry point, so it can never be a connection target.
-// Returning false rejects the drop with no edge created. The source / target
-// nodes are resolved for us.
 const isValidConnection: WorkflowBuilderIsValidConnection = ({ targetNode }) => targetNode.data.type !== 'trigger';
 
-// Advanced escape hatch: forward extra ReactFlow props the SDK doesn't surface as
-// first-class props. SDK-owned props (nodes, onConnect, …) can't be set here.
+// Advanced escape hatch: forward extra ReactFlow props (SDK-owned props can't be set here).
 const reactFlowProps = {
   zoomOnDoubleClick: false,
 } satisfies WorkflowBuilderReactFlowProps;

--- a/apps/demo/src/app/app.tsx
+++ b/apps/demo/src/app/app.tsx
@@ -1,5 +1,10 @@
 import { WorkflowBuilder } from '@workflowbuilder/sdk';
-import type { WorkflowBuilderEdgeTemplates, WorkflowBuilderNodeTemplates } from '@workflowbuilder/sdk';
+import type {
+  WorkflowBuilderEdgeTemplates,
+  WorkflowBuilderIsValidConnection,
+  WorkflowBuilderNodeTemplates,
+  WorkflowBuilderReactFlowProps,
+} from '@workflowbuilder/sdk';
 
 import '@workflowbuilder/sdk/style.css';
 
@@ -30,6 +35,17 @@ const edgeTemplates = {
   dashed: DashedEdge,
 } satisfies WorkflowBuilderEdgeTemplates;
 
+// A trigger is a workflow entry point, so it can never be a connection target.
+// Returning false rejects the drop with no edge created. The source / target
+// nodes are resolved for us.
+const isValidConnection: WorkflowBuilderIsValidConnection = ({ targetNode }) => targetNode.data.type !== 'trigger';
+
+// Advanced escape hatch: forward extra ReactFlow props the SDK doesn't surface as
+// first-class props. SDK-owned props (nodes, onConnect, …) can't be set here.
+const reactFlowProps = {
+  zoomOnDoubleClick: false,
+} satisfies WorkflowBuilderReactFlowProps;
+
 export function App() {
   return (
     <WorkflowBuilder.Root
@@ -38,6 +54,8 @@ export function App() {
       nodeTemplates={nodeTemplates}
       edgeTemplates={edgeTemplates}
       diagramTemplates={demoTemplates}
+      isValidConnection={isValidConnection}
+      reactFlowProps={reactFlowProps}
       plugins={[
         demoPlugin,
         analyticsPlugin,

--- a/apps/docs/src/content/docs/guides/configuring-the-editor.md
+++ b/apps/docs/src/content/docs/guides/configuring-the-editor.md
@@ -17,18 +17,20 @@ import { WorkflowBuilder } from '@workflowbuilder/sdk';
 
 All props optional unless marked.
 
-| Prop               | Type                                                                 | Default                        | Description                                                            |
-| ------------------ | -------------------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------- |
-| `integration`      | [`WorkflowBuilderIntegration`](#integration-strategies)              | `{ strategy: 'localStorage' }` | How the builder loads and persists diagram data.                       |
-| `nodeTypes`        | [`PaletteItemOrGroup[]`](#node-types)                                | `[]`                           | Node type definitions rendered in the palette and used for validation. |
-| `diagramTemplates` | `TemplateModel[]`                                                    | `[]`                           | Diagram templates available in the template selector.                  |
-| `jsonForm`         | [`WorkflowBuilderJsonFormConfig`](/guides/custom-jsonforms-control/) | —                              | Custom JSONForms renderers, cells, and translations.                   |
-| `plugins`          | [`WorkflowBuilderPlugin[]`](/guides/build-a-plugin/)                 | —                              | Plugin initializer functions. Each called once on first mount.         |
-| `name`             | `string`                                                             | —                              | Workflow name displayed in the header.                                 |
-| `layoutDirection`  | `'DOWN' \| 'RIGHT'`                                                  | `'DOWN'`                       | Flow direction of the diagram.                                         |
-| `initialNodes`     | `WorkflowBuilderNode[]`                                              | `[]`                           | Initial diagram nodes (used by the `props` integration strategy).      |
-| `initialEdges`     | `WorkflowBuilderEdge[]`                                              | `[]`                           | Initial diagram edges (used by the `props` integration strategy).      |
-| `children`         | `ReactNode`                                                          | `<DefaultLayout />`            | Custom layout. Omit children for the default floating-overlay layout.  |
+| Prop                | Type                                                                 | Default                        | Description                                                            |
+| ------------------- | -------------------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------- |
+| `integration`       | [`WorkflowBuilderIntegration`](#integration-strategies)              | `{ strategy: 'localStorage' }` | How the builder loads and persists diagram data.                       |
+| `nodeTypes`         | [`PaletteItemOrGroup[]`](#node-types)                                | `[]`                           | Node type definitions rendered in the palette and used for validation. |
+| `diagramTemplates`  | `TemplateModel[]`                                                    | `[]`                           | Diagram templates available in the template selector.                  |
+| `jsonForm`          | [`WorkflowBuilderJsonFormConfig`](/guides/custom-jsonforms-control/) | —                              | Custom JSONForms renderers, cells, and translations.                   |
+| `plugins`           | [`WorkflowBuilderPlugin[]`](/guides/build-a-plugin/)                 | —                              | Plugin initializer functions. Each called once on first mount.         |
+| `name`              | `string`                                                             | —                              | Workflow name displayed in the header.                                 |
+| `layoutDirection`   | `'DOWN' \| 'RIGHT'`                                                  | `'DOWN'`                       | Flow direction of the diagram.                                         |
+| `initialNodes`      | `WorkflowBuilderNode[]`                                              | `[]`                           | Initial diagram nodes (used by the `props` integration strategy).      |
+| `initialEdges`      | `WorkflowBuilderEdge[]`                                              | `[]`                           | Initial diagram edges (used by the `props` integration strategy).      |
+| `isValidConnection` | [`WorkflowBuilderIsValidConnection`](#connection-validation)         | —                              | Validate connections as the user draws them.                           |
+| `reactFlowProps`    | [`WorkflowBuilderReactFlowProps`](#advanced-reactflow-props)         | —                              | Escape hatch for the underlying ReactFlow canvas.                      |
+| `children`          | `ReactNode`                                                          | `<DefaultLayout />`            | Custom layout. Omit children for the default floating-overlay layout.  |
 
 ## Compound subcomponents
 
@@ -166,6 +168,43 @@ type DidSaveStatus = 'success' | 'error' | 'alreadyStarted';
 ```
 
 Today the runtime treats every non-empty resolution of `onDataSave` as "the save finished", surfacing the success-style snackbar — `'success'`, `'error'`, and `'alreadyStarted'` all behave the same way at the UI level. Throw from `onDataSave` instead of resolving to `'error'` if you need an error snackbar.
+
+## Connection validation
+
+`isValidConnection` decides whether a connection between two nodes is allowed. It runs live while the user drags a connection: return `false` to reject it. No edge is created and there is no flicker.
+
+The callback receives the resolved `sourceNode` and `targetNode` (plus the raw `connection`), so a rule can branch on `data.type` / `data.properties` without reaching into the store. Declare it at module scope (or memoize) so the reference stays stable.
+
+```tsx
+import { WorkflowBuilder, type WorkflowBuilderIsValidConnection } from '@workflowbuilder/sdk';
+
+const isValidConnection: WorkflowBuilderIsValidConnection = ({ sourceNode, targetNode }) =>
+  !(sourceNode.data.type === 'start' && targetNode.data.type === 'start');
+
+<WorkflowBuilder.Root isValidConnection={isValidConnection} />;
+```
+
+This validates interactive drags only. Programmatic edge writes (templates, paste, `setStoreEdges`) are not gated, the same as in ReactFlow.
+
+The SDK ships no colour for the in-drag handle state. To add a visual cue, style ReactFlow's handle classes yourself: during a drag it adds `connectingto` to the hovered handle, plus `valid` when `isValidConnection` allows the connection (`.react-flow__handle.connectingto` for an invalid target, `.react-flow__handle.connectingto.valid` for an allowed one).
+
+## Advanced: ReactFlow props
+
+`reactFlowProps` forwards extra props straight to the underlying ReactFlow canvas, for capabilities the SDK does not surface as first-class props: zoom limits, key codes, viewport bounds, edge reconnection, observability handlers (`onNodeClick`, `onPaneClick`, …), performance flags, and so on.
+
+```tsx
+import { WorkflowBuilder, type WorkflowBuilderReactFlowProps } from '@workflowbuilder/sdk';
+
+const reactFlowProps = {
+  maxZoom: 1.5,
+  zoomOnDoubleClick: false,
+  onNodeClick: (_, node) => console.log(node.id),
+} satisfies WorkflowBuilderReactFlowProps;
+
+<WorkflowBuilder.Root reactFlowProps={reactFlowProps} />;
+```
+
+Props the SDK owns (graph data, the connection / selection / change handlers, node and edge type maps, the connection line, plus `colorMode`) are omitted from `WorkflowBuilderReactFlowProps`, so they can't be set here and this can never break the editor. To **observe** SDK-owned events use the listener APIs (`addNodeChangedListener`, `addNodeDragStartListener`) instead. To change colours use the design tokens, not `colorMode`. Passing arbitrary ReactFlow props couples your app to ReactFlow's version.
 
 ## Minimal example
 

--- a/apps/docs/src/content/docs/guides/configuring-the-editor.md
+++ b/apps/docs/src/content/docs/guides/configuring-the-editor.md
@@ -171,9 +171,7 @@ Today the runtime treats every non-empty resolution of `onDataSave` as "the save
 
 ## Connection validation
 
-`isValidConnection` decides whether a connection between two nodes is allowed. It runs live while the user drags a connection: return `false` to reject it. No edge is created and there is no flicker.
-
-The callback receives the resolved `sourceNode` and `targetNode` (plus the raw `connection`), so a rule can branch on `data.type` / `data.properties` without reaching into the store. Declare it at module scope (or memoize) so the reference stays stable.
+`isValidConnection` decides whether a dragged connection is allowed. Return `false` to reject it: no edge is created, no flicker. It receives the resolved `sourceNode` / `targetNode` (plus the raw `connection`), so a rule can branch on node `data` without reaching into the store. Declare it at module scope (or memoize) to keep the reference stable.
 
 ```tsx
 import { WorkflowBuilder, type WorkflowBuilderIsValidConnection } from '@workflowbuilder/sdk';
@@ -184,11 +182,11 @@ const isValidConnection: WorkflowBuilderIsValidConnection = ({ sourceNode, targe
 <WorkflowBuilder.Root isValidConnection={isValidConnection} />;
 ```
 
-This validates interactive drags only. Programmatic edge writes (templates, paste, `setStoreEdges`) are not gated, the same as in ReactFlow.
+Validates interactive drags only, not programmatic edge writes (templates, paste, `setStoreEdges`). Fail-open: if an endpoint can't be resolved to a node, the connection is allowed.
 
 ## Advanced: ReactFlow props
 
-`reactFlowProps` forwards extra props straight to the underlying ReactFlow canvas, for capabilities the SDK does not surface as first-class props: zoom limits, key codes, viewport bounds, edge reconnection, observability handlers (`onNodeClick`, `onPaneClick`, …), performance flags, and so on.
+`reactFlowProps` forwards extra props to the underlying ReactFlow canvas for things the SDK doesn't expose directly (zoom limits, key codes, `onNodeClick`, performance flags, …).
 
 ```tsx
 import { WorkflowBuilder, type WorkflowBuilderReactFlowProps } from '@workflowbuilder/sdk';
@@ -202,7 +200,7 @@ const reactFlowProps = {
 <WorkflowBuilder.Root reactFlowProps={reactFlowProps} />;
 ```
 
-Props the SDK owns (graph data, the connection / selection / change handlers, node and edge type maps, the connection line, plus `colorMode`) are omitted from `WorkflowBuilderReactFlowProps`, so they can't be set here and this can never break the editor. To **observe** SDK-owned events use the listener APIs (`addNodeChangedListener`, `addNodeDragStartListener`) instead. To change colours use the design tokens, not `colorMode`. Passing arbitrary ReactFlow props couples your app to ReactFlow's version.
+Props the SDK owns (graph data, the connection / selection / change handlers, type maps, `colorMode`, …) can't be set here. To observe SDK events use the listener APIs (`addNodeChangedListener`, …); to theme use the design tokens. Treat `reactFlowProps` as static config: runtime value changes may not apply immediately.
 
 ## Minimal example
 

--- a/apps/docs/src/content/docs/guides/configuring-the-editor.md
+++ b/apps/docs/src/content/docs/guides/configuring-the-editor.md
@@ -186,8 +186,6 @@ const isValidConnection: WorkflowBuilderIsValidConnection = ({ sourceNode, targe
 
 This validates interactive drags only. Programmatic edge writes (templates, paste, `setStoreEdges`) are not gated, the same as in ReactFlow.
 
-The SDK ships no colour for the in-drag handle state. To add a visual cue, style ReactFlow's handle classes yourself: during a drag it adds `connectingto` to the hovered handle, plus `valid` when `isValidConnection` allows the connection (`.react-flow__handle.connectingto` for an invalid target, `.react-flow__handle.connectingto.valid` for an allowed one).
-
 ## Advanced: ReactFlow props
 
 `reactFlowProps` forwards extra props straight to the underlying ReactFlow canvas, for capabilities the SDK does not surface as first-class props: zoom limits, key codes, viewport bounds, edge reconnection, observability handlers (`onNodeClick`, `onPaneClick`, …), performance flags, and so on.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -103,7 +103,7 @@ If you omit `<WorkflowBuilder.TopBar />`, use [`useWorkflowBuilderActions()`](ht
 | `initialNodes`      | `WorkflowBuilderNode[]`            | Starting diagram nodes.                                                                                                                                                                                                                        |
 | `initialEdges`      | `WorkflowBuilderEdge[]`            | Starting diagram edges.                                                                                                                                                                                                                        |
 | `isValidConnection` | `WorkflowBuilderIsValidConnection` | Validate connections as the user draws them. See [Connection validation](#connection-validation). **Stable reference required.**                                                                                                               |
-| `reactFlowProps`    | `WorkflowBuilderReactFlowProps`    | Advanced escape hatch for the underlying ReactFlow canvas. See [Advanced: ReactFlow props](#advanced-reactflow-props). Stable reference preferred, not required.                                                                               |
+| `reactFlowProps`    | `WorkflowBuilderReactFlowProps`    | Advanced escape hatch for the underlying ReactFlow canvas. See [Advanced: ReactFlow props](#advanced-reactflow-props). Treat as static config (runtime value changes may not apply immediately).                                               |
 
 Full reference (every public type, hook, and helper): <https://www.workflowbuilder.io/docs/api/core/workflowbuilder/>.
 
@@ -159,14 +159,12 @@ Full guide: [Build a plugin](https://www.workflowbuilder.io/docs/guides/build-a-
 
 ## Connection validation
 
-Pass `isValidConnection` to decide whether a connection between two nodes is allowed. It runs live while the user drags a connection: return `false` to reject it. No edge is created and there is no flicker.
-
-The callback receives the resolved `sourceNode` and `targetNode` (plus the raw `connection`), so you branch on `data.type` / `data.properties` without reaching into the store:
+`isValidConnection` decides whether a dragged connection is allowed. Return `false` to reject it: no edge is created, no flicker. It receives the resolved `sourceNode` / `targetNode` (plus the raw `connection`), so you branch on node `data` without reaching into the store.
 
 ```tsx
 import { WorkflowBuilder, type WorkflowBuilderIsValidConnection } from '@workflowbuilder/sdk';
 
-// Declared at module scope so the reference stays stable across renders.
+// Module scope keeps the reference stable.
 const isValidConnection: WorkflowBuilderIsValidConnection = ({ sourceNode, targetNode }) =>
   !(sourceNode.data.type === 'start' && targetNode.data.type === 'start');
 
@@ -175,11 +173,11 @@ export function App() {
 }
 ```
 
-This validates interactive drags only. Programmatic edge writes (templates, paste, `setStoreEdges`) are not gated, the same as in ReactFlow.
+Validates interactive drags only, not programmatic edge writes (templates, paste, `setStoreEdges`). Fail-open: if an endpoint can't be resolved to a node, the connection is allowed.
 
 ## Advanced: ReactFlow props
 
-`reactFlowProps` forwards extra props straight to the underlying ReactFlow canvas for capabilities the SDK does not surface as first-class props: zoom limits, key codes, viewport bounds, edge reconnection, observability handlers (`onNodeClick`, `onPaneClick`, …), performance flags, and so on.
+`reactFlowProps` forwards extra props to the underlying ReactFlow canvas for things the SDK doesn't expose directly (zoom limits, key codes, `onNodeClick`, performance flags, …).
 
 ```tsx
 const reactFlowProps = {
@@ -191,7 +189,7 @@ const reactFlowProps = {
 <WorkflowBuilder.Root reactFlowProps={reactFlowProps} />;
 ```
 
-Props the SDK owns (graph data, the connection / selection / change handlers, node & edge type maps, the connection line, plus `colorMode`) are omitted from the type, so they can't be set here and this can never break the editor. To **observe** SDK-owned events (node / edge changes, drag start) use the listener APIs (`addNodeChangedListener`, `addNodeDragStartListener`) instead. To change colours use [Theming](#theming), not `colorMode`. Passing arbitrary ReactFlow props couples your app to ReactFlow's version.
+Props the SDK owns (graph data, the connection / selection / change handlers, type maps, `colorMode`, …) can't be set here. To observe SDK events use the listener APIs (`addNodeChangedListener`, …); to theme use [Theming](#theming). Treat `reactFlowProps` as static config: runtime value changes may not apply immediately.
 
 ## Theming
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -89,19 +89,21 @@ If you omit `<WorkflowBuilder.TopBar />`, use [`useWorkflowBuilderActions()`](ht
 
 ## `<WorkflowBuilder.Root>` props
 
-| Prop               | Type                            | Description                                                                                                                                                                                                                                    |
-| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeTypes`        | `PaletteItemOrGroup[]`          | Node type definitions. Appear in the palette and drive validation. **Must be a stable reference** — declare at module scope or memoize.                                                                                                        |
-| `nodeTemplates`    | `WorkflowBuilderNodeTemplates`  | Per-node-type custom renderers. Map of `data.type` → React component, overriding the default node renderer for that type. **Stable reference required** (same as `nodeTypes`).                                                                 |
-| `edgeTemplates`    | `WorkflowBuilderEdgeTemplates`  | Per-edge-type custom renderers. Map of `edge.type` → React component taking ReactFlow `EdgeProps`, overriding the built-in `labelEdge`. Unregistered types fall back to the default edge. **Stable reference required** (same as `nodeTypes`). |
-| `diagramTemplates` | `TemplateModel[]`               | Diagram templates available in the template selector. **Stable reference required** (same as `nodeTypes`).                                                                                                                                     |
-| `plugins`          | `WorkflowBuilderPlugin[]`       | Functions registering decorators. Synchronous, executed once.                                                                                                                                                                                  |
-| `jsonForm`         | `WorkflowBuilderJsonFormConfig` | Custom JsonForms renderers, cells, translations.                                                                                                                                                                                               |
-| `integration`      | `WorkflowBuilderIntegration`    | Data source / sink. Defaults to `localStorage`.                                                                                                                                                                                                |
-| `name`             | `string`                        | Workflow name shown in the header.                                                                                                                                                                                                             |
-| `layoutDirection`  | `'DOWN' \| 'RIGHT'`             | Initial flow direction.                                                                                                                                                                                                                        |
-| `initialNodes`     | `WorkflowBuilderNode[]`         | Starting diagram nodes.                                                                                                                                                                                                                        |
-| `initialEdges`     | `WorkflowBuilderEdge[]`         | Starting diagram edges.                                                                                                                                                                                                                        |
+| Prop                | Type                               | Description                                                                                                                                                                                                                                    |
+| ------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nodeTypes`         | `PaletteItemOrGroup[]`             | Node type definitions. Appear in the palette and drive validation. **Must be a stable reference** — declare at module scope or memoize.                                                                                                        |
+| `nodeTemplates`     | `WorkflowBuilderNodeTemplates`     | Per-node-type custom renderers. Map of `data.type` → React component, overriding the default node renderer for that type. **Stable reference required** (same as `nodeTypes`).                                                                 |
+| `edgeTemplates`     | `WorkflowBuilderEdgeTemplates`     | Per-edge-type custom renderers. Map of `edge.type` → React component taking ReactFlow `EdgeProps`, overriding the built-in `labelEdge`. Unregistered types fall back to the default edge. **Stable reference required** (same as `nodeTypes`). |
+| `diagramTemplates`  | `TemplateModel[]`                  | Diagram templates available in the template selector. **Stable reference required** (same as `nodeTypes`).                                                                                                                                     |
+| `plugins`           | `WorkflowBuilderPlugin[]`          | Functions registering decorators. Synchronous, executed once.                                                                                                                                                                                  |
+| `jsonForm`          | `WorkflowBuilderJsonFormConfig`    | Custom JsonForms renderers, cells, translations.                                                                                                                                                                                               |
+| `integration`       | `WorkflowBuilderIntegration`       | Data source / sink. Defaults to `localStorage`.                                                                                                                                                                                                |
+| `name`              | `string`                           | Workflow name shown in the header.                                                                                                                                                                                                             |
+| `layoutDirection`   | `'DOWN' \| 'RIGHT'`                | Initial flow direction.                                                                                                                                                                                                                        |
+| `initialNodes`      | `WorkflowBuilderNode[]`            | Starting diagram nodes.                                                                                                                                                                                                                        |
+| `initialEdges`      | `WorkflowBuilderEdge[]`            | Starting diagram edges.                                                                                                                                                                                                                        |
+| `isValidConnection` | `WorkflowBuilderIsValidConnection` | Validate connections as the user draws them. See [Connection validation](#connection-validation). **Stable reference required.**                                                                                                               |
+| `reactFlowProps`    | `WorkflowBuilderReactFlowProps`    | Advanced escape hatch for the underlying ReactFlow canvas. See [Advanced: ReactFlow props](#advanced-reactflow-props). **Stable reference required.**                                                                                          |
 
 Full reference (every public type, hook, and helper): <https://www.workflowbuilder.io/docs/api/core/workflowbuilder/>.
 
@@ -154,6 +156,42 @@ export function App() {
 Plugins are synchronous. If you need async work (config fetch, WASM load, feature flag lookup), await it outside the SDK and construct the plugin around the resolved value before passing it to `<Root>`.
 
 Full guide: [Build a plugin](https://www.workflowbuilder.io/docs/guides/build-a-plugin/).
+
+## Connection validation
+
+Pass `isValidConnection` to decide whether a connection between two nodes is allowed. It runs live while the user drags a connection: return `false` to reject it. No edge is created and there is no flicker.
+
+The callback receives the resolved `sourceNode` and `targetNode` (plus the raw `connection`), so you branch on `data.type` / `data.properties` without reaching into the store:
+
+```tsx
+import { WorkflowBuilder, type WorkflowBuilderIsValidConnection } from '@workflowbuilder/sdk';
+
+// Declared at module scope so the reference stays stable across renders.
+const isValidConnection: WorkflowBuilderIsValidConnection = ({ sourceNode, targetNode }) =>
+  !(sourceNode.data.type === 'start' && targetNode.data.type === 'start');
+
+export function App() {
+  return <WorkflowBuilder.Root isValidConnection={isValidConnection} />;
+}
+```
+
+This validates interactive drags only. Programmatic edge writes (templates, paste, `setStoreEdges`) are not gated, the same as in ReactFlow.
+
+## Advanced: ReactFlow props
+
+`reactFlowProps` forwards extra props straight to the underlying ReactFlow canvas for capabilities the SDK does not surface as first-class props: zoom limits, key codes, viewport bounds, edge reconnection, observability handlers (`onNodeClick`, `onPaneClick`, …), performance flags, and so on.
+
+```tsx
+const reactFlowProps = {
+  maxZoom: 1.5,
+  zoomOnDoubleClick: false,
+  onNodeClick: (_, node) => console.log(node.id),
+} satisfies WorkflowBuilderReactFlowProps;
+
+<WorkflowBuilder.Root reactFlowProps={reactFlowProps} />;
+```
+
+Props the SDK owns (graph data, the connection / selection / change handlers, node & edge type maps, the connection line, plus `colorMode`) are omitted from the type, so they can't be set here and this can never break the editor. To **observe** SDK-owned events (node / edge changes, drag start) use the listener APIs (`addNodeChangedListener`, `addNodeDragStartListener`) instead. To change colours use [Theming](#theming), not `colorMode`. Passing arbitrary ReactFlow props couples your app to ReactFlow's version.
 
 ## Theming
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -103,7 +103,7 @@ If you omit `<WorkflowBuilder.TopBar />`, use [`useWorkflowBuilderActions()`](ht
 | `initialNodes`      | `WorkflowBuilderNode[]`            | Starting diagram nodes.                                                                                                                                                                                                                        |
 | `initialEdges`      | `WorkflowBuilderEdge[]`            | Starting diagram edges.                                                                                                                                                                                                                        |
 | `isValidConnection` | `WorkflowBuilderIsValidConnection` | Validate connections as the user draws them. See [Connection validation](#connection-validation). **Stable reference required.**                                                                                                               |
-| `reactFlowProps`    | `WorkflowBuilderReactFlowProps`    | Advanced escape hatch for the underlying ReactFlow canvas. See [Advanced: ReactFlow props](#advanced-reactflow-props). **Stable reference required.**                                                                                          |
+| `reactFlowProps`    | `WorkflowBuilderReactFlowProps`    | Advanced escape hatch for the underlying ReactFlow canvas. See [Advanced: ReactFlow props](#advanced-reactflow-props). Stable reference preferred, not required.                                                                               |
 
 Full reference (every public type, hook, and helper): <https://www.workflowbuilder.io/docs/api/core/workflowbuilder/>.
 

--- a/packages/sdk/src/data/react-flow-config.spec.ts
+++ b/packages/sdk/src/data/react-flow-config.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { getIsValidConnection, getReactFlowProps, setIsValidConnection, setReactFlowProps } from './react-flow-config';
+
+const alwaysValid = () => true;
+
+beforeEach(() => {
+  setIsValidConnection(null);
+  setReactFlowProps(null);
+});
+
+describe('react-flow-config holder', () => {
+  it('round-trips isValidConnection and resets to null', () => {
+    setIsValidConnection(alwaysValid);
+    expect(getIsValidConnection()).toBe(alwaysValid);
+
+    setIsValidConnection(null);
+    expect(getIsValidConnection()).toBeNull();
+  });
+
+  it('round-trips reactFlowProps', () => {
+    const props = { maxZoom: 3 };
+
+    setReactFlowProps(props);
+    expect(getReactFlowProps()).toBe(props);
+  });
+
+  it('returns the same frozen empty object whenever unset', () => {
+    const first = getReactFlowProps();
+    setReactFlowProps(null);
+    const second = getReactFlowProps();
+
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(first).toEqual({});
+  });
+});

--- a/packages/sdk/src/data/react-flow-config.ts
+++ b/packages/sdk/src/data/react-flow-config.ts
@@ -22,7 +22,7 @@ export function getIsValidConnection(): WorkflowBuilderIsValidConnection | null 
 }
 
 export function setReactFlowProps(props: WorkflowBuilderReactFlowProps | null): void {
-  // Falls back to the same frozen object so `useReactFlowProps()` keeps a stable
+  // Falls back to the same frozen object so `getReactFlowProps()` keeps a stable
   // reference when unset.
   reactFlowProps = props ?? EMPTY_PROPS;
 }

--- a/packages/sdk/src/data/react-flow-config.ts
+++ b/packages/sdk/src/data/react-flow-config.ts
@@ -3,10 +3,9 @@ import type {
   WorkflowBuilderReactFlowProps,
 } from '../workflow-builder-root/workflow-builder-root.types';
 
-// Holders for the React Flow config that flows from `<WorkflowBuilder.Root>` to
-// `<WorkflowBuilder.Canvas>` (same pattern as `data/edge-templates.ts`). Not in
-// the store: this is render config, not diagram state, so it must survive
-// `resetWorkflowStore()`.
+// React Flow config passed to `<WorkflowBuilder.Root>`, read by the canvas. Kept
+// out of the store so it survives `resetWorkflowStore()` (same pattern as
+// `data/edge-templates.ts`).
 
 const EMPTY_PROPS: Readonly<WorkflowBuilderReactFlowProps> = Object.freeze({});
 
@@ -22,8 +21,7 @@ export function getIsValidConnection(): WorkflowBuilderIsValidConnection | null 
 }
 
 export function setReactFlowProps(props: WorkflowBuilderReactFlowProps | null): void {
-  // Falls back to the same frozen object so `getReactFlowProps()` keeps a stable
-  // reference when unset.
+  // Reuse the frozen object so the reference stays stable when unset.
   reactFlowProps = props ?? EMPTY_PROPS;
 }
 

--- a/packages/sdk/src/data/react-flow-config.ts
+++ b/packages/sdk/src/data/react-flow-config.ts
@@ -1,0 +1,32 @@
+import type {
+  WorkflowBuilderIsValidConnection,
+  WorkflowBuilderReactFlowProps,
+} from '../workflow-builder-root/workflow-builder-root.types';
+
+// Holders for the React Flow config that flows from `<WorkflowBuilder.Root>` to
+// `<WorkflowBuilder.Canvas>` (same pattern as `data/edge-templates.ts`). Not in
+// the store: this is render config, not diagram state, so it must survive
+// `resetWorkflowStore()`.
+
+const EMPTY_PROPS: Readonly<WorkflowBuilderReactFlowProps> = Object.freeze({});
+
+let isValidConnection: WorkflowBuilderIsValidConnection | null = null;
+let reactFlowProps: WorkflowBuilderReactFlowProps = EMPTY_PROPS;
+
+export function setIsValidConnection(fn: WorkflowBuilderIsValidConnection | null): void {
+  isValidConnection = fn;
+}
+
+export function getIsValidConnection(): WorkflowBuilderIsValidConnection | null {
+  return isValidConnection;
+}
+
+export function setReactFlowProps(props: WorkflowBuilderReactFlowProps | null): void {
+  // Falls back to the same frozen object so `useReactFlowProps()` keeps a stable
+  // reference when unset.
+  reactFlowProps = props ?? EMPTY_PROPS;
+}
+
+export function getReactFlowProps(): WorkflowBuilderReactFlowProps {
+  return reactFlowProps;
+}

--- a/packages/sdk/src/features/diagram/diagram.spec.tsx
+++ b/packages/sdk/src/features/diagram/diagram.spec.tsx
@@ -1,0 +1,106 @@
+// Pins the prop-precedence contract that `reactFlowProps` is sold on
+// (README "Advanced: ReactFlow props"): the consumer escape hatch can override
+// SDK *defaults*, but never the props the SDK *owns*. The guarantee lives in
+// the spread order in `diagram.tsx` (`{...defaults} {...consumer} {...owned}`),
+// so this test renders the canvas with a `ReactFlow` capture stub and inspects
+// the props it actually receives. A reorder of those spreads, or an owned prop
+// leaking into the consumer set, fails here.
+//
+// The node/edge type maps, palette drop, delete modal and temporary edge are
+// stubbed: they pull the overflow-ui + xyflow rendering stack (CSS side
+// effects) and are irrelevant to the spread contract.
+import { render } from '@testing-library/react';
+import { ReactFlow } from '@xyflow/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setIsValidConnection, setReactFlowProps } from '../../data/react-flow-config';
+import type { WorkflowBuilderNode } from '../../node/node-data';
+import { resetWorkflowStore, useStore } from '../../store/store';
+import type { WorkflowBuilderReactFlowProps } from '../../workflow-builder-root/workflow-builder-root.types';
+import { DiagramContainer } from './diagram';
+
+const { updateNodeInternals } = vi.hoisted(() => ({ updateNodeInternals: vi.fn() }));
+
+vi.mock('@xyflow/react', () => ({
+  // Capture stub: the test only inspects the props ReactFlow receives, so it
+  // renders nothing.
+  ReactFlow: vi.fn(() => null),
+  Background: () => null,
+  SelectionMode: { Partial: 'partial' },
+  useUpdateNodeInternals: () => updateNodeInternals,
+}));
+
+vi.mock('./hooks/use-node-types', () => ({ useNodeTypes: () => ({}) }));
+vi.mock('./hooks/use-edge-types', () => ({ useEdgeTypes: () => ({}) }));
+vi.mock('./edges/temporary-edge/temporary-edge', () => ({ TemporaryEdge: () => null }));
+vi.mock('../../hooks/use-palette-drop', () => ({ usePaletteDrop: () => ({ onDropFromPalette: vi.fn() }) }));
+vi.mock('../modals/delete-confirmation/use-delete-confirmation', () => ({
+  useDeleteConfirmation: () => ({ openDeleteConfirmationModal: vi.fn() }),
+}));
+
+function makeNode(id: string): WorkflowBuilderNode {
+  return { id, position: { x: 0, y: 0 }, type: 'action', data: { type: 'action', icon: 'Plus', properties: {} } };
+}
+
+/** Props the (mocked) `ReactFlow` received on the latest render. */
+function capturedFlowProps() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return vi.mocked(ReactFlow).mock.calls.at(-1)![0] as any;
+}
+
+beforeEach(() => {
+  resetWorkflowStore();
+  setIsValidConnection(null);
+  setReactFlowProps(null);
+  vi.mocked(ReactFlow).mockClear();
+});
+
+describe('DiagramContainer — reactFlowProps precedence', () => {
+  it('lets the consumer override SDK defaults', () => {
+    setReactFlowProps({ minZoom: 0.5, panOnScroll: false, zoomOnDoubleClick: false });
+
+    render(<DiagramContainer />);
+    const props = capturedFlowProps();
+
+    expect(props.minZoom).toBe(0.5);
+    expect(props.panOnScroll).toBe(false);
+    expect(props.zoomOnDoubleClick).toBe(false);
+    // A default the consumer did not touch is untouched.
+    expect(props.selectionMode).toBe('partial');
+  });
+
+  it('never lets reactFlowProps override SDK-owned props', () => {
+    useStore.setState({ nodes: [makeNode('real')] });
+    const consumerOnConnect = vi.fn();
+    // Cast: these keys are omitted from the public type, so only a JS / `as`
+    // consumer could reach them. The runtime spread order must still win.
+    setReactFlowProps({
+      nodes: [makeNode('hijack-a'), makeNode('hijack-b')],
+      nodesConnectable: false,
+      onConnect: consumerOnConnect,
+    } as unknown as WorkflowBuilderReactFlowProps);
+
+    render(<DiagramContainer />);
+    const props = capturedFlowProps();
+
+    expect(props.nodes).toHaveLength(1);
+    expect(props.nodes[0].id).toBe('real');
+    // Store is editable on a fresh reset, so the SDK value wins over the
+    // consumer's `false`.
+    expect(props.nodesConnectable).toBe(true);
+    expect(props.onConnect).not.toBe(consumerOnConnect);
+  });
+
+  it('keeps the SDK-owned isValidConnection slot even when the consumer sets one via reactFlowProps', () => {
+    const consumerIsValid = vi.fn().mockReturnValue(false);
+    setReactFlowProps({ isValidConnection: consumerIsValid } as unknown as WorkflowBuilderReactFlowProps);
+
+    render(<DiagramContainer />);
+    const props = capturedFlowProps();
+
+    // No Root-level `isValidConnection` set, so the owned slot resolves to
+    // `undefined` (ReactFlow default) — the consumer's smuggled callback never wins.
+    expect(props.isValidConnection).toBeUndefined();
+    expect(consumerIsValid).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/features/diagram/diagram.spec.tsx
+++ b/packages/sdk/src/features/diagram/diagram.spec.tsx
@@ -1,14 +1,7 @@
-// Pins the prop-precedence contract that `reactFlowProps` is sold on
-// (README "Advanced: ReactFlow props"): the consumer escape hatch can override
-// SDK *defaults*, but never the props the SDK *owns*. The guarantee lives in
-// the spread order in `diagram.tsx` (`{...defaults} {...consumer} {...owned}`),
-// so this test renders the canvas with a `ReactFlow` capture stub and inspects
-// the props it actually receives. A reorder of those spreads, or an owned prop
-// leaking into the consumer set, fails here.
-//
-// The node/edge type maps, palette drop, delete modal and temporary edge are
-// stubbed: they pull the overflow-ui + xyflow rendering stack (CSS side
-// effects) and are irrelevant to the spread contract.
+// Pins the `reactFlowProps` precedence contract: a consumer can override SDK
+// *defaults* but never the props the SDK *owns* (spread order in `diagram.tsx`).
+// Renders with a `ReactFlow` capture stub and inspects the props it receives.
+// The rendering-stack deps below are stubbed (CSS side effects, irrelevant here).
 import { render } from '@testing-library/react';
 import { ReactFlow } from '@xyflow/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -25,8 +18,7 @@ import { DiagramContainer } from './diagram';
 const { updateNodeInternals } = vi.hoisted(() => ({ updateNodeInternals: vi.fn() }));
 
 vi.mock('@xyflow/react', () => ({
-  // Capture stub: the test only inspects the props ReactFlow receives, so it
-  // renders nothing.
+  // Capture stub: only the received props matter, so it renders nothing.
   ReactFlow: vi.fn(() => null),
   Background: () => null,
   SelectionMode: { Partial: 'partial' },
@@ -45,9 +37,8 @@ function makeNode(id: string): WorkflowBuilderNode {
   return { id, position: { x: 0, y: 0 }, type: 'action', data: { type: 'action', icon: 'Plus', properties: {} } };
 }
 
-// Unique reference smuggled in via `reactFlowProps` under every SDK-owned key.
-// The SDK must overwrite each one, so this reference must never survive to
-// ReactFlow.
+// Smuggled in via `reactFlowProps` under every SDK-owned key. The SDK must
+// overwrite each one, so this reference must never reach ReactFlow.
 const OWNED_SENTINEL = { __sentinel: true };
 
 /** Props the (mocked) `ReactFlow` received on the latest render. */
@@ -80,8 +71,8 @@ describe('DiagramContainer — reactFlowProps precedence', () => {
   it('never lets reactFlowProps override SDK-owned props', () => {
     useStore.setState({ nodes: [makeNode('real')] });
     const consumerOnConnect = vi.fn();
-    // Cast: these keys are omitted from the public type, so only a JS / `as`
-    // consumer could reach them. The runtime spread order must still win.
+    // Cast past the public type (a JS consumer could reach these); the spread
+    // order must still win.
     setReactFlowProps({
       nodes: [makeNode('hijack-a'), makeNode('hijack-b')],
       nodesConnectable: false,
@@ -93,8 +84,7 @@ describe('DiagramContainer — reactFlowProps precedence', () => {
 
     expect(props.nodes).toHaveLength(1);
     expect(props.nodes[0].id).toBe('real');
-    // Store is editable on a fresh reset, so the SDK value wins over the
-    // consumer's `false`.
+    // Editable store on fresh reset, so the SDK's `true` wins over `false`.
     expect(props.nodesConnectable).toBe(true);
     expect(props.onConnect).not.toBe(consumerOnConnect);
   });
@@ -106,19 +96,15 @@ describe('DiagramContainer — reactFlowProps precedence', () => {
     render(<DiagramContainer />);
     const props = capturedFlowProps();
 
-    // No Root-level `isValidConnection` set, so the owned slot resolves to
-    // `undefined` (ReactFlow default). The consumer's smuggled callback never wins.
+    // No Root-level callback, so the owned slot is `undefined`; the smuggled one never wins.
     expect(props.isValidConnection).toBeUndefined();
     expect(consumerIsValid).not.toHaveBeenCalled();
   });
 
   it('sets every SDK-managed prop as an owned attribute below the spreads', () => {
-    // Exhaustive over `SdkManagedReactFlowKey`: adding a key to that union forces
-    // a new entry here (the `Record` literal stops compiling otherwise), and this
-    // test then proves `diagram.tsx` actually sets it after the consumer spread.
-    // A managed key missing from the owned JSX block, or moved above the spread,
-    // lets the sentinel survive and fails here. Covers every key, not just the
-    // representative handful asserted above.
+    // Exhaustive over `SdkManagedReactFlowKey`: a new key forces an entry here
+    // (the `Record` won't compile otherwise), proving `diagram.tsx` sets it after
+    // the consumer spread. A managed key above the spread lets the sentinel survive.
     const sentinels: Record<SdkManagedReactFlowKey, unknown> = {
       nodes: OWNED_SENTINEL,
       edges: OWNED_SENTINEL,

--- a/packages/sdk/src/features/diagram/diagram.spec.tsx
+++ b/packages/sdk/src/features/diagram/diagram.spec.tsx
@@ -16,7 +16,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setIsValidConnection, setReactFlowProps } from '../../data/react-flow-config';
 import type { WorkflowBuilderNode } from '../../node/node-data';
 import { resetWorkflowStore, useStore } from '../../store/store';
-import type { WorkflowBuilderReactFlowProps } from '../../workflow-builder-root/workflow-builder-root.types';
+import type {
+  SdkManagedReactFlowKey,
+  WorkflowBuilderReactFlowProps,
+} from '../../workflow-builder-root/workflow-builder-root.types';
 import { DiagramContainer } from './diagram';
 
 const { updateNodeInternals } = vi.hoisted(() => ({ updateNodeInternals: vi.fn() }));
@@ -41,6 +44,11 @@ vi.mock('../modals/delete-confirmation/use-delete-confirmation', () => ({
 function makeNode(id: string): WorkflowBuilderNode {
   return { id, position: { x: 0, y: 0 }, type: 'action', data: { type: 'action', icon: 'Plus', properties: {} } };
 }
+
+// Unique reference smuggled in via `reactFlowProps` under every SDK-owned key.
+// The SDK must overwrite each one, so this reference must never survive to
+// ReactFlow.
+const OWNED_SENTINEL = { __sentinel: true };
 
 /** Props the (mocked) `ReactFlow` received on the latest render. */
 function capturedFlowProps() {
@@ -99,8 +107,49 @@ describe('DiagramContainer — reactFlowProps precedence', () => {
     const props = capturedFlowProps();
 
     // No Root-level `isValidConnection` set, so the owned slot resolves to
-    // `undefined` (ReactFlow default) — the consumer's smuggled callback never wins.
+    // `undefined` (ReactFlow default). The consumer's smuggled callback never wins.
     expect(props.isValidConnection).toBeUndefined();
     expect(consumerIsValid).not.toHaveBeenCalled();
+  });
+
+  it('sets every SDK-managed prop as an owned attribute below the spreads', () => {
+    // Exhaustive over `SdkManagedReactFlowKey`: adding a key to that union forces
+    // a new entry here (the `Record` literal stops compiling otherwise), and this
+    // test then proves `diagram.tsx` actually sets it after the consumer spread.
+    // A managed key missing from the owned JSX block, or moved above the spread,
+    // lets the sentinel survive and fails here. Covers every key, not just the
+    // representative handful asserted above.
+    const sentinels: Record<SdkManagedReactFlowKey, unknown> = {
+      nodes: OWNED_SENTINEL,
+      edges: OWNED_SENTINEL,
+      nodeTypes: OWNED_SENTINEL,
+      edgeTypes: OWNED_SENTINEL,
+      onConnect: OWNED_SENTINEL,
+      onConnectStart: OWNED_SENTINEL,
+      onConnectEnd: OWNED_SENTINEL,
+      onNodesChange: OWNED_SENTINEL,
+      onEdgesChange: OWNED_SENTINEL,
+      onSelectionChange: OWNED_SENTINEL,
+      onInit: OWNED_SENTINEL,
+      onBeforeDelete: OWNED_SENTINEL,
+      onNodeDragStart: OWNED_SENTINEL,
+      onNodeDragStop: OWNED_SENTINEL,
+      onEdgeMouseEnter: OWNED_SENTINEL,
+      onEdgeMouseLeave: OWNED_SENTINEL,
+      onDragOver: OWNED_SENTINEL,
+      onDrop: OWNED_SENTINEL,
+      connectionLineComponent: OWNED_SENTINEL,
+      nodesConnectable: OWNED_SENTINEL,
+      nodesDraggable: OWNED_SENTINEL,
+      isValidConnection: OWNED_SENTINEL,
+    };
+
+    setReactFlowProps(sentinels as unknown as WorkflowBuilderReactFlowProps);
+    render(<DiagramContainer />);
+    const props = capturedFlowProps();
+
+    for (const key of Object.keys(sentinels)) {
+      expect(props[key], `${key} must be set by the SDK, not by reactFlowProps`).not.toBe(OWNED_SENTINEL);
+    }
   });
 });

--- a/packages/sdk/src/features/diagram/diagram.tsx
+++ b/packages/sdk/src/features/diagram/diagram.tsx
@@ -1,7 +1,6 @@
 import {
   Background,
   type EdgeTypes,
-  type FitViewOptions,
   type NodeChange,
   type OnBeforeDelete,
   type OnConnect,
@@ -17,11 +16,13 @@ import type { DragEvent } from 'react';
 import styles from './diagram.module.css';
 import '@xyflow/react/dist/style.css';
 
+import { getReactFlowProps } from '../../data/react-flow-config';
 import { usePaletteDrop } from '../../hooks/use-palette-drop';
 import type { WorkflowBuilderOnSelectionChangeParams } from '../../node/common';
 import type { WorkflowBuilderEdge, WorkflowBuilderNode } from '../../node/node-data';
 import { getStoreNodes } from '../../store/slices/diagram-slice/actions';
 import { useStore } from '../../store/store';
+import type { WorkflowBuilderReactFlowProps } from '../../workflow-builder-root/workflow-builder-root.types';
 import { trackFutureChange } from '../changes-tracker/stores/use-changes-tracker-store';
 import { useDeleteConfirmation } from '../modals/delete-confirmation/use-delete-confirmation';
 import { withOptionalComponentPlugins } from '../plugins-core/adapters/adapter-components';
@@ -30,9 +31,27 @@ import { SNAP_GRID, SNAP_IS_ACTIVE } from './diagram.const';
 import { TemporaryEdge } from './edges/temporary-edge/temporary-edge';
 import { useEdgeTypes } from './hooks/use-edge-types';
 import { useNodeTypes } from './hooks/use-node-types';
+import { useIsValidConnection } from './hooks/use-react-flow-config';
 import { callNodeChangedListeners } from './listeners/node-changed-listeners';
 import { callNodeDragStartListeners } from './listeners/node-drag-start-listeners';
 import { diagramStateSelector } from './selectors';
+
+/**
+ * ReactFlow tuning the SDK applies by default. Spread before `reactFlowProps` so
+ * a consumer can override any of it. Module level for a stable reference.
+ */
+const SDK_DEFAULT_FLOW_PROPS = {
+  fitView: true,
+  fitViewOptions: { maxZoom: 1 },
+  panOnScroll: true,
+  minZoom: 0.1,
+  snapToGrid: SNAP_IS_ACTIVE,
+  snapGrid: SNAP_GRID,
+  selectionOnDrag: true,
+  selectionMode: SelectionMode.Partial,
+  deleteKeyCode,
+  panOnDrag: [1, 2],
+} satisfies WorkflowBuilderReactFlowProps;
 
 /**
  * Props accepted by {@link DiagramContainer}. Use this when typing a
@@ -76,6 +95,11 @@ function DiagramContainerComponent({ edgeTypes = {} }: DiagramContainerProps) {
 
   const setConnectionBeingDragged = useStore((store) => store.setConnectionBeingDragged);
   const nodeTypes = useNodeTypes();
+  const isValidConnection = useIsValidConnection();
+  // Plain read, not a hook: the holder is written by `<WorkflowBuilder.Root>`
+  // during its render (an ancestor), so the value is current by the time this
+  // child renders, and the reference is stable (frozen empty object when unset).
+  const consumerReactFlowProps = getReactFlowProps();
 
   // React Flow caches each handle's measured bounds in `nodeInternals`. When
   // `layoutDirection` flips, existing nodes re-render their `<Handle>` with a
@@ -95,8 +119,6 @@ function DiagramContainerComponent({ edgeTypes = {} }: DiagramContainerProps) {
   }, []);
 
   const { onDropFromPalette } = usePaletteDrop();
-
-  const fitViewOptions: FitViewOptions = useMemo(() => ({ maxZoom: 1 }), []);
 
   const onNodeDragStart: OnNodeDrag = useCallback((event, node, nodes) => {
     trackFutureChange('nodeDragStart');
@@ -180,42 +202,35 @@ function DiagramContainerComponent({ edgeTypes = {} }: DiagramContainerProps) {
     [isReadOnlyMode, openDeleteConfirmationModal],
   );
 
-  const panOnDrag = [1, 2];
-
   return (
     <div className={styles['container']}>
       <ReactFlow<WorkflowBuilderNode, WorkflowBuilderEdge>
-        edges={edges}
-        edgeTypes={diagramEdgeTypes}
-        fitView
-        fitViewOptions={fitViewOptions}
-        onDragOver={onDragOver}
-        onInit={onInit}
-        onDrop={onDrop}
-        connectionLineComponent={TemporaryEdge}
-        panOnScroll
+        {...SDK_DEFAULT_FLOW_PROPS}
+        {...consumerReactFlowProps}
+        // SDK-owned props, spread last so they always win over `reactFlowProps`.
+        // Keep them below the spreads.
         nodes={nodes}
-        nodesConnectable={!isReadOnlyMode}
-        nodesDraggable={!isReadOnlyMode}
+        edges={edges}
         nodeTypes={nodeTypes}
+        edgeTypes={diagramEdgeTypes}
+        onInit={onInit}
         onConnect={onConnect}
-        onEdgesChange={onEdgesChange}
         onConnectStart={onConnectStart}
         onConnectEnd={onConnectEnd}
+        onEdgesChange={onEdgesChange}
+        onNodesChange={handleOnNodesChange}
+        onSelectionChange={handleOnSelectionChange}
         onEdgeMouseEnter={onEdgeMouseEnter}
         onEdgeMouseLeave={onEdgeMouseLeave}
-        onNodesChange={handleOnNodesChange}
         onNodeDragStart={onNodeDragStart}
         onNodeDragStop={onNodeDragStop}
         onBeforeDelete={onBeforeDelete}
-        onSelectionChange={handleOnSelectionChange}
-        minZoom={0.1}
-        snapToGrid={SNAP_IS_ACTIVE}
-        snapGrid={SNAP_GRID}
-        selectionOnDrag
-        panOnDrag={panOnDrag}
-        selectionMode={SelectionMode.Partial}
-        deleteKeyCode={deleteKeyCode}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        connectionLineComponent={TemporaryEdge}
+        nodesConnectable={!isReadOnlyMode}
+        nodesDraggable={!isReadOnlyMode}
+        isValidConnection={isValidConnection}
       >
         <Background />
       </ReactFlow>

--- a/packages/sdk/src/features/diagram/diagram.tsx
+++ b/packages/sdk/src/features/diagram/diagram.tsx
@@ -36,10 +36,8 @@ import { callNodeChangedListeners } from './listeners/node-changed-listeners';
 import { callNodeDragStartListeners } from './listeners/node-drag-start-listeners';
 import { diagramStateSelector } from './selectors';
 
-/**
- * ReactFlow tuning the SDK applies by default. Spread before `reactFlowProps` so
- * a consumer can override any of it. Module level for a stable reference.
- */
+// SDK default ReactFlow tuning. Spread before `reactFlowProps` so a consumer can
+// override any of it. Module level for a stable reference.
 const SDK_DEFAULT_FLOW_PROPS = {
   fitView: true,
   fitViewOptions: { maxZoom: 1 },
@@ -96,9 +94,8 @@ function DiagramContainerComponent({ edgeTypes = {} }: DiagramContainerProps) {
   const setConnectionBeingDragged = useStore((store) => store.setConnectionBeingDragged);
   const nodeTypes = useNodeTypes();
   const isValidConnection = useIsValidConnection();
-  // Plain read, not a hook: the holder is written by `<WorkflowBuilder.Root>`
-  // during its render (an ancestor), so the value is current by the time this
-  // child renders, and the reference is stable (frozen empty object when unset).
+  // Plain read: the ancestor `<WorkflowBuilder.Root>` writes the holder during
+  // its render, so the value is current here (stable, frozen empty when unset).
   const consumerReactFlowProps = getReactFlowProps();
 
   // React Flow caches each handle's measured bounds in `nodeInternals`. When
@@ -207,8 +204,7 @@ function DiagramContainerComponent({ edgeTypes = {} }: DiagramContainerProps) {
       <ReactFlow<WorkflowBuilderNode, WorkflowBuilderEdge>
         {...SDK_DEFAULT_FLOW_PROPS}
         {...consumerReactFlowProps}
-        // SDK-owned props, spread last so they always win over `reactFlowProps`.
-        // Keep them below the spreads.
+        // SDK-owned props: spread last so they always win over `reactFlowProps`.
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}

--- a/packages/sdk/src/features/diagram/hooks/use-react-flow-config.spec.ts
+++ b/packages/sdk/src/features/diagram/hooks/use-react-flow-config.spec.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setIsValidConnection, setReactFlowProps } from '../../../data/react-flow-config';
+import type { WorkflowBuilderNode } from '../../../node/node-data';
+import { resetWorkflowStore, useStore } from '../../../store/store';
+import { useIsValidConnection } from './use-react-flow-config';
+
+function makeNode(id: string, dataType: string): WorkflowBuilderNode {
+  return {
+    id,
+    position: { x: 0, y: 0 },
+    type: dataType,
+    data: { type: dataType, icon: 'Plus', properties: {} },
+  };
+}
+
+beforeEach(() => {
+  resetWorkflowStore();
+  setIsValidConnection(null);
+  setReactFlowProps(null);
+});
+
+describe('useIsValidConnection', () => {
+  it('returns undefined when no consumer callback is set', () => {
+    const { result } = renderHook(() => useIsValidConnection());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('forwards the resolved nodes and connection, returning the consumer result', () => {
+    useStore.setState({ nodes: [makeNode('a', 'start'), makeNode('b', 'action')] });
+    const spy = vi.fn().mockReturnValue(false);
+    setIsValidConnection(spy);
+
+    const { result } = renderHook(() => useIsValidConnection());
+    const connection = { source: 'a', target: 'b', sourceHandle: 'source', targetHandle: 'target' };
+    const valid = result.current?.(connection);
+
+    expect(valid).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const params = spy.mock.calls[0][0];
+    expect(params.sourceNode.id).toBe('a');
+    expect(params.targetNode.id).toBe('b');
+    expect(params.connection).toEqual(connection);
+  });
+
+  it('allows the connection (returns true) when a node id cannot be resolved', () => {
+    useStore.setState({ nodes: [makeNode('a', 'start')] });
+    const spy = vi.fn().mockReturnValue(false);
+    setIsValidConnection(spy);
+
+    const { result } = renderHook(() => useIsValidConnection());
+    const valid = result.current?.({ source: 'a', target: 'missing', sourceHandle: null, targetHandle: null });
+
+    expect(valid).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('normalizes undefined handle ids to null', () => {
+    useStore.setState({ nodes: [makeNode('a', 'start'), makeNode('b', 'action')] });
+    const spy = vi.fn().mockReturnValue(true);
+    setIsValidConnection(spy);
+
+    const { result } = renderHook(() => useIsValidConnection());
+    // Edge-shaped candidate without handle fields.
+    result.current?.({ source: 'a', target: 'b' } as never);
+
+    const params = spy.mock.calls[0][0];
+    expect(params.connection.sourceHandle).toBeNull();
+    expect(params.connection.targetHandle).toBeNull();
+  });
+});

--- a/packages/sdk/src/features/diagram/hooks/use-react-flow-config.ts
+++ b/packages/sdk/src/features/diagram/hooks/use-react-flow-config.ts
@@ -1,0 +1,40 @@
+import type { Connection, Edge, IsValidConnection } from '@xyflow/react';
+import { useCallback } from 'react';
+
+import { getIsValidConnection } from '../../../data/react-flow-config';
+import type { WorkflowBuilderEdge } from '../../../node/node-data';
+import { getStoreNodes } from '../../../store/slices/diagram-slice/actions';
+
+/**
+ * Adapts the consumer's enriched `isValidConnection` to ReactFlow's native
+ * signature, resolving the candidate's node ids against the live store. Returns
+ * `undefined` when no callback is set (ReactFlow keeps its default), and allows
+ * the connection when a node cannot be resolved.
+ */
+export function useIsValidConnection(): IsValidConnection<WorkflowBuilderEdge> | undefined {
+  // Read outside the callback so the dep stays stable across renders.
+  const isValidConnection = getIsValidConnection();
+
+  const adapter = useCallback<IsValidConnection<WorkflowBuilderEdge>>(
+    (candidate: Connection | Edge) => {
+      if (!isValidConnection) return true;
+
+      const nodes = getStoreNodes();
+      const sourceNode = nodes.find((node) => node.id === candidate.source);
+      const targetNode = nodes.find((node) => node.id === candidate.target);
+      if (!sourceNode || !targetNode) return true;
+
+      const connection: Connection = {
+        source: candidate.source,
+        target: candidate.target,
+        sourceHandle: candidate.sourceHandle ?? null,
+        targetHandle: candidate.targetHandle ?? null,
+      };
+
+      return isValidConnection({ connection, sourceNode, targetNode });
+    },
+    [isValidConnection],
+  );
+
+  return isValidConnection ? adapter : undefined;
+}

--- a/packages/sdk/src/features/diagram/hooks/use-react-flow-config.ts
+++ b/packages/sdk/src/features/diagram/hooks/use-react-flow-config.ts
@@ -6,10 +6,9 @@ import type { WorkflowBuilderEdge } from '../../../node/node-data';
 import { getStoreNodes } from '../../../store/slices/diagram-slice/actions';
 
 /**
- * Adapts the consumer's enriched `isValidConnection` to ReactFlow's native
- * signature, resolving the candidate's node ids against the live store. Returns
- * `undefined` when no callback is set (ReactFlow keeps its default), and allows
- * the connection when a node cannot be resolved.
+ * Adapts the consumer's `isValidConnection` to ReactFlow's signature, resolving
+ * node ids against the store. Returns `undefined` when unset (ReactFlow default);
+ * allows the connection when a node can't be resolved.
  */
 export function useIsValidConnection(): IsValidConnection<WorkflowBuilderEdge> | undefined {
   // Read outside the callback so the dep stays stable across renders.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,9 @@ export type {
   WorkflowBuilderJsonFormConfig,
   WorkflowBuilderNodeTemplates,
   WorkflowBuilderEdgeTemplates,
+  WorkflowBuilderIsValidConnection,
+  IsValidConnectionParams,
+  WorkflowBuilderReactFlowProps,
 } from './workflow-builder-root';
 
 // =============================================================================

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -57,7 +57,7 @@ export type {
   WorkflowBuilderNodeTemplates,
   WorkflowBuilderEdgeTemplates,
   WorkflowBuilderIsValidConnection,
-  IsValidConnectionParams,
+  WorkflowBuilderIsValidConnectionParams,
   WorkflowBuilderReactFlowProps,
 } from './workflow-builder-root';
 

--- a/packages/sdk/src/workflow-builder-root/index.ts
+++ b/packages/sdk/src/workflow-builder-root/index.ts
@@ -1,9 +1,12 @@
 export { WorkflowBuilderRoot } from './workflow-builder-root';
 export type {
+  IsValidConnectionParams,
   WorkflowBuilderEdgeTemplates,
   WorkflowBuilderIntegration,
+  WorkflowBuilderIsValidConnection,
   WorkflowBuilderJsonFormConfig,
   WorkflowBuilderNodeTemplates,
   WorkflowBuilderPlugin,
+  WorkflowBuilderReactFlowProps,
   WorkflowBuilderRootProps,
 } from './workflow-builder-root.types';

--- a/packages/sdk/src/workflow-builder-root/index.ts
+++ b/packages/sdk/src/workflow-builder-root/index.ts
@@ -1,9 +1,9 @@
 export { WorkflowBuilderRoot } from './workflow-builder-root';
 export type {
-  IsValidConnectionParams,
   WorkflowBuilderEdgeTemplates,
   WorkflowBuilderIntegration,
   WorkflowBuilderIsValidConnection,
+  WorkflowBuilderIsValidConnectionParams,
   WorkflowBuilderJsonFormConfig,
   WorkflowBuilderNodeTemplates,
   WorkflowBuilderPlugin,

--- a/packages/sdk/src/workflow-builder-root/workflow-builder-root.spec.tsx
+++ b/packages/sdk/src/workflow-builder-root/workflow-builder-root.spec.tsx
@@ -203,9 +203,8 @@ describe('WorkflowBuilderRoot — react-flow config wiring', () => {
   });
 
   it('resets the holders to their defaults when the props are omitted', () => {
-    // Seed stale config as if a previous Root had set it, then mount a Root
-    // without the props: the render-body writes must clear the holders so a
-    // remount never inherits the old config.
+    // Stale config from a previous Root must be cleared when a Root mounts
+    // without the props, so a remount never inherits it.
     setIsValidConnection(vi.fn(() => false));
     setReactFlowProps({ maxZoom: 9 });
 

--- a/packages/sdk/src/workflow-builder-root/workflow-builder-root.spec.tsx
+++ b/packages/sdk/src/workflow-builder-root/workflow-builder-root.spec.tsx
@@ -21,6 +21,12 @@ import type { ReactNode } from 'react';
 import { StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  getIsValidConnection,
+  getReactFlowProps,
+  setIsValidConnection,
+  setReactFlowProps,
+} from '../data/react-flow-config';
 import type { WorkflowBuilderNode } from '../node/node-data';
 import { resetWorkflowStore, useStore } from '../store/store';
 import { WorkflowBuilderRoot } from './workflow-builder-root';
@@ -62,6 +68,8 @@ function makeNode(id: string): WorkflowBuilderNode {
 // still-mounted subscriber outside `act(...)`.
 beforeEach(() => {
   resetWorkflowStore();
+  setIsValidConnection(null);
+  setReactFlowProps(null);
   localStorage.clear();
   delete document.documentElement.dataset.theme;
 });
@@ -176,5 +184,38 @@ describe('WorkflowBuilderRoot — StrictMode lifecycle contract', () => {
     // for the Probe is the upper bound. Anything beyond that signals a
     // subscription loop.
     expect(renderCount - initialRenders).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('WorkflowBuilderRoot — react-flow config wiring', () => {
+  it('writes isValidConnection and reactFlowProps into the holders during render', () => {
+    const isValidConnection = vi.fn(() => true);
+    const reactFlowProps = { maxZoom: 3 };
+
+    render(
+      <StrictMode>
+        <WorkflowBuilderRoot isValidConnection={isValidConnection} reactFlowProps={reactFlowProps} />
+      </StrictMode>,
+    );
+
+    expect(getIsValidConnection()).toBe(isValidConnection);
+    expect(getReactFlowProps()).toBe(reactFlowProps);
+  });
+
+  it('resets the holders to their defaults when the props are omitted', () => {
+    // Seed stale config as if a previous Root had set it, then mount a Root
+    // without the props: the render-body writes must clear the holders so a
+    // remount never inherits the old config.
+    setIsValidConnection(vi.fn(() => false));
+    setReactFlowProps({ maxZoom: 9 });
+
+    render(
+      <StrictMode>
+        <WorkflowBuilderRoot />
+      </StrictMode>,
+    );
+
+    expect(getIsValidConnection()).toBeNull();
+    expect(getReactFlowProps()).toEqual({});
   });
 });

--- a/packages/sdk/src/workflow-builder-root/workflow-builder-root.tsx
+++ b/packages/sdk/src/workflow-builder-root/workflow-builder-root.tsx
@@ -6,6 +6,7 @@ import { registerPluginTranslation } from '../features/plugins-core/adapters/ada
 import { setCustomEdgeTemplates } from '../data/edge-templates';
 import { setCustomNodeTemplates } from '../data/node-templates';
 import { setCustomPaletteNodes } from '../data/palette';
+import { setIsValidConnection, setReactFlowProps } from '../data/react-flow-config';
 import { setCustomTemplates } from '../data/templates';
 import { RuntimeIntegrationWrapper } from '../features/integration/components/runtime-integration-wrapper';
 import { registerCustomCells, registerCustomRenderers } from '../features/json-form/extension-registry';
@@ -58,6 +59,8 @@ export function WorkflowBuilderRoot({
   layoutDirection,
   initialNodes,
   initialEdges,
+  isValidConnection,
+  reactFlowProps,
   children,
 }: WorkflowBuilderRootProps) {
   // Plugin / JsonForms boot — run once per Root lifetime on the first render
@@ -126,6 +129,8 @@ export function WorkflowBuilderRoot({
   setCustomTemplates(diagramTemplates ?? null);
   setCustomNodeTemplates(nodeTemplates ?? null);
   setCustomEdgeTemplates(edgeTemplates ?? null);
+  setIsValidConnection(isValidConnection ?? null);
+  setReactFlowProps(reactFlowProps ?? null);
 
   const { strategy, endpoints, onDataSave } = resolveIntegration(integration);
 

--- a/packages/sdk/src/workflow-builder-root/workflow-builder-root.types.ts
+++ b/packages/sdk/src/workflow-builder-root/workflow-builder-root.types.ts
@@ -1,4 +1,4 @@
-import type { EdgeProps } from '@xyflow/react';
+import type { Connection, EdgeProps, ReactFlowProps } from '@xyflow/react';
 import type { ComponentType, PropsWithChildren } from 'react';
 
 import type { WorkflowNodeTemplateProps } from '../features/diagram/nodes/workflow-node-template/workflow-node-template';
@@ -91,6 +91,101 @@ export type WorkflowBuilderJsonFormConfig = {
 };
 
 /**
+ * Arguments passed to a {@link WorkflowBuilderIsValidConnection} callback. The
+ * SDK resolves the source and target nodes from the connection's node ids, so a
+ * rule can branch on `data.type` / `data.properties` without touching the store.
+ *
+ * @category Core
+ */
+export type IsValidConnectionParams = {
+  /** Raw ReactFlow connection candidate — source / target node ids + handle ids. */
+  connection: Connection;
+  /** The node the connection is dragged from (resolved from `connection.source`). */
+  sourceNode: WorkflowBuilderNode;
+  /** The node the connection is dragged to (resolved from `connection.target`). */
+  targetNode: WorkflowBuilderNode;
+};
+
+/**
+ * Decides whether a connection between two nodes is allowed. Runs live while
+ * the user drags a connection: return `false` to block the drop. No edge is
+ * created and there is no flicker, because the connection is rejected before it
+ * ever enters the graph.
+ *
+ * Fail-open: if either endpoint can't be resolved to a node in the store, the
+ * connection is allowed and this callback is not invoked, so a strict
+ * deny-by-default rule still can't block a drop whose nodes are unknown.
+ *
+ * @category Core
+ */
+export type WorkflowBuilderIsValidConnection = (params: IsValidConnectionParams) => boolean;
+
+/**
+ * ReactFlow props the SDK manages itself and spreads last in `diagram.tsx`, so
+ * they always win at runtime. Omitted from {@link WorkflowBuilderReactFlowProps}.
+ * Edit this union when the SDK starts or stops managing a prop.
+ */
+type SdkManagedReactFlowKey =
+  | 'nodes'
+  | 'edges'
+  | 'defaultNodes'
+  | 'defaultEdges'
+  | 'nodeTypes'
+  | 'edgeTypes'
+  | 'onConnect'
+  | 'onConnectStart'
+  | 'onConnectEnd'
+  | 'onNodesChange'
+  | 'onEdgesChange'
+  | 'onSelectionChange'
+  | 'onInit'
+  | 'onBeforeDelete'
+  | 'onNodeDragStart'
+  | 'onNodeDragStop'
+  | 'onEdgeMouseEnter'
+  | 'onEdgeMouseLeave'
+  | 'onDragOver'
+  | 'onDrop'
+  | 'connectionLineComponent'
+  | 'nodesConnectable'
+  | 'nodesDraggable'
+  | 'isValidConnection';
+
+/**
+ * ReactFlow props the SDK reserves but does not set: governed elsewhere, so a
+ * `reactFlowProps` override would silently fight that system. `colorMode` is
+ * owned by the SDK theming layer (design tokens / `initTheme`), so it is omitted
+ * here rather than left to conflict with the active theme.
+ */
+type SdkReservedReactFlowKey = 'colorMode';
+
+/** Every ReactFlow key the escape hatch must not expose. */
+type SdkOwnedReactFlowKey = SdkManagedReactFlowKey | SdkReservedReactFlowKey;
+
+/**
+ * Identity type that compiles only when `A` is assignable to `B`. Used below so
+ * an owned key that is no longer a real ReactFlow prop fails the build (`Omit`
+ * does not validate its keys).
+ */
+type AssertAssignable<A extends B, B> = A;
+
+/**
+ * Escape hatch for the underlying ReactFlow canvas: forwards any ReactFlow prop
+ * except the ones the SDK owns ({@link SdkOwnedReactFlowKey}), which are omitted
+ * here and always win at runtime, so the editor cannot be broken from the
+ * outside. Theme via the SDK design tokens rather than ReactFlow's `colorMode`
+ * (omitted here for that reason).
+ *
+ * **Must be a stable reference** — declare at module level or memoize.
+ *
+ * @category Core
+ */
+export type WorkflowBuilderReactFlowProps = Omit<
+  ReactFlowProps<WorkflowBuilderNode, WorkflowBuilderEdge>,
+  AssertAssignable<SdkOwnedReactFlowKey, keyof ReactFlowProps<WorkflowBuilderNode, WorkflowBuilderEdge>>
+>;
+
+/**
  * Props accepted by `<WorkflowBuilder.Root>`.
  *
  * @category Core
@@ -147,4 +242,23 @@ export type WorkflowBuilderRootProps = PropsWithChildren<{
   initialNodes?: WorkflowBuilderNode[];
   /** Initial edges rendered on first mount. */
   initialEdges?: WorkflowBuilderEdge[];
+  /**
+   * Validate connections as the user draws them. Receives the candidate
+   * `connection` plus the resolved `sourceNode` / `targetNode`; return `false`
+   * to reject it. An invalid drop creates no edge and does not flicker.
+   *
+   * **Must be a stable reference** (declare at module level or memoize).
+   *
+   * @example
+   * ```ts
+   * const isValidConnection: WorkflowBuilderIsValidConnection = ({ sourceNode, targetNode }) =>
+   *   !(sourceNode.data.type === 'start' && targetNode.data.type === 'start');
+   * ```
+   */
+  isValidConnection?: WorkflowBuilderIsValidConnection;
+  /**
+   * Advanced. Forwards extra props to the underlying ReactFlow canvas. See
+   * {@link WorkflowBuilderReactFlowProps} for what is allowed.
+   */
+  reactFlowProps?: WorkflowBuilderReactFlowProps;
 }>;

--- a/packages/sdk/src/workflow-builder-root/workflow-builder-root.types.ts
+++ b/packages/sdk/src/workflow-builder-root/workflow-builder-root.types.ts
@@ -91,43 +91,34 @@ export type WorkflowBuilderJsonFormConfig = {
 };
 
 /**
- * Arguments passed to a {@link WorkflowBuilderIsValidConnection} callback. The
- * SDK resolves the source and target nodes from the connection's node ids, so a
- * rule can branch on `data.type` / `data.properties` without touching the store.
+ * Arguments for {@link WorkflowBuilderIsValidConnection}. Source / target nodes
+ * are resolved from the connection's ids, so a rule can branch on node `data`.
  *
  * @category Core
  */
 export type WorkflowBuilderIsValidConnectionParams = {
-  /** Raw ReactFlow connection candidate: source / target node ids + handle ids. */
+  /** The connection candidate (handle ids normalized to `null`). */
   connection: Connection;
-  /** The node the connection is dragged from (resolved from `connection.source`). */
+  /** Node the connection is dragged from. */
   sourceNode: WorkflowBuilderNode;
-  /** The node the connection is dragged to (resolved from `connection.target`). */
+  /** Node the connection is dragged to. */
   targetNode: WorkflowBuilderNode;
 };
 
 /**
- * Decides whether a connection between two nodes is allowed. Runs live while
- * the user drags a connection: return `false` to block the drop. No edge is
- * created and there is no flicker, because the connection is rejected before it
- * ever enters the graph.
- *
- * Fail-open: if either endpoint can't be resolved to a node in the store, the
- * connection is allowed and this callback is not invoked, so a strict
- * deny-by-default rule still can't block a drop whose nodes are unknown.
+ * Decides whether a dragged connection is allowed. Return `false` to block the
+ * drop (no edge created, no flicker). Fail-open: if an endpoint can't be
+ * resolved to a node, the connection is allowed and this is not invoked.
  *
  * @category Core
  */
 export type WorkflowBuilderIsValidConnection = (params: WorkflowBuilderIsValidConnectionParams) => boolean;
 
 /**
- * ReactFlow props the SDK sets itself, as explicit JSX attributes spread last in
- * `diagram.tsx`, so they always win at runtime over `reactFlowProps`. Omitted
- * from {@link WorkflowBuilderReactFlowProps}. Every key here must appear in that
- * owned-attribute block; the `diagram.spec` precedence test enforces it. Edit
- * this union when the SDK starts or stops setting a prop.
- *
- * Exported for that test only; not re-exported from the public entry point.
+ * ReactFlow props the SDK sets itself (spread last in `diagram.tsx`, so they win
+ * over `reactFlowProps`) and omits from {@link WorkflowBuilderReactFlowProps}.
+ * The `diagram.spec` precedence test enforces each one stays owned. Internal:
+ * exported for that test only.
  */
 export type SdkManagedReactFlowKey =
   | 'nodes'
@@ -154,35 +145,26 @@ export type SdkManagedReactFlowKey =
   | 'isValidConnection';
 
 /**
- * ReactFlow props the SDK reserves but does not set: allowing them would silently
- * fight a system that owns the same concern. `defaultNodes` / `defaultEdges` are
- * the uncontrolled-mode counterparts of the controlled `nodes` / `edges` the SDK
- * drives, so they would desync the store. `colorMode` is owned by the SDK theming
- * layer (design tokens / `initTheme`), so it is omitted rather than left to
- * conflict with the active theme. None of these are spread in `diagram.tsx`.
+ * ReactFlow props omitted from {@link WorkflowBuilderReactFlowProps} but not
+ * re-set in `diagram.tsx`. `default*` are no-ops under the SDK's controlled
+ * `nodes` / `edges`; `colorMode` would clash with the SDK theme. Type-level guard
+ * only (a JS / `as`-cast consumer can still smuggle them; worst case is cosmetic).
  */
 type SdkReservedReactFlowKey = 'defaultNodes' | 'defaultEdges' | 'colorMode';
 
 /** Every ReactFlow key the escape hatch must not expose. */
 type SdkOwnedReactFlowKey = SdkManagedReactFlowKey | SdkReservedReactFlowKey;
 
-/**
- * Identity type that compiles only when `A` is assignable to `B`. Used below so
- * an owned key that is no longer a real ReactFlow prop fails the build (`Omit`
- * does not validate its keys).
- */
+/** Compiles only when `A extends B`. Fails the build if an owned key stops being a real ReactFlow prop (`Omit` doesn't validate keys). */
 type AssertAssignable<A extends B, B> = A;
 
 /**
  * Escape hatch for the underlying ReactFlow canvas: forwards any ReactFlow prop
- * except the ones the SDK owns ({@link SdkOwnedReactFlowKey}), which are omitted
- * here and always win at runtime, so the editor cannot be broken from the
- * outside. Theme via the SDK design tokens rather than ReactFlow's `colorMode`
- * (omitted here for that reason).
+ * except the ones the SDK owns ({@link SdkOwnedReactFlowKey}). Theme via the SDK
+ * design tokens, not `colorMode`.
  *
- * A stable reference is preferred but not required: this value is only spread
- * onto the canvas, never used as a hook dependency, so an inline object does not
- * trigger remounts the way an unstable `nodeTypes` / `edgeTemplates` would.
+ * Treat as static config: the canvas reads it out-of-band, so changing a value
+ * at runtime may not apply until the canvas re-renders.
  *
  * @category Core
  */
@@ -249,11 +231,8 @@ export type WorkflowBuilderRootProps = PropsWithChildren<{
   /** Initial edges rendered on first mount. */
   initialEdges?: WorkflowBuilderEdge[];
   /**
-   * Validate connections as the user draws them. Receives the candidate
-   * `connection` plus the resolved `sourceNode` / `targetNode`; return `false`
-   * to reject it. An invalid drop creates no edge and does not flicker.
-   *
-   * **Must be a stable reference** (declare at module level or memoize).
+   * Validate connections as the user draws them. Return `false` to reject the
+   * drop. **Must be a stable reference.**
    *
    * @example
    * ```ts
@@ -263,9 +242,9 @@ export type WorkflowBuilderRootProps = PropsWithChildren<{
    */
   isValidConnection?: WorkflowBuilderIsValidConnection;
   /**
-   * Advanced. Forwards extra props to the underlying ReactFlow canvas. See
-   * {@link WorkflowBuilderReactFlowProps} for what is allowed. A stable
-   * reference is preferred but not required (it is only spread onto the canvas).
+   * Advanced escape hatch: forwards extra props to the ReactFlow canvas (see
+   * {@link WorkflowBuilderReactFlowProps}). Treat as static config; runtime value
+   * changes may not apply immediately.
    */
   reactFlowProps?: WorkflowBuilderReactFlowProps;
 }>;

--- a/packages/sdk/src/workflow-builder-root/workflow-builder-root.types.ts
+++ b/packages/sdk/src/workflow-builder-root/workflow-builder-root.types.ts
@@ -97,8 +97,8 @@ export type WorkflowBuilderJsonFormConfig = {
  *
  * @category Core
  */
-export type IsValidConnectionParams = {
-  /** Raw ReactFlow connection candidate — source / target node ids + handle ids. */
+export type WorkflowBuilderIsValidConnectionParams = {
+  /** Raw ReactFlow connection candidate: source / target node ids + handle ids. */
   connection: Connection;
   /** The node the connection is dragged from (resolved from `connection.source`). */
   sourceNode: WorkflowBuilderNode;
@@ -118,18 +118,20 @@ export type IsValidConnectionParams = {
  *
  * @category Core
  */
-export type WorkflowBuilderIsValidConnection = (params: IsValidConnectionParams) => boolean;
+export type WorkflowBuilderIsValidConnection = (params: WorkflowBuilderIsValidConnectionParams) => boolean;
 
 /**
- * ReactFlow props the SDK manages itself and spreads last in `diagram.tsx`, so
- * they always win at runtime. Omitted from {@link WorkflowBuilderReactFlowProps}.
- * Edit this union when the SDK starts or stops managing a prop.
+ * ReactFlow props the SDK sets itself, as explicit JSX attributes spread last in
+ * `diagram.tsx`, so they always win at runtime over `reactFlowProps`. Omitted
+ * from {@link WorkflowBuilderReactFlowProps}. Every key here must appear in that
+ * owned-attribute block; the `diagram.spec` precedence test enforces it. Edit
+ * this union when the SDK starts or stops setting a prop.
+ *
+ * Exported for that test only; not re-exported from the public entry point.
  */
-type SdkManagedReactFlowKey =
+export type SdkManagedReactFlowKey =
   | 'nodes'
   | 'edges'
-  | 'defaultNodes'
-  | 'defaultEdges'
   | 'nodeTypes'
   | 'edgeTypes'
   | 'onConnect'
@@ -152,12 +154,14 @@ type SdkManagedReactFlowKey =
   | 'isValidConnection';
 
 /**
- * ReactFlow props the SDK reserves but does not set: governed elsewhere, so a
- * `reactFlowProps` override would silently fight that system. `colorMode` is
- * owned by the SDK theming layer (design tokens / `initTheme`), so it is omitted
- * here rather than left to conflict with the active theme.
+ * ReactFlow props the SDK reserves but does not set: allowing them would silently
+ * fight a system that owns the same concern. `defaultNodes` / `defaultEdges` are
+ * the uncontrolled-mode counterparts of the controlled `nodes` / `edges` the SDK
+ * drives, so they would desync the store. `colorMode` is owned by the SDK theming
+ * layer (design tokens / `initTheme`), so it is omitted rather than left to
+ * conflict with the active theme. None of these are spread in `diagram.tsx`.
  */
-type SdkReservedReactFlowKey = 'colorMode';
+type SdkReservedReactFlowKey = 'defaultNodes' | 'defaultEdges' | 'colorMode';
 
 /** Every ReactFlow key the escape hatch must not expose. */
 type SdkOwnedReactFlowKey = SdkManagedReactFlowKey | SdkReservedReactFlowKey;
@@ -176,7 +180,9 @@ type AssertAssignable<A extends B, B> = A;
  * outside. Theme via the SDK design tokens rather than ReactFlow's `colorMode`
  * (omitted here for that reason).
  *
- * **Must be a stable reference** — declare at module level or memoize.
+ * A stable reference is preferred but not required: this value is only spread
+ * onto the canvas, never used as a hook dependency, so an inline object does not
+ * trigger remounts the way an unstable `nodeTypes` / `edgeTemplates` would.
  *
  * @category Core
  */
@@ -258,7 +264,8 @@ export type WorkflowBuilderRootProps = PropsWithChildren<{
   isValidConnection?: WorkflowBuilderIsValidConnection;
   /**
    * Advanced. Forwards extra props to the underlying ReactFlow canvas. See
-   * {@link WorkflowBuilderReactFlowProps} for what is allowed.
+   * {@link WorkflowBuilderReactFlowProps} for what is allowed. A stable
+   * reference is preferred but not required (it is only spread onto the canvas).
    */
   reactFlowProps?: WorkflowBuilderReactFlowProps;
 }>;


### PR DESCRIPTION
Expose two opt-in props on <WorkflowBuilder.Root>:

- isValidConnection: validates connections live while the user drags them. Receives the candidate connection plus the resolved source/target nodes, so a rule branches on data.type without touching the store. A rejected drop creates no edge and does not flicker. Fails open when an endpoint cannot be resolved to a node.
- reactFlowProps: escape hatch that forwards extra props to the underlying ReactFlow canvas. SDK-owned props (graph data, connection/selection/change handlers, type maps, the connection line) plus colorMode are omitted from the type and spread last, so they always win and the editor cannot be broken from the outside. Theme via the SDK design tokens, not colorMode.

Config flows through module-level holders (same pattern as edge-templates), written during Root render so descendants read current values on first paint.

Tests cover the holder, the isValidConnection adapter, and the spread-order contract (owned props win, defaults stay overridable). Demo and SDK + site docs updated. Changeset: minor.