### PR TITLE
fix(sdk): language selector reflects resolved language for regional locales

### DIFF
--- a/.changeset/fix-language-selector-regional-locale.md
+++ b/.changeset/fix-language-selector-regional-locale.md
@@ -1,0 +1,5 @@
+---
+'@workflowbuilder/sdk': patch
+---
+
+Fix the language selector displaying "EN" while the UI rendered Polish for regional locales (e.g. `pl-PL`). The selector now resolves the current option from the base/resolved language instead of the raw `i18n.language`, so its label reflects the language the strings actually render in.

--- a/packages/sdk/src/features/i18n/components/language-selector/language-selector.spec.tsx
+++ b/packages/sdk/src/features/i18n/components/language-selector/language-selector.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Controllable i18n stub — each test sets `language` / `resolvedLanguage`.
+const i18nState = { language: 'en', resolvedLanguage: 'en', changeLanguage: vi.fn() };
+
+// Render the Menu's trigger (children) so the displayed language code is queryable.
+vi.mock('@synergycodes/overflow-ui', () => ({
+  Menu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  NavButton: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock('@workflow-builder/icons', () => ({
+  Icon: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: i18nState }),
+}));
+
+const { LanguageSelector } = await import('./language-selector');
+
+describe('LanguageSelector — label reflects the resolved language', () => {
+  it('shows PL for a regional Polish locale that resolves to pl (regression: used to show EN)', () => {
+    i18nState.language = 'pl-PL';
+    i18nState.resolvedLanguage = 'pl';
+
+    render(<LanguageSelector />);
+
+    expect(screen.getByText('PL')).toBeTruthy();
+    expect(screen.queryByText('EN')).toBeNull();
+  });
+
+  it('shows EN for english', () => {
+    i18nState.language = 'en';
+    i18nState.resolvedLanguage = 'en';
+
+    render(<LanguageSelector />);
+
+    expect(screen.getByText('EN')).toBeTruthy();
+  });
+});

--- a/packages/sdk/src/features/i18n/components/language-selector/language-selector.tsx
+++ b/packages/sdk/src/features/i18n/components/language-selector/language-selector.tsx
@@ -20,7 +20,8 @@ const languages: Language[] = [
 export function LanguageSelector() {
   const { t, i18n } = useTranslation();
 
-  const currentLanguage = languages.find((lang) => lang.code === i18n.language) || languages[0];
+  const resolvedCode = i18n.resolvedLanguage ?? i18n.language?.split('-')[0];
+  const currentLanguage = languages.find((lang) => lang.code === resolvedCode) || languages[0];
 
   const languageItems: MenuItemProps[] = useMemo(
     () =>


### PR DESCRIPTION
## Problem

The language selector displayed **EN** while the UI rendered **Polish**, on machines with a regional locale. Not reliably reproducible.

## Root cause

`features/i18n/components/language-selector/language-selector.tsx` matched the current option against the raw `i18n.language`:

```ts
const currentLanguage = languages.find((lang) => lang.code === i18n.language) || languages[0];
```

The SDK i18n uses `LanguageDetector` (`order: ['localStorage','navigator']`, `load: 'languageOnly'`) with no consumer-set default. When the browser reports a regional locale (e.g. `pl-PL`), `i18n.language` is `pl-PL` — which equals neither `en` nor `pl` — so the lookup falls back to `languages[0]` (English) and the selector shows **EN**, while translations resolve via `resolvedLanguage` (`pl`) → **Polish strings**.

## Fix

Match on the resolved base language instead:

```ts
const activeCode = i18n.resolvedLanguage ?? i18n.language?.split('-')[0];
const currentLanguage = languages.find((lang) => lang.code === activeCode) || languages[0];
```

Adds a regression spec (`language-selector.spec.tsx`) covering the `pl-PL` → `PL` case. Changeset: patch.

## Verify

- `pnpm -F @workflowbuilder/sdk test` — 197 passing (incl. the new spec).
- Repro pre-fix: set browser / `localStorage['i18nextLng']` to `pl-PL` → selector shows EN, strings Polish.

Surfaced while working on the AI Studio demo. ClickUp: 86cahawyn.