### PR TITLE
fix(sdk): decision-node ports and panel spacing, TextArea maxRows

### DIFF
--- a/.changeset/decision-branches-panel-spacing.md
+++ b/.changeset/decision-branches-panel-spacing.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': patch
 ---
 
-Branch cards in the decision node's properties panel are now vertically spaced - the control's wrapper was an unstyled div, so the cards and the add-branch button rendered glued together.
+Branch cards in the decision node's properties panel are now vertically spaced - the control's wrapper was an unstyled div, so the cards and the add-branch button rendered glued together outside an Accordion. The accordion layout's compensating `> div:not([class])` selector is removed along with it; a custom control relying on that undocumented behavior should style its own root.

--- a/.changeset/decision-branches-panel-spacing.md
+++ b/.changeset/decision-branches-panel-spacing.md
@@ -1,0 +1,5 @@
+---
+'@workflowbuilder/sdk': patch
+---
+
+Branch cards in the decision node's properties panel are now vertically spaced - the control's wrapper was an unstyled div, so the cards and the add-branch button rendered glued together.

--- a/.changeset/decision-branches-panel-spacing.md
+++ b/.changeset/decision-branches-panel-spacing.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': patch
 ---
 
-Branch cards in the decision node's properties panel are now vertically spaced - the control's wrapper was an unstyled div, so the cards and the add-branch button rendered glued together outside an Accordion. The accordion layout's compensating `> div:not([class])` selector is removed along with it; a custom control relying on that undocumented behavior should style its own root.
+Branch cards in the decision properties panel are now vertically spaced. The accordion layout no longer lays out classless child divs - custom controls should style their own root.

--- a/.changeset/decision-node-outer-source-handle.md
+++ b/.changeset/decision-node-outer-source-handle.md
@@ -1,0 +1,5 @@
+---
+'@workflowbuilder/sdk': patch
+---
+
+The decision node no longer renders its node-level output port when branches exist - each branch carries its own source handle, so the outer one was a redundant, disconnected port. Branchless decision nodes keep the node-level port. Note: a saved diagram that connected an edge to a branched decision node's outer `source` handle loses that connection point.

--- a/.changeset/decision-node-outer-source-handle.md
+++ b/.changeset/decision-node-outer-source-handle.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': patch
 ---
 
-The decision node no longer renders its node-level output port when branches exist - each branch carries its own source handle, so the outer one was a redundant, disconnected port. Branchless decision nodes keep the node-level port. Note: a saved diagram that connected an edge to a branched decision node's outer `source` handle loses that connection point.
+The decision node no longer renders a node-level output port - branches are its only outputs. Execution routes exclusively through branch handles (an edge from the bare `source` could never fire), so the port only invited dead connections. Note: a saved diagram with an edge from a decision node's bare `source` handle loses that connection point.

--- a/.changeset/decision-node-outer-source-handle.md
+++ b/.changeset/decision-node-outer-source-handle.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': patch
 ---
 
-The decision node no longer renders a node-level output port - branches are its only outputs. Execution routes exclusively through branch handles (an edge from the bare `source` could never fire), so the port only invited dead connections. Note: a saved diagram with an edge from a decision node's bare `source` handle loses that connection point.
+The decision node no longer renders a node-level output port - branches are its only outputs. Edges drawn from the old bare `source` handle lose their connection point.

--- a/.changeset/fix-language-selector-regional-locale.md
+++ b/.changeset/fix-language-selector-regional-locale.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': patch
 ---
 
-Fix the language selector displaying "EN" while the UI rendered Polish for regional locales (e.g. `pl-PL`). The selector now resolves the current option from the base/resolved language instead of the raw `i18n.language`, so its label reflects the language the strings actually render in.
+The language selector no longer shows "EN" while the UI renders Polish for regional locales (e.g. `pl-PL`).

--- a/.changeset/textarea-max-rows.md
+++ b/.changeset/textarea-max-rows.md
@@ -1,0 +1,5 @@
+---
+'@workflowbuilder/sdk': patch
+---
+
+The `TextArea` uischema control now accepts `maxRows` (alongside `minRows`), capping how far the field auto-grows.

--- a/.changeset/textarea-max-rows.md
+++ b/.changeset/textarea-max-rows.md
@@ -2,4 +2,4 @@
 '@workflowbuilder/sdk': patch
 ---
 
-The `TextArea` uischema control now accepts `maxRows` (alongside `minRows`), capping how far the field auto-grows.
+The `TextArea` uischema control accepts `maxRows`, capping how far the field auto-grows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ The SDK is the only npm-published workspace; everything else under `apps/` and `
 **Daily SDK change:**
 
 1. Edit `packages/sdk/**`, run tests/typecheck locally.
-2. **Add a changeset** with `/wb.changeset <patch|minor|major> "<summary>"`. Required for any consumer-visible change. Skip only for changes that don't ship in `dist/` (e.g. `eslint.config.mjs`, internal tests, source-only comments).
+2. **Add a changeset** with `/wb.changeset <patch|minor|major> "<summary>"`. Required for any consumer-visible change. Skip only for changes that don't ship in `dist/` (e.g. `eslint.config.mjs`, internal tests, source-only comments). Keep it to 1-2 plain sentences: the consumer-visible change plus any migration note - changesets become the public CHANGELOG, so no rationale, investigation history, or noise (that belongs in the commit message and PR).
 3. Commit code + changeset together with a Conventional Commits message:
    ```
    git add packages/sdk/... .changeset/<slug>.md

--- a/packages/sdk/src/features/diagram/nodes/decision-node-template/decision-node-template.tsx
+++ b/packages/sdk/src/features/diagram/nodes/decision-node-template/decision-node-template.tsx
@@ -72,7 +72,10 @@ export const DecisionNodeTemplate = memo(
         </NodePanel.Content>
         <NodePanel.Handles isVisible={isCanvasNode} alignment={handlesAlignment}>
           <Handle id={handleTargetId} position={handleTargetPosition} type="target" />
-          <Handle id={handleSourceId} position={handleSourcePosition} type="source" />
+          {/* Branches carry their own source handles; the node-level one only exists while there are none. */}
+          {(decisionBranches ?? []).length === 0 && (
+            <Handle id={handleSourceId} position={handleSourcePosition} type="source" />
+          )}
         </NodePanel.Handles>
       </NodePanel.Root>
     );

--- a/packages/sdk/src/features/diagram/nodes/decision-node-template/decision-node-template.tsx
+++ b/packages/sdk/src/features/diagram/nodes/decision-node-template/decision-node-template.tsx
@@ -45,10 +45,7 @@ export const DecisionNodeTemplate = memo(
     const iconElement = useMemo(() => <Icon name={icon} size="large" />, [icon]);
 
     const handleTargetId = getHandleId({ handleType: 'target' });
-    const handleSourceId = getHandleId({ handleType: 'source' });
-
     const handleTargetPosition = getHandlePosition({ direction: layoutDirection, handleType: 'target' });
-    const handleSourcePosition = getHandlePosition({ direction: layoutDirection, handleType: 'source' });
 
     const isCanvasNode = showHandles;
 
@@ -72,10 +69,6 @@ export const DecisionNodeTemplate = memo(
         </NodePanel.Content>
         <NodePanel.Handles isVisible={isCanvasNode} alignment={handlesAlignment}>
           <Handle id={handleTargetId} position={handleTargetPosition} type="target" />
-          {/* Branches carry their own source handles; the node-level one only exists while there are none. */}
-          {(decisionBranches ?? []).length === 0 && (
-            <Handle id={handleSourceId} position={handleSourcePosition} type="source" />
-          )}
         </NodePanel.Handles>
       </NodePanel.Root>
     );

--- a/packages/sdk/src/features/json-form/controls/decision-branches-control/decision-branches-control.module.css
+++ b/packages/sdk/src/features/json-form/controls/decision-branches-control/decision-branches-control.module.css
@@ -1,0 +1,9 @@
+:root {
+  --wb-decision-branches-gap: 0.75rem;
+}
+
+.branches {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wb-decision-branches-gap);
+}

--- a/packages/sdk/src/features/json-form/controls/decision-branches-control/decision-branches-control.spec.tsx
+++ b/packages/sdk/src/features/json-form/controls/decision-branches-control/decision-branches-control.spec.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./branch-card/branch-card', () => ({
+  BranchCard: () => <div data-testid="branch-card" />,
+}));
+
+vi.mock('../../../diagram/nodes/components/placeholder-button/placeholder-button', () => ({
+  PlaceholderButton: () => <button type="button">add</button>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Unwrap withJsonFormsControlProps so props flow directly instead of from JSONForms context.
+vi.mock('../../utils/rendering', () => ({
+  createControlRenderer: (_type: string, renderer: unknown) => ({ tester: undefined, renderer }),
+}));
+
+const { decisionBranchesControlRenderer } = await import('./decision-branches-control');
+
+const branch = (id: string) => ({ id, sourceHandle: `source:inner:${id}`, label: id, conditions: [] });
+
+describe('DecisionBranchesControl', () => {
+  it('stacks branch cards in a styled container (regression: unstyled div rendered them glued)', () => {
+    const Control = decisionBranchesControlRenderer.renderer as unknown as React.ComponentType<Record<string, unknown>>;
+    const { container, getAllByTestId } = render(
+      <Control
+        data={[branch('a'), branch('b')]}
+        handleChange={() => {}}
+        path="decisionBranches"
+        enabled={true}
+        errors=""
+        uischema={{ type: 'DecisionBranches', scope: '#/properties/decisionBranches' }}
+      />,
+    );
+
+    const wrapper = getAllByTestId('branch-card')[0].parentElement;
+    expect(wrapper?.className).toContain('branches');
+    expect(container.querySelectorAll('[data-testid="branch-card"]')).toHaveLength(2);
+  });
+});

--- a/packages/sdk/src/features/json-form/controls/decision-branches-control/decision-branches-control.tsx
+++ b/packages/sdk/src/features/json-form/controls/decision-branches-control/decision-branches-control.tsx
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import styles from './decision-branches-control.module.css';
+
 import { PlaceholderButton } from '../../../diagram/nodes/components/placeholder-button/placeholder-button';
 import type { DecisionBranch, DecisionBranchesControlProps } from '../../types/controls';
 import { createControlRenderer } from '../../utils/rendering';
@@ -38,7 +40,7 @@ function DecisionBranchesControl(props: DecisionBranchesControlProps) {
   }
 
   return (
-    <div>
+    <div className={styles['branches']}>
       {decisionBranches.map((branch, index) => (
         <BranchCard
           key={branch.id}

--- a/packages/sdk/src/features/json-form/controls/text-area-control/text-area-control.tsx
+++ b/packages/sdk/src/features/json-form/controls/text-area-control/text-area-control.tsx
@@ -7,7 +7,7 @@ import { ControlWrapper } from '../control-wrapper';
 
 function TextAreaControl(props: TextAreaControlProps) {
   const { data, handleChange, path, enabled, uischema } = props;
-  const { placeholder, minRows, disabled } = uischema;
+  const { placeholder, minRows, maxRows, disabled } = uischema;
   const isDisabled = !enabled || disabled === true;
 
   const [inputValue, setInputValue] = useState<string>(data);
@@ -30,6 +30,7 @@ function TextAreaControl(props: TextAreaControlProps) {
         disabled={isDisabled}
         value={inputValue}
         minRows={minRows}
+        maxRows={maxRows}
         placeholder={placeholder}
         onChange={onChange}
         onBlur={onBlur}

--- a/packages/sdk/src/features/json-form/layouts/accordion-layout/accordion-layout.module.css
+++ b/packages/sdk/src/features/json-form/layouts/accordion-layout/accordion-layout.module.css
@@ -1,5 +1,4 @@
-.accordion-content,
-.accordion-content > div:not([class]) {
+.accordion-content {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;

--- a/packages/sdk/src/types/controls.ts
+++ b/packages/sdk/src/types/controls.ts
@@ -37,7 +37,7 @@ export type TextAreaControlElement = Override<
   BaseControlElement,
   {
     type: 'TextArea';
-  } & Pick<TextAreaProps, 'placeholder' | 'minRows'>
+  } & Pick<TextAreaProps, 'placeholder' | 'minRows' | 'maxRows'>
 >;
 export type TextAreaControlProps = ControlProps<string, TextAreaControlElement>;
 


### PR DESCRIPTION
Three consumer-facing fixes surfaced while building the AI Studio demo (#48). Each is a `patch` with its own changeset.

## Changes

1. **Decision node: no node-level output port at all** - branches are the decision node's only outputs. Execution routes exclusively through branch handles (the executor sets nextPort to the matched branch or fails with no_branch_matched), so an edge from the bare `source` handle could never fire - the port only invited connections that silently dead-end. Initially kept for branchless nodes, removed entirely after review feedback.
   *Not affected:* the demo's canned decision nodes (simple-flow) render as plain nodes, not this template. *Caveat:* a saved diagram with an edge from a decision node's bare `source` loses that connection point (it was non-functional anyway).
2. **`maxRows` on the `TextArea` uischema control** - overflow-ui's TextArea supports it; the uischema type and control only forwarded `minRows`, so consumers had to cap field growth with CSS `max-height`. (`VariableTextArea` untouched - it doesn't forward row props at all today.)
3. **Branch cards in the decision properties panel render glued together** - `DecisionBranchesControl` wrapped the cards and the add-branch button in an unstyled `div`. The accordion layout papered over this with a `.accordion-content > div:not([class])` selector, so the gap only appeared when the control happened to sit inside an Accordion (demo) and vanished otherwise (AI Studio). The control now styles its own wrapper (same 0.75rem gap - accordion-hosted rendering is pixel-identical) and the classless-div hack is removed; it had no other in-repo target. Regression spec included.

## Verify

- `pnpm -F @workflowbuilder/sdk test` - 198 passing (incl. the new control spec); typecheck + lint clean.
- Follow-up in #48 once this merges: drop the interim CSS overrides in `apps/ai-studio/src/app/node-overrides.css` (outer-port hide, textarea max-height) and set `maxRows` in the ai-agent uischema.
