### PR TITLE
feat(ai-studio): floating button reopens the welcome modal

### DIFF
--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.module.css
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.module.css
@@ -109,3 +109,25 @@
 .cta:hover {
   background: var(--ax-colors-acc1-600, #0477c5);
 }
+
+.reopen {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 2.5rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 0.0625rem solid var(--wb-app-bar-border-color);
+  border-radius: 50%;
+  background: var(--wb-app-bar-background);
+  color: var(--ax-txt-secondary-default, #4d5059);
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.reopen:hover {
+  color: var(--ax-colors-acc1-500, #1096e7);
+}

--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
@@ -16,10 +16,6 @@ function hasAcknowledged(): boolean {
 export function DisclaimerModal() {
   const [open, setOpen] = useState(() => !hasAcknowledged());
 
-  if (!open) {
-    return null;
-  }
-
   function dismiss() {
     try {
       localStorage.setItem(STORAGE_KEY, 'true');
@@ -27,6 +23,14 @@ export function DisclaimerModal() {
       // storage unavailable
     }
     setOpen(false);
+  }
+
+  if (!open) {
+    return (
+      <button className={styles['reopen']} onClick={() => setOpen(true)} aria-label="About this demo">
+        <Info size={20} weight="bold" />
+      </button>
+    );
   }
 
   return (


### PR DESCRIPTION
The welcome/disclaimer modal shows only on the first visit. This adds a small floating info button in the bottom-right corner of the canvas (clear of the React Flow watermark) that reopens it on demand.

Follow-up to #48 - this commit was authored on the original branch after the merge cut-off, so it never landed on main.