### PR TITLE
fix(ai-studio): re-adapt visualization when the render format changes

### DIFF
--- a/apps/ai-studio/src/components/visualize/visualize-card.tsx
+++ b/apps/ai-studio/src/components/visualize/visualize-card.tsx
@@ -1,12 +1,12 @@
 import { ArrowsOut, DownloadSimple, Eye } from '@phosphor-icons/react';
 import { getStoreEdges, getStoreNodes } from '@workflowbuilder/sdk';
-import { Suspense, useEffect, useRef, useState } from 'react';
+import { Suspense, useRef, useState } from 'react';
 
 import styles from './visualize-card.module.css';
 
+import { useAdaptedVisualization } from '../../hooks/use-adapted-visualization';
 import { VISUALIZE_MODES } from '../../nodes/visualize/schema';
 import { useExecutionStore } from '../../stores/use-execution-store';
-import { adaptVisualization } from '../../utils/adapt-visualization';
 import { type VisualizeRenderer, detectFormat } from '../../utils/detect-format';
 import { downloadPng } from '../../utils/export-visualization';
 import { extractOutputText } from '../../utils/extract-output-text';
@@ -22,7 +22,6 @@ type Props = {
 
 type VisualizeMode = VisualizeRenderer | 'auto';
 const VALID_MODES = new Set<string>(VISUALIZE_MODES);
-const ADAPTABLE = new Set<VisualizeRenderer>(['diagram', 'chart', 'table', 'json', 'stat-cards']);
 
 function EmptyState({ running }: { running: boolean }) {
   if (running) {
@@ -47,9 +46,7 @@ function EmptyState({ running }: { running: boolean }) {
 
 export function VisualizeCard({ props }: Props) {
   const nodeId = props?.nodeId ?? '';
-  const [expanded, setExpanded] = useState(false);
-  const [adaptedText, setAdaptedText] = useState<string | null>(null);
-  const [adapting, setAdapting] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   // Nodes/edges are static during a run, so snapshot reads are fine.
@@ -69,28 +66,7 @@ export function VisualizeCard({ props }: Props) {
   const detection = detectFormat(text);
   const activeRenderer: VisualizeRenderer = mode === 'auto' ? detection.renderer : mode;
 
-  useEffect(() => {
-    setAdaptedText(null);
-  }, [text]);
-
-  useEffect(() => {
-    if (!hasOutput || !ADAPTABLE.has(activeRenderer) || adaptedText !== null) return;
-    let cancelled = false;
-    setAdapting(true);
-    adaptVisualization(text, activeRenderer)
-      .then((output) => {
-        if (!cancelled) setAdaptedText(output);
-      })
-      .catch(() => {
-        // keep original content
-      })
-      .finally(() => {
-        if (!cancelled) setAdapting(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [hasOutput, activeRenderer, text, adaptedText]);
+  const { adaptedText, isAdapting } = useAdaptedVisualization(text, activeRenderer, hasOutput);
 
   if (!isVisualizeNode) {
     return null;
@@ -109,20 +85,20 @@ export function VisualizeCard({ props }: Props) {
           <div className={styles['toolbar']}>
             <span className={styles['badge']}>{badge}</span>
             <div className={styles['actions']}>
-              <button type="button" className={styles['action']} title="Expand" onClick={() => setExpanded(true)}>
+              <button type="button" className={styles['action']} title="Expand" onClick={() => setIsExpanded(true)}>
                 <ArrowsOut />
               </button>
               <CopyResultButton
                 className={styles['action']}
                 getTarget={() => contentRef.current}
                 text={renderText}
-                disabled={adapting}
+                disabled={isAdapting}
               />
               <button
                 type="button"
                 className={styles['action']}
                 title="Download PNG"
-                disabled={adapting}
+                disabled={isAdapting}
                 onClick={() => contentRef.current && void downloadPng(contentRef.current)}
               >
                 <DownloadSimple />
@@ -130,7 +106,7 @@ export function VisualizeCard({ props }: Props) {
             </div>
           </div>
           <div className={styles['body']}>
-            {adapting ? (
+            {isAdapting ? (
               <div className={styles['empty']}>
                 <div className={styles['dots']}>
                   <span className={styles['dot']} />
@@ -151,14 +127,14 @@ export function VisualizeCard({ props }: Props) {
       ) : (
         <EmptyState running={selfStatus === 'running'} />
       )}
-      {expanded && (
+      {isExpanded && (
         <VisualizeModal
           renderer={activeRenderer}
           text={renderText}
           data={data}
           badge={badge}
           isVector={isVector}
-          onClose={() => setExpanded(false)}
+          onClose={() => setIsExpanded(false)}
         />
       )}
     </div>

--- a/apps/ai-studio/src/components/visualize/visualize-card.tsx
+++ b/apps/ai-studio/src/components/visualize/visualize-card.tsx
@@ -66,14 +66,13 @@ export function VisualizeCard({ props }: Props) {
   const detection = detectFormat(text);
   const activeRenderer: VisualizeRenderer = mode === 'auto' ? detection.renderer : mode;
 
-  const { adaptedText, isAdapting } = useAdaptedVisualization(text, activeRenderer, hasOutput);
+  const { renderText, isAdapted, isAdapting } = useAdaptedVisualization(text, activeRenderer, hasOutput);
 
   if (!isVisualizeNode) {
     return null;
   }
 
-  const renderText = adaptedText ?? text;
-  const data = adaptedText === null && mode === 'auto' ? detection.data : undefined;
+  const data = !isAdapted && mode === 'auto' ? detection.data : undefined;
   const Renderer = hasOutput ? getRenderer(activeRenderer) : null;
   const badge = mode === 'auto' ? `Auto › ${RENDERER_LABELS[activeRenderer]}` : RENDERER_LABELS[activeRenderer];
   const isVector = activeRenderer === 'chart' || activeRenderer === 'diagram';

--- a/apps/ai-studio/src/hooks/use-adapted-visualization.ts
+++ b/apps/ai-studio/src/hooks/use-adapted-visualization.ts
@@ -44,7 +44,6 @@ export function useAdaptedVisualization(text: string, renderer: VisualizeRendere
   const adaptedOutput = cached?.output ?? null;
 
   return {
-    /** Adapted content when available, the raw text otherwise. */
     renderText: adaptedOutput ?? text,
     isAdapted: adaptedOutput !== null,
     isAdapting,

--- a/apps/ai-studio/src/hooks/use-adapted-visualization.ts
+++ b/apps/ai-studio/src/hooks/use-adapted-visualization.ts
@@ -41,5 +41,12 @@ export function useAdaptedVisualization(text: string, renderer: VisualizeRendere
     return () => controller.abort();
   }, [shouldAdapt, adaptationKey, text, renderer]);
 
-  return { adaptedText: cached?.output ?? null, isAdapting };
+  const adaptedOutput = cached?.output ?? null;
+
+  return {
+    /** Adapted content when available, the raw text otherwise. */
+    renderText: adaptedOutput ?? text,
+    isAdapted: adaptedOutput !== null,
+    isAdapting,
+  };
 }

--- a/apps/ai-studio/src/hooks/use-adapted-visualization.ts
+++ b/apps/ai-studio/src/hooks/use-adapted-visualization.ts
@@ -5,7 +5,8 @@ import type { VisualizeRenderer } from '../utils/detect-format';
 
 const ADAPTABLE = new Set<VisualizeRenderer>(['diagram', 'chart', 'table', 'json', 'stat-cards']);
 
-type Adaptation = { key: string; output: string };
+// output null = the adapt call failed and the raw text is rendered instead.
+type Adaptation = { key: string; output: string | null };
 
 // The adapted content is an async derived value keyed by (renderer, text).
 // A stale adaptation is ignored by the key check, never reset by an effect,
@@ -15,29 +16,30 @@ export function useAdaptedVisualization(text: string, renderer: VisualizeRendere
   const [isAdapting, setIsAdapting] = useState(false);
 
   const adaptationKey = `${renderer}\n${text}`;
-  const adaptedText = adaptation?.key === adaptationKey ? adaptation.output : null;
-  const shouldAdapt = hasOutput && ADAPTABLE.has(renderer) && adaptedText === null;
+  const cached = adaptation?.key === adaptationKey ? adaptation : null;
+  const shouldAdapt = hasOutput && ADAPTABLE.has(renderer) && cached === null;
 
   useEffect(() => {
     if (!shouldAdapt) return;
 
-    let cancelled = false;
-    setIsAdapting(true);
-    adaptVisualization(text, renderer)
-      .then((output) => {
-        if (!cancelled) setAdaptation({ key: adaptationKey, output });
-      })
-      .catch(() => {
-        // keep original content
-      })
-      .finally(() => {
-        if (!cancelled) setIsAdapting(false);
-      });
+    const controller = new AbortController();
 
-    return () => {
-      cancelled = true;
-    };
+    async function adapt() {
+      setIsAdapting(true);
+      try {
+        const output = await adaptVisualization(text, renderer, controller.signal);
+        setAdaptation({ key: adaptationKey, output });
+      } catch {
+        if (!controller.signal.aborted) setAdaptation({ key: adaptationKey, output: null });
+      } finally {
+        if (!controller.signal.aborted) setIsAdapting(false);
+      }
+    }
+
+    void adapt();
+
+    return () => controller.abort();
   }, [shouldAdapt, adaptationKey, text, renderer]);
 
-  return { adaptedText, isAdapting };
+  return { adaptedText: cached?.output ?? null, isAdapting };
 }

--- a/apps/ai-studio/src/hooks/use-adapted-visualization.ts
+++ b/apps/ai-studio/src/hooks/use-adapted-visualization.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import { adaptVisualization } from '../utils/adapt-visualization';
+import type { VisualizeRenderer } from '../utils/detect-format';
+
+const ADAPTABLE = new Set<VisualizeRenderer>(['diagram', 'chart', 'table', 'json', 'stat-cards']);
+
+type Adaptation = { key: string; output: string };
+
+// The adapted content is an async derived value keyed by (renderer, text).
+// A stale adaptation is ignored by the key check, never reset by an effect,
+// so switching the render format re-adapts for the new one.
+export function useAdaptedVisualization(text: string, renderer: VisualizeRenderer, hasOutput: boolean) {
+  const [adaptation, setAdaptation] = useState<Adaptation | null>(null);
+  const [isAdapting, setIsAdapting] = useState(false);
+
+  const adaptationKey = `${renderer}\n${text}`;
+  const adaptedText = adaptation?.key === adaptationKey ? adaptation.output : null;
+  const shouldAdapt = hasOutput && ADAPTABLE.has(renderer) && adaptedText === null;
+
+  useEffect(() => {
+    if (!shouldAdapt) return;
+
+    let cancelled = false;
+    setIsAdapting(true);
+    adaptVisualization(text, renderer)
+      .then((output) => {
+        if (!cancelled) setAdaptation({ key: adaptationKey, output });
+      })
+      .catch(() => {
+        // keep original content
+      })
+      .finally(() => {
+        if (!cancelled) setIsAdapting(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldAdapt, adaptationKey, text, renderer]);
+
+  return { adaptedText, isAdapting };
+}

--- a/apps/ai-studio/src/utils/adapt-visualization.ts
+++ b/apps/ai-studio/src/utils/adapt-visualization.ts
@@ -1,7 +1,7 @@
 import { BACKEND_URL } from '../config';
 import { getTurnstileToken } from '../security/turnstile';
 
-export async function adaptVisualization(content: string, format: string): Promise<string> {
+export async function adaptVisualization(content: string, format: string, signal?: AbortSignal): Promise<string> {
   const token = await getTurnstileToken();
   const response = await fetch(`${BACKEND_URL}/api/visualize/adapt`, {
     method: 'POST',
@@ -10,6 +10,7 @@ export async function adaptVisualization(content: string, format: string): Promi
       ...(token ? { 'cf-turnstile-token': token } : {}),
     },
     body: JSON.stringify({ content, format }),
+    signal,
   });
   if (!response.ok) {
     const error = (await response.json().catch(() => ({}))) as { message?: string };


### PR DESCRIPTION
## What

"Adapt with AI" in the Visualize node ran at most once per output. The adapted content was cached in bare component state and reset only when the source text changed, so switching **Render as** to another format fed the previous format's adaptation to the new renderer - e.g. the chart renderer received the stat-cards JSON and displayed it as raw text - and the AI was never called again. Failures were also silently swallowed, which made the whole thing look randomly broken.

The adaptation is now an async derived value keyed by `(renderer, text)`, extracted into a `useAdaptedVisualization` hook. A stale adaptation is ignored by the key check instead of being reset by an effect, so every format change triggers a fresh adapt for that format, and the two-effect choreography in `VisualizeCard` is gone.

## Verification

Exercised in the browser with an instrumented `fetch` against the local stack: first adaptation fires once and renders (chart with proper axes), switching to Stat cards fires a second `/api/visualize/adapt` request and renders real stat cards instead of raw JSON. `pnpm lint` and `pnpm typecheck` (ai-studio) are green.