### PR TITLE
feat(ai-studio): dock execution log beside the properties panel

### DIFF
--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
@@ -18,8 +18,7 @@ function hasAcknowledged(): boolean {
 
 export function DisclaimerModal() {
   const [open, setOpen] = useState(() => !hasAcknowledged());
-  // The reopen button shares the bottom-right corner with the execution log
-  // and the expanded properties panel - hide it while either is on screen.
+  // the reopen button shares the bottom-right corner with both of these
   const logVisible = useExecutionStore((s) => s.events.length > 0 || s.status !== 'idle');
   const { panelExpanded } = useRightPanelAnchor();
 

--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
@@ -3,6 +3,9 @@ import { useState } from 'react';
 
 import styles from './disclaimer-modal.module.css';
 
+import { useRightPanelAnchor } from '../../hooks/use-right-panel-anchor';
+import { useExecutionStore } from '../../stores/use-execution-store';
+
 const STORAGE_KEY = 'ai-studio:disclaimer-acknowledged';
 
 function hasAcknowledged(): boolean {
@@ -15,6 +18,10 @@ function hasAcknowledged(): boolean {
 
 export function DisclaimerModal() {
   const [open, setOpen] = useState(() => !hasAcknowledged());
+  // The reopen button shares the bottom-right corner with the execution log
+  // and the expanded properties panel - hide it while either is on screen.
+  const logVisible = useExecutionStore((s) => s.events.length > 0 || s.status !== 'idle');
+  const { panelExpanded } = useRightPanelAnchor();
 
   function dismiss() {
     try {
@@ -26,6 +33,8 @@ export function DisclaimerModal() {
   }
 
   if (!open) {
+    if (logVisible || panelExpanded) return null;
+
     return (
       <button className={styles['reopen']} onClick={() => setOpen(true)} aria-label="About this demo">
         <Info size={20} weight="bold" />

--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
@@ -18,7 +18,6 @@ function hasAcknowledged(): boolean {
 
 export function DisclaimerModal() {
   const [open, setOpen] = useState(() => !hasAcknowledged());
-  // the reopen button shares the bottom-right corner with both of these
   const logVisible = useExecutionStore((s) => s.events.length > 0 || s.status !== 'idle');
   const { panelExpanded } = useRightPanelAnchor();
 

--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
@@ -18,7 +18,7 @@ function hasAcknowledged(): boolean {
 
 export function DisclaimerModal() {
   const [open, setOpen] = useState(() => !hasAcknowledged());
-  const logVisible = useExecutionStore((s) => s.events.length > 0 || s.status !== 'idle');
+  const logVisible = useExecutionStore((state) => state.events.length > 0 || state.status !== 'idle');
   const { panelExpanded } = useRightPanelAnchor();
 
   function dismiss() {

--- a/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
+++ b/apps/ai-studio/src/components/disclaimer/disclaimer-modal.tsx
@@ -17,9 +17,9 @@ function hasAcknowledged(): boolean {
 }
 
 export function DisclaimerModal() {
-  const [open, setOpen] = useState(() => !hasAcknowledged());
-  const logVisible = useExecutionStore((state) => state.events.length > 0 || state.status !== 'idle');
-  const { panelExpanded } = useRightPanelAnchor();
+  const [isOpen, setIsOpen] = useState(() => !hasAcknowledged());
+  const isLogVisible = useExecutionStore((state) => state.events.length > 0 || state.status !== 'idle');
+  const { isPanelExpanded } = useRightPanelAnchor();
 
   function dismiss() {
     try {
@@ -27,14 +27,14 @@ export function DisclaimerModal() {
     } catch {
       // storage unavailable
     }
-    setOpen(false);
+    setIsOpen(false);
   }
 
-  if (!open) {
-    if (logVisible || panelExpanded) return null;
+  if (!isOpen) {
+    if (isLogVisible || isPanelExpanded) return null;
 
     return (
-      <button className={styles['reopen']} onClick={() => setOpen(true)} aria-label="About this demo">
+      <button className={styles['reopen']} onClick={() => setIsOpen(true)} aria-label="About this demo">
         <Info size={20} weight="bold" />
       </button>
     );

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -1,6 +1,5 @@
 .panel {
   position: fixed;
-  /* Aligned with the bottom edge of the SDK right panel (1rem layout padding). */
   bottom: 1rem;
   right: var(--log-panel-right, 1rem);
   width: 30rem;

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -62,14 +62,14 @@
   }
 }
 
-.event--toggleable {
-  cursor: pointer;
-}
-
 .event-header {
   display: flex;
   align-items: center;
   gap: 0.375rem;
+}
+
+.event-header--toggleable {
+  cursor: pointer;
 }
 
 .badge {

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -62,14 +62,14 @@
   }
 }
 
+.event--toggleable {
+  cursor: pointer;
+}
+
 .event-header {
   display: flex;
   align-items: center;
   gap: 0.375rem;
-}
-
-.event-header--toggleable {
-  cursor: pointer;
 }
 
 .badge {

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -63,15 +63,14 @@
   }
 }
 
+.event--toggleable {
+  cursor: pointer;
+}
+
 .event-header {
   display: flex;
   align-items: center;
   gap: 0.375rem;
-  cursor: default;
-}
-
-.event-header:has(+ .detail) {
-  cursor: pointer;
 }
 
 .badge {
@@ -126,7 +125,6 @@
   word-break: break-word;
   line-height: 1.5;
   font-size: 0.7rem;
-  cursor: pointer;
 }
 
 .detail--expanded {

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -4,7 +4,7 @@
   right: var(--log-panel-right, 1rem);
   width: 30rem;
   max-width: calc(100vw - 3rem);
-  max-height: 430px;
+  max-height: 26.875rem;
   background: var(--wb-app-bar-background);
   border: 0.0625rem solid var(--wb-app-bar-border-color);
   border-radius: var(--wb-app-bar-border-radius);

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -4,7 +4,7 @@
   right: var(--log-panel-right, 1rem);
   width: 30rem;
   max-width: calc(100vw - 3rem);
-  max-height: 26.875rem; /* 430px */
+  max-height: 430px;
   background: var(--wb-app-bar-background);
   border: 0.0625rem solid var(--wb-app-bar-border-color);
   border-radius: var(--wb-app-bar-border-radius);

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -1,11 +1,11 @@
 .panel {
   position: fixed;
-  bottom: 1.5rem;
-  left: 50%;
-  transform: translateX(-50%);
+  /* Aligned with the bottom edge of the SDK right panel (1rem layout padding). */
+  bottom: 1rem;
+  right: var(--log-panel-right, 1rem);
   width: 30rem;
   max-width: calc(100vw - 3rem);
-  max-height: 60vh;
+  max-height: 26.875rem; /* 430px */
   background: var(--wb-app-bar-background);
   border: 0.0625rem solid var(--wb-app-bar-border-color);
   border-radius: var(--wb-app-bar-border-radius);

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -44,11 +44,13 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   const hasDetail = !!detail;
   const truncated = detail && detail.length > 120 ? detail.slice(0, 120) + '…' : detail;
 
-  function handleToggle(mouseEvent: React.MouseEvent) {
-    if (!hasDetail) return;
-    if (globalThis.getSelection()?.toString()) return;
-    if (mouseEvent.target instanceof Element && mouseEvent.target.closest('a, button')) return;
-    setExpanded((v) => !v);
+  function handleToggle({ target }: React.MouseEvent) {
+    const clickedInteractiveElement = target instanceof Element && !!target.closest('a, button');
+    const isSelectingText = !!globalThis.getSelection()?.toString();
+
+    if (hasDetail && !clickedInteractiveElement && !isSelectingText) {
+      setExpanded((isExpanded) => !isExpanded);
+    }
   }
 
   return (

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -44,12 +44,22 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   const hasDetail = !!detail;
   const truncated = detail && detail.length > 120 ? detail.slice(0, 120) + '…' : detail;
 
+  function handleToggle(mouseEvent: React.MouseEvent) {
+    if (!hasDetail) return;
+    // Selecting text (to copy log content) must not toggle the entry.
+    if (globalThis.getSelection()?.toString()) return;
+    // Nor should clicks on interactive elements inside the detail.
+    if (mouseEvent.target instanceof Element && mouseEvent.target.closest('a, button')) return;
+    setExpanded((v) => !v);
+  }
+
   return (
     <div
       data-node-id={isNode ? nodeId : undefined}
-      className={`${styles['event']} ${styles[`event--${event.type.split('_')[0]}`] ?? ''} ${highlighted ? styles['event--highlighted'] : ''}`}
+      className={`${styles['event']} ${hasDetail ? styles['event--toggleable'] : ''} ${styles[`event--${event.type.split('_')[0]}`] ?? ''} ${highlighted ? styles['event--highlighted'] : ''}`}
+      onClick={handleToggle}
     >
-      <div className={styles['event-header']} onClick={() => hasDetail && setExpanded((v) => !v)}>
+      <div className={styles['event-header']}>
         <span className={`${styles['badge']} ${styles[`badge--${event.type}`]}`}>{label}</span>
         {isNode && <span className={styles['node-id']}>{(event as { nodeId: string }).nodeId.slice(0, 8)}</span>}
         <span className={styles['time']}>{formatTime(event.timestamp)}</span>

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -19,11 +19,11 @@ function formatTime(isoTimestamp: string) {
 }
 
 function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNodeId: string | null }) {
-  const [expanded, setExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const nodeId = (event as { nodeId?: string | null }).nodeId;
   const isNode = typeof nodeId === 'string' && nodeId.length > 0;
-  const highlighted = isNode && nodeId === selectedNodeId;
+  const isHighlighted = isNode && nodeId === selectedNodeId;
   const label = event.type.replaceAll('_', ' ');
 
   let detail: string | undefined;
@@ -55,7 +55,7 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
     const isSelectingText = !!globalThis.getSelection()?.toString();
 
     if (hasDetail && !clickedInteractiveElement && !isSelectingText) {
-      setExpanded((isExpanded) => !isExpanded);
+      setIsExpanded((current) => !current);
     }
   }
 
@@ -64,7 +64,7 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
       data-node-id={isNode ? nodeId : undefined}
       className={clsx(styles['event'], {
         [styles['event--toggleable']]: hasDetail,
-        [styles['event--highlighted']]: highlighted,
+        [styles['event--highlighted']]: isHighlighted,
       })}
       onClick={handleToggle}
     >
@@ -72,11 +72,11 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
         <span className={clsx(styles['badge'], styles[`badge--${event.type}`])}>{label}</span>
         {isNode && <span className={styles['node-id']}>{nodeId.slice(0, NODE_ID_PREVIEW_CHARS)}</span>}
         <span className={styles['time']}>{formatTime(event.timestamp)}</span>
-        {hasDetail && <span className={styles['toggle']}>{expanded ? '▲' : '▼'}</span>}
+        {hasDetail && <span className={styles['toggle']}>{isExpanded ? '▲' : '▼'}</span>}
       </div>
       {hasDetail && (
-        <div className={clsx(styles['detail'], { [styles['detail--expanded']]: expanded })}>
-          {expanded ? detail : truncated}
+        <div className={clsx(styles['detail'], { [styles['detail--expanded']]: isExpanded })}>
+          {isExpanded ? detail : truncated}
         </div>
       )}
     </div>
@@ -87,7 +87,7 @@ export function ExecutionLogPanel() {
   const events = useExecutionStore((state) => state.events);
   const status = useExecutionStore((state) => state.status);
   const executionId = useExecutionStore((state) => state.executionId);
-  const collapsed = useExecutionStore((state) => state.logCollapsed);
+  const isCollapsed = useExecutionStore((state) => state.isLogCollapsed);
   // Clicking a node (incl. its flag marker) selects it on the canvas; the
   // highlight derives from that selection, so it clears on deselect.
   const selectedNodeId = useSingleSelectedElement()?.node?.id ?? null;
@@ -101,15 +101,15 @@ export function ExecutionLogPanel() {
   }, [executionId]);
 
   useEffect(() => {
-    if (!collapsed && stickToBottomRef.current && bodyRef.current) {
+    if (!isCollapsed && stickToBottomRef.current && bodyRef.current) {
       bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
     }
-  }, [events.length, collapsed]);
+  }, [events.length, isCollapsed]);
 
   useEffect(() => {
-    if (!selectedNodeId || collapsed) return;
+    if (!selectedNodeId || isCollapsed) return;
     bodyRef.current?.querySelector(`[data-node-id="${selectedNodeId}"]`)?.scrollIntoView({ block: 'nearest' });
-  }, [selectedNodeId, collapsed]);
+  }, [selectedNodeId, isCollapsed]);
 
   function handleBodyScroll() {
     const body = bodyRef.current;
@@ -123,15 +123,15 @@ export function ExecutionLogPanel() {
 
   return (
     <div
-      className={clsx(styles['panel'], { [styles['panel--collapsed']]: collapsed })}
+      className={clsx(styles['panel'], { [styles['panel--collapsed']]: isCollapsed })}
       style={{ '--log-panel-right': `${rightOffset}px` } as React.CSSProperties}
     >
       <div className={styles['header']} onClick={toggleLog}>
         <span className={styles['title']}>Execution Log</span>
         <span className={clsx(styles['status'], styles[`status--${status}`])}>{status}</span>
-        <span className={styles['toggle']}>{collapsed ? '▲' : '▼'}</span>
+        <span className={styles['toggle']}>{isCollapsed ? '▲' : '▼'}</span>
       </div>
-      {!collapsed && (
+      {!isCollapsed && (
         <div ref={bodyRef} className={styles['body']} onScroll={handleBodyScroll}>
           {events.map((event) => (
             <EventRow key={`${event.executionId}-${event.sequence}`} event={event} selectedNodeId={selectedNodeId} />

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -46,9 +46,7 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
 
   function handleToggle(mouseEvent: React.MouseEvent) {
     if (!hasDetail) return;
-    // Selecting text (to copy log content) must not toggle the entry.
     if (globalThis.getSelection()?.toString()) return;
-    // Nor should clicks on interactive elements inside the detail.
     if (mouseEvent.target instanceof Element && mouseEvent.target.closest('a, button')) return;
     setExpanded((v) => !v);
   }
@@ -85,8 +83,6 @@ export function ExecutionLogPanel() {
   const { rightOffset } = useRightPanelAnchor();
 
   const bodyRef = useRef<HTMLDivElement>(null);
-  // Follow the newest entry only while the user stays at the bottom; any
-  // scroll away pauses following, scrolling back to the bottom resumes it.
   const stickToBottomRef = useRef(true);
 
   useEffect(() => {

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -50,11 +50,10 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   const truncated =
     detail && detail.length > DETAIL_PREVIEW_CHARS ? detail.slice(0, DETAIL_PREVIEW_CHARS) + '…' : detail;
 
-  function handleToggle({ target }: React.MouseEvent) {
-    const clickedInteractiveElement = target instanceof Element && !!target.closest('a, button');
+  function handleToggle() {
     const isSelectingText = !!globalThis.getSelection()?.toString();
 
-    if (hasDetail && !clickedInteractiveElement && !isSelectingText) {
+    if (hasDetail && !isSelectingText) {
       setExpanded((isExpanded) => !isExpanded);
     }
   }
@@ -62,13 +61,12 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   return (
     <div
       data-node-id={isNode ? nodeId : undefined}
-      className={clsx(styles['event'], {
-        [styles['event--toggleable']]: hasDetail,
-        [styles['event--highlighted']]: highlighted,
-      })}
-      onClick={handleToggle}
+      className={clsx(styles['event'], { [styles['event--highlighted']]: highlighted })}
     >
-      <div className={styles['event-header']}>
+      <div
+        className={clsx(styles['event-header'], { [styles['event-header--toggleable']]: hasDetail })}
+        onClick={handleToggle}
+      >
         <span className={clsx(styles['badge'], styles[`badge--${event.type}`])}>{label}</span>
         {isNode && <span className={styles['node-id']}>{nodeId.slice(0, NODE_ID_PREVIEW_CHARS)}</span>}
         <span className={styles['time']}>{formatTime(event.timestamp)}</span>

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -5,6 +5,7 @@ import type { ExecutionEvent } from '@workflow-builder/types/workflow-execution/
 
 import styles from './log-panel.module.css';
 
+import { useRightPanelAnchor } from '../../hooks/use-right-panel-anchor';
 import { toggleLog, useExecutionStore } from '../../stores/use-execution-store';
 import { extractOutputText } from '../../utils/extract-output-text';
 
@@ -66,15 +67,24 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
 export function ExecutionLogPanel() {
   const events = useExecutionStore((s) => s.events);
   const status = useExecutionStore((s) => s.status);
+  const executionId = useExecutionStore((s) => s.executionId);
   const collapsed = useExecutionStore((s) => s.logCollapsed);
   // Clicking a node (incl. its flag marker) selects it on the canvas; the
   // highlight derives from that selection, so it clears on deselect.
   const selectedNodeId = useSingleSelectedElement()?.node?.id ?? null;
+  const { rightOffset } = useRightPanelAnchor();
 
   const bodyRef = useRef<HTMLDivElement>(null);
+  // Follow the newest entry only while the user stays at the bottom; any
+  // scroll away pauses following, scrolling back to the bottom resumes it.
+  const stickToBottomRef = useRef(true);
 
   useEffect(() => {
-    if (!collapsed && bodyRef.current) {
+    stickToBottomRef.current = true;
+  }, [executionId]);
+
+  useEffect(() => {
+    if (!collapsed && stickToBottomRef.current && bodyRef.current) {
       bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
     }
   }, [events.length, collapsed]);
@@ -84,17 +94,26 @@ export function ExecutionLogPanel() {
     bodyRef.current?.querySelector(`[data-node-id="${selectedNodeId}"]`)?.scrollIntoView({ block: 'nearest' });
   }, [selectedNodeId, collapsed]);
 
+  function handleBodyScroll() {
+    const body = bodyRef.current;
+    if (!body) return;
+    stickToBottomRef.current = body.scrollHeight - body.scrollTop - body.clientHeight < 4;
+  }
+
   if (events.length === 0 && status === 'idle') return null;
 
   return (
-    <div className={`${styles['panel']} ${collapsed ? styles['panel--collapsed'] : ''}`}>
+    <div
+      className={`${styles['panel']} ${collapsed ? styles['panel--collapsed'] : ''}`}
+      style={{ '--log-panel-right': `${rightOffset}px` } as React.CSSProperties}
+    >
       <div className={styles['header']} onClick={toggleLog}>
         <span className={styles['title']}>Execution Log</span>
         <span className={`${styles['status']} ${styles[`status--${status}`]}`}>{status}</span>
         <span className={styles['toggle']}>{collapsed ? '▲' : '▼'}</span>
       </div>
       {!collapsed && (
-        <div ref={bodyRef} className={styles['body']}>
+        <div ref={bodyRef} className={styles['body']} onScroll={handleBodyScroll}>
           {events.map((event) => (
             <EventRow key={`${event.executionId}-${event.sequence}`} event={event} selectedNodeId={selectedNodeId} />
           ))}

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -50,10 +50,11 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   const truncated =
     detail && detail.length > DETAIL_PREVIEW_CHARS ? detail.slice(0, DETAIL_PREVIEW_CHARS) + '…' : detail;
 
-  function handleToggle() {
+  function handleToggle({ target }: React.MouseEvent) {
+    const clickedInteractiveElement = target instanceof Element && !!target.closest('a, button');
     const isSelectingText = !!globalThis.getSelection()?.toString();
 
-    if (hasDetail && !isSelectingText) {
+    if (hasDetail && !clickedInteractiveElement && !isSelectingText) {
       setExpanded((isExpanded) => !isExpanded);
     }
   }
@@ -61,12 +62,13 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   return (
     <div
       data-node-id={isNode ? nodeId : undefined}
-      className={clsx(styles['event'], { [styles['event--highlighted']]: highlighted })}
+      className={clsx(styles['event'], {
+        [styles['event--toggleable']]: hasDetail,
+        [styles['event--highlighted']]: highlighted,
+      })}
+      onClick={handleToggle}
     >
-      <div
-        className={clsx(styles['event-header'], { [styles['event-header--toggleable']]: hasDetail })}
-        onClick={handleToggle}
-      >
+      <div className={styles['event-header']}>
         <span className={clsx(styles['badge'], styles[`badge--${event.type}`])}>{label}</span>
         {isNode && <span className={styles['node-id']}>{nodeId.slice(0, NODE_ID_PREVIEW_CHARS)}</span>}
         <span className={styles['time']}>{formatTime(event.timestamp)}</span>

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -1,4 +1,5 @@
 import { useSingleSelectedElement } from '@workflowbuilder/sdk';
+import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
 
 import type { ExecutionEvent } from '@workflow-builder/types/workflow-execution/execution-events';
@@ -9,8 +10,12 @@ import { useRightPanelAnchor } from '../../hooks/use-right-panel-anchor';
 import { toggleLog, useExecutionStore } from '../../stores/use-execution-store';
 import { extractOutputText } from '../../utils/extract-output-text';
 
-function formatTime(iso: string) {
-  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+const DETAIL_PREVIEW_CHARS = 120;
+const NODE_ID_PREVIEW_CHARS = 8;
+const AT_BOTTOM_TOLERANCE_PX = 4;
+
+function formatTime(isoTimestamp: string) {
+  return new Date(isoTimestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
 function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNodeId: string | null }) {
@@ -42,7 +47,8 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   }
 
   const hasDetail = !!detail;
-  const truncated = detail && detail.length > 120 ? detail.slice(0, 120) + '…' : detail;
+  const truncated =
+    detail && detail.length > DETAIL_PREVIEW_CHARS ? detail.slice(0, DETAIL_PREVIEW_CHARS) + '…' : detail;
 
   function handleToggle({ target }: React.MouseEvent) {
     const clickedInteractiveElement = target instanceof Element && !!target.closest('a, button');
@@ -56,17 +62,20 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
   return (
     <div
       data-node-id={isNode ? nodeId : undefined}
-      className={`${styles['event']} ${hasDetail ? styles['event--toggleable'] : ''} ${styles[`event--${event.type.split('_')[0]}`] ?? ''} ${highlighted ? styles['event--highlighted'] : ''}`}
+      className={clsx(styles['event'], {
+        [styles['event--toggleable']]: hasDetail,
+        [styles['event--highlighted']]: highlighted,
+      })}
       onClick={handleToggle}
     >
       <div className={styles['event-header']}>
-        <span className={`${styles['badge']} ${styles[`badge--${event.type}`]}`}>{label}</span>
-        {isNode && <span className={styles['node-id']}>{(event as { nodeId: string }).nodeId.slice(0, 8)}</span>}
+        <span className={clsx(styles['badge'], styles[`badge--${event.type}`])}>{label}</span>
+        {isNode && <span className={styles['node-id']}>{nodeId.slice(0, NODE_ID_PREVIEW_CHARS)}</span>}
         <span className={styles['time']}>{formatTime(event.timestamp)}</span>
         {hasDetail && <span className={styles['toggle']}>{expanded ? '▲' : '▼'}</span>}
       </div>
       {hasDetail && (
-        <div className={`${styles['detail']} ${expanded ? styles['detail--expanded'] : ''}`}>
+        <div className={clsx(styles['detail'], { [styles['detail--expanded']]: expanded })}>
           {expanded ? detail : truncated}
         </div>
       )}
@@ -75,10 +84,10 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
 }
 
 export function ExecutionLogPanel() {
-  const events = useExecutionStore((s) => s.events);
-  const status = useExecutionStore((s) => s.status);
-  const executionId = useExecutionStore((s) => s.executionId);
-  const collapsed = useExecutionStore((s) => s.logCollapsed);
+  const events = useExecutionStore((state) => state.events);
+  const status = useExecutionStore((state) => state.status);
+  const executionId = useExecutionStore((state) => state.executionId);
+  const collapsed = useExecutionStore((state) => state.logCollapsed);
   // Clicking a node (incl. its flag marker) selects it on the canvas; the
   // highlight derives from that selection, so it clears on deselect.
   const selectedNodeId = useSingleSelectedElement()?.node?.id ?? null;
@@ -105,19 +114,21 @@ export function ExecutionLogPanel() {
   function handleBodyScroll() {
     const body = bodyRef.current;
     if (!body) return;
-    stickToBottomRef.current = body.scrollHeight - body.scrollTop - body.clientHeight < 4;
+
+    const distanceFromBottom = body.scrollHeight - body.scrollTop - body.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < AT_BOTTOM_TOLERANCE_PX;
   }
 
   if (events.length === 0 && status === 'idle') return null;
 
   return (
     <div
-      className={`${styles['panel']} ${collapsed ? styles['panel--collapsed'] : ''}`}
+      className={clsx(styles['panel'], { [styles['panel--collapsed']]: collapsed })}
       style={{ '--log-panel-right': `${rightOffset}px` } as React.CSSProperties}
     >
       <div className={styles['header']} onClick={toggleLog}>
         <span className={styles['title']}>Execution Log</span>
-        <span className={`${styles['status']} ${styles[`status--${status}`]}`}>{status}</span>
+        <span className={clsx(styles['status'], styles[`status--${status}`])}>{status}</span>
         <span className={styles['toggle']}>{collapsed ? '▲' : '▼'}</span>
       </div>
       {!collapsed && (

--- a/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
+++ b/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const GAP_PX = 16;
+const EXPANDED_HEIGHT_RATIO = 0.9;
 
 type RightPanelAnchor = {
   panelExpanded: boolean;
@@ -9,42 +10,54 @@ type RightPanelAnchor = {
 
 const collapsedAnchor: RightPanelAnchor = { panelExpanded: false, rightOffset: GAP_PX };
 
+function findRightPanel() {
+  const panel = document.querySelector('#viewport-bounds')?.nextElementSibling;
+
+  return panel instanceof HTMLElement ? panel : undefined;
+}
+
+function measureAnchor(panel: HTMLElement): RightPanelAnchor {
+  const sidebar = panel.firstElementChild?.firstElementChild;
+  if (!(sidebar instanceof HTMLElement)) return collapsedAnchor;
+
+  const panelExpanded = sidebar.offsetHeight >= panel.offsetHeight * EXPANDED_HEIGHT_RATIO;
+  if (!panelExpanded) return collapsedAnchor;
+
+  return {
+    panelExpanded: true,
+    rightOffset: Math.round(window.innerWidth - sidebar.getBoundingClientRect().left) + GAP_PX,
+  };
+}
+
+function sameAnchor(current: RightPanelAnchor, next: RightPanelAnchor) {
+  return current.panelExpanded === next.panelExpanded && current.rightOffset === next.rightOffset;
+}
+
+function observeAnchor(panel: HTMLElement, onMeasure: (next: RightPanelAnchor) => void) {
+  const updateAnchor = () => onMeasure(measureAnchor(panel));
+
+  updateAnchor();
+
+  const observer = new ResizeObserver(updateAnchor);
+  observer.observe(panel);
+  window.addEventListener('resize', updateAnchor);
+
+  return () => {
+    observer.disconnect();
+    window.removeEventListener('resize', updateAnchor);
+  };
+}
+
 // The SDK does not expose the properties panel's expanded state, so this
 // measures the DOM: the panel is the element after #viewport-bounds.
 export function useRightPanelAnchor(): RightPanelAnchor {
   const [anchor, setAnchor] = useState(collapsedAnchor);
 
   useEffect(() => {
-    const anchorElement = document.querySelector('#viewport-bounds')?.nextElementSibling;
-    if (!(anchorElement instanceof HTMLElement)) return;
-    const panel: HTMLElement = anchorElement;
+    const panel = findRightPanel();
+    if (!panel) return;
 
-    function measure() {
-      const sidebar = panel.firstElementChild?.firstElementChild;
-      const panelExpanded = sidebar instanceof HTMLElement && sidebar.offsetHeight >= panel.offsetHeight * 0.9;
-
-      const next = panelExpanded
-        ? {
-            panelExpanded,
-            rightOffset: Math.round(window.innerWidth - sidebar.getBoundingClientRect().left) + GAP_PX,
-          }
-        : collapsedAnchor;
-
-      setAnchor((current) =>
-        current.panelExpanded === next.panelExpanded && current.rightOffset === next.rightOffset ? current : next,
-      );
-    }
-
-    measure();
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(panel);
-    window.addEventListener('resize', measure);
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('resize', measure);
-    };
+    return observeAnchor(panel, (next) => setAnchor((current) => (sameAnchor(current, next) ? current : next)));
   }, []);
 
   return anchor;

--- a/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
+++ b/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+
+const GAP_PX = 16;
+
+type RightPanelAnchor = {
+  /** Whether the SDK properties panel is expanded to full content height. */
+  panelExpanded: boolean;
+  /**
+   * Distance (px) from the right viewport edge at which a floating element
+   * should sit so it hugs the properties panel: left of the panel when it
+   * is expanded, at the viewport edge when it is collapsed or absent.
+   */
+  rightOffset: number;
+};
+
+const collapsedAnchor: RightPanelAnchor = { panelExpanded: false, rightOffset: GAP_PX };
+
+/**
+ * The SDK does not expose the properties panel's expanded state, so this
+ * measures the DOM: the right panel is the element after `#viewport-bounds`
+ * in the default layout, and it is expanded when it fills the content height.
+ */
+export function useRightPanelAnchor(): RightPanelAnchor {
+  const [anchor, setAnchor] = useState(collapsedAnchor);
+
+  useEffect(() => {
+    const anchorElement = document.querySelector('#viewport-bounds')?.nextElementSibling;
+    if (!(anchorElement instanceof HTMLElement)) return;
+    const panel: HTMLElement = anchorElement;
+
+    function measure() {
+      const sidebar = panel.firstElementChild?.firstElementChild;
+      const panelExpanded = sidebar instanceof HTMLElement && sidebar.offsetHeight >= panel.offsetHeight * 0.9;
+
+      const next = panelExpanded
+        ? {
+            panelExpanded,
+            rightOffset: Math.round(window.innerWidth - sidebar.getBoundingClientRect().left) + GAP_PX,
+          }
+        : collapsedAnchor;
+
+      setAnchor((current) =>
+        current.panelExpanded === next.panelExpanded && current.rightOffset === next.rightOffset ? current : next,
+      );
+    }
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(panel);
+    window.addEventListener('resize', measure);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
+  return anchor;
+}

--- a/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
+++ b/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
@@ -4,11 +4,11 @@ const GAP_PX = 16;
 const EXPANDED_HEIGHT_RATIO = 0.9;
 
 type RightPanelAnchor = {
-  panelExpanded: boolean;
+  isPanelExpanded: boolean;
   rightOffset: number;
 };
 
-const collapsedAnchor: RightPanelAnchor = { panelExpanded: false, rightOffset: GAP_PX };
+const collapsedAnchor: RightPanelAnchor = { isPanelExpanded: false, rightOffset: GAP_PX };
 
 function findRightPanel() {
   const panel = document.querySelector('#viewport-bounds')?.nextElementSibling;
@@ -20,17 +20,17 @@ function measureAnchor(panel: HTMLElement): RightPanelAnchor {
   const sidebar = panel.firstElementChild?.firstElementChild;
   if (!(sidebar instanceof HTMLElement)) return collapsedAnchor;
 
-  const panelExpanded = sidebar.offsetHeight >= panel.offsetHeight * EXPANDED_HEIGHT_RATIO;
-  if (!panelExpanded) return collapsedAnchor;
+  const isPanelExpanded = sidebar.offsetHeight >= panel.offsetHeight * EXPANDED_HEIGHT_RATIO;
+  if (!isPanelExpanded) return collapsedAnchor;
 
   return {
-    panelExpanded: true,
+    isPanelExpanded: true,
     rightOffset: Math.round(window.innerWidth - sidebar.getBoundingClientRect().left) + GAP_PX,
   };
 }
 
 function sameAnchor(current: RightPanelAnchor, next: RightPanelAnchor) {
-  return current.panelExpanded === next.panelExpanded && current.rightOffset === next.rightOffset;
+  return current.isPanelExpanded === next.isPanelExpanded && current.rightOffset === next.rightOffset;
 }
 
 function observeAnchor(panel: HTMLElement, onMeasure: (next: RightPanelAnchor) => void) {

--- a/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
+++ b/apps/ai-studio/src/hooks/use-right-panel-anchor.ts
@@ -3,23 +3,14 @@ import { useEffect, useState } from 'react';
 const GAP_PX = 16;
 
 type RightPanelAnchor = {
-  /** Whether the SDK properties panel is expanded to full content height. */
   panelExpanded: boolean;
-  /**
-   * Distance (px) from the right viewport edge at which a floating element
-   * should sit so it hugs the properties panel: left of the panel when it
-   * is expanded, at the viewport edge when it is collapsed or absent.
-   */
   rightOffset: number;
 };
 
 const collapsedAnchor: RightPanelAnchor = { panelExpanded: false, rightOffset: GAP_PX };
 
-/**
- * The SDK does not expose the properties panel's expanded state, so this
- * measures the DOM: the right panel is the element after `#viewport-bounds`
- * in the default layout, and it is expanded when it fills the content height.
- */
+// The SDK does not expose the properties panel's expanded state, so this
+// measures the DOM: the panel is the element after #viewport-bounds.
 export function useRightPanelAnchor(): RightPanelAnchor {
   const [anchor, setAnchor] = useState(collapsedAnchor);
 

--- a/apps/ai-studio/src/stores/use-execution-store.ts
+++ b/apps/ai-studio/src/stores/use-execution-store.ts
@@ -38,7 +38,7 @@ function storeLogCollapsed(logCollapsed: boolean) {
   try {
     sessionStorage.setItem(LOG_COLLAPSED_STORAGE_KEY, String(logCollapsed));
   } catch {
-    // Storage unavailable (e.g. blocked); collapse state just won't persist.
+    // storage unavailable
   }
 }
 
@@ -60,8 +60,7 @@ export function resetExecution() {
 }
 
 export function setExecutionStarted(executionId: string, streamUrl: string) {
-  // Opening the log on every run is an event-driven override, deliberately
-  // not written to sessionStorage - the stored value tracks user toggles only.
+  // logCollapsed deliberately not persisted here - storage tracks user toggles only
   useExecutionStore.setState({
     executionId,
     status: 'pending',

--- a/apps/ai-studio/src/stores/use-execution-store.ts
+++ b/apps/ai-studio/src/stores/use-execution-store.ts
@@ -24,13 +24,31 @@ type ExecutionStore = {
   logCollapsed: boolean;
 };
 
+const LOG_COLLAPSED_STORAGE_KEY = 'ai-studio:log-collapsed';
+
+function readStoredLogCollapsed() {
+  try {
+    return sessionStorage.getItem(LOG_COLLAPSED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function storeLogCollapsed(logCollapsed: boolean) {
+  try {
+    sessionStorage.setItem(LOG_COLLAPSED_STORAGE_KEY, String(logCollapsed));
+  } catch {
+    // Storage unavailable (e.g. blocked); collapse state just won't persist.
+  }
+}
+
 const emptyStore: ExecutionStore = {
   executionId: undefined,
   status: 'idle',
   streamUrl: undefined,
   nodeStates: {},
   events: [],
-  logCollapsed: false,
+  logCollapsed: readStoredLogCollapsed(),
 };
 
 export const useExecutionStore = create<ExecutionStore>()(
@@ -38,16 +56,19 @@ export const useExecutionStore = create<ExecutionStore>()(
 );
 
 export function resetExecution() {
-  useExecutionStore.setState(emptyStore);
+  useExecutionStore.setState({ ...emptyStore, logCollapsed: readStoredLogCollapsed() });
 }
 
 export function setExecutionStarted(executionId: string, streamUrl: string) {
+  // Opening the log on every run is an event-driven override, deliberately
+  // not written to sessionStorage - the stored value tracks user toggles only.
   useExecutionStore.setState({
     executionId,
     status: 'pending',
     streamUrl,
     nodeStates: {},
     events: [],
+    logCollapsed: false,
   });
 }
 
@@ -103,11 +124,17 @@ function applyEventToNodeStates(event: ExecutionEvent, states: Record<string, No
 }
 
 export function setLogCollapsed(logCollapsed: boolean) {
+  storeLogCollapsed(logCollapsed);
   useExecutionStore.setState({ logCollapsed });
 }
 
 export function toggleLog() {
-  useExecutionStore.setState((state) => ({ logCollapsed: !state.logCollapsed }));
+  useExecutionStore.setState((state) => {
+    const logCollapsed = !state.logCollapsed;
+    storeLogCollapsed(logCollapsed);
+
+    return { logCollapsed };
+  });
 }
 
 function eventToExecutionStatus(event: ExecutionEvent): ExecutionStatus | undefined {

--- a/apps/ai-studio/src/stores/use-execution-store.ts
+++ b/apps/ai-studio/src/stores/use-execution-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 
 import type {
   ExecutionEvent,
@@ -21,26 +21,8 @@ type ExecutionStore = {
   streamUrl: string | undefined;
   nodeStates: Record<string, NodeExecutionState>;
   events: ExecutionEvent[];
-  logCollapsed: boolean;
+  isLogCollapsed: boolean;
 };
-
-const LOG_COLLAPSED_STORAGE_KEY = 'ai-studio:log-collapsed';
-
-function readStoredLogCollapsed() {
-  try {
-    return sessionStorage.getItem(LOG_COLLAPSED_STORAGE_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-
-function persistLogCollapsed(logCollapsed: boolean) {
-  try {
-    sessionStorage.setItem(LOG_COLLAPSED_STORAGE_KEY, String(logCollapsed));
-  } catch {
-    // storage unavailable
-  }
-}
 
 const emptyStore: ExecutionStore = {
   executionId: undefined,
@@ -48,26 +30,32 @@ const emptyStore: ExecutionStore = {
   streamUrl: undefined,
   nodeStates: {},
   events: [],
-  logCollapsed: readStoredLogCollapsed(),
+  isLogCollapsed: false,
 };
 
 export const useExecutionStore = create<ExecutionStore>()(
-  devtools(() => ({ ...emptyStore }), { name: 'aiStudioExecutionStore' }),
+  devtools(
+    persist(() => ({ ...emptyStore }), {
+      name: 'ai-studio:execution-log',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({ isLogCollapsed: state.isLogCollapsed }),
+    }),
+    { name: 'aiStudioExecutionStore' },
+  ),
 );
 
 export function resetExecution() {
-  useExecutionStore.setState({ ...emptyStore, logCollapsed: readStoredLogCollapsed() });
+  useExecutionStore.setState((state) => ({ ...emptyStore, isLogCollapsed: state.isLogCollapsed }));
 }
 
 export function setExecutionStarted(executionId: string, streamUrl: string) {
-  // logCollapsed deliberately not persisted here - storage tracks user toggles only
   useExecutionStore.setState({
     executionId,
     status: 'pending',
     streamUrl,
     nodeStates: {},
     events: [],
-    logCollapsed: false,
+    isLogCollapsed: false,
   });
 }
 
@@ -122,13 +110,12 @@ function applyEventToNodeStates(event: ExecutionEvent, states: Record<string, No
   }
 }
 
-export function setLogCollapsed(logCollapsed: boolean) {
-  persistLogCollapsed(logCollapsed);
-  useExecutionStore.setState({ logCollapsed });
+export function setLogCollapsed(isLogCollapsed: boolean) {
+  useExecutionStore.setState({ isLogCollapsed });
 }
 
 export function toggleLog() {
-  setLogCollapsed(!useExecutionStore.getState().logCollapsed);
+  setLogCollapsed(!useExecutionStore.getState().isLogCollapsed);
 }
 
 function eventToExecutionStatus(event: ExecutionEvent): ExecutionStatus | undefined {

--- a/apps/ai-studio/src/stores/use-execution-store.ts
+++ b/apps/ai-studio/src/stores/use-execution-store.ts
@@ -34,7 +34,7 @@ function readStoredLogCollapsed() {
   }
 }
 
-function storeLogCollapsed(logCollapsed: boolean) {
+function persistLogCollapsed(logCollapsed: boolean) {
   try {
     sessionStorage.setItem(LOG_COLLAPSED_STORAGE_KEY, String(logCollapsed));
   } catch {
@@ -123,17 +123,12 @@ function applyEventToNodeStates(event: ExecutionEvent, states: Record<string, No
 }
 
 export function setLogCollapsed(logCollapsed: boolean) {
-  storeLogCollapsed(logCollapsed);
+  persistLogCollapsed(logCollapsed);
   useExecutionStore.setState({ logCollapsed });
 }
 
 export function toggleLog() {
-  useExecutionStore.setState((state) => {
-    const logCollapsed = !state.logCollapsed;
-    storeLogCollapsed(logCollapsed);
-
-    return { logCollapsed };
-  });
+  setLogCollapsed(!useExecutionStore.getState().logCollapsed);
 }
 
 function eventToExecutionStatus(event: ExecutionEvent): ExecutionStatus | undefined {


### PR DESCRIPTION
## What

**Execution Log placement**
- The log is no longer a centered overlay covering the canvas. It floats bottom-right, hugging the left edge of the properties panel when the panel is expanded, and the viewport edge when it is not. Position reacts to the panel via a ResizeObserver-based hook (`useRightPanelAnchor`).
- Height grows with entries from a single header up to a 430px cap (no fixed initial height).
- Auto-scroll follows the newest entry; scrolling away pauses it, returning to the bottom resumes it.
- Collapse state persists per browser session; starting a new execution reopens a collapsed log.

**Log entry interaction**
- The whole entry (header + detail box) is now one collapse/expand toggle. Previously the detail box showed a pointer cursor but ignored clicks.
- Selecting text inside an entry does not trigger the toggle, so log output stays copyable.
- Clicks on links/buttons inside the detail do not propagate to the toggle.

**Welcome reopen button**
- The floating info button shared the bottom-right corner with the new log position and already overlapped the expanded properties panel footer. It now hides while the log is visible or the panel is expanded.

## Verification

Exercised in the browser against a simulated execution stream: anchor behavior in both panel states, growth to the 430px cap, auto-scroll pause/resume, session persistence of the collapse state, auto-open on execution start, whole-entry toggling, and the text-selection guard. `pnpm lint`, `pnpm typecheck` (ai-studio), `pnpm format`, and `pnpm test` are green. The `apps/docs` typecheck failure (`astro check` / Starlight sidebar types) is pre-existing and unrelated.