### PR TITLE
fix(deploy): complete the LLM env wiring for the demo stack

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -19,4 +19,4 @@ TURNSTILE_SECRET_KEY=
 # Optional: leave empty to disable AI adapt (the endpoint returns 501). The
 # execution worker keeps its own key for running workflows.
 OPENROUTER_API_KEY=
-AI_MODEL=google/gemini-2.5-flash-lite
+AI_MODEL=mistralai/mistral-small-3.2-24b-instruct

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -20,5 +20,5 @@ export const env = {
   TURNSTILE_SECRET_KEY: process.env['TURNSTILE_SECRET_KEY'] ?? null,
   // Null = the "AI adapt" endpoint is disabled (returns 501). The worker keeps its own key.
   OPENROUTER_API_KEY: process.env['OPENROUTER_API_KEY'] ?? null,
-  AI_MODEL: envOr('AI_MODEL', 'google/gemini-2.5-flash-lite'),
+  AI_MODEL: envOr('AI_MODEL', 'mistralai/mistral-small-3.2-24b-instruct'),
 };

--- a/apps/execution-worker/.env.example
+++ b/apps/execution-worker/.env.example
@@ -3,7 +3,7 @@ TEMPORAL_ADDRESS=127.0.0.1:7233
 
 # OpenRouter — any model
 OPENROUTER_API_KEY=sk-or-...
-AI_MODEL=google/gemini-2.5-flash-lite
+AI_MODEL=mistralai/mistral-small-3.2-24b-instruct
 
 # Tavily web search (optional). Enables the AI Agent's "Web search" tool. Get a
 # free key at https://tavily.com (free tier ~1000 searches/month). Leave empty

--- a/apps/execution-worker/src/env.ts
+++ b/apps/execution-worker/src/env.ts
@@ -18,7 +18,7 @@ export const env = {
   TEMPORAL_ADDRESS: envOr('TEMPORAL_ADDRESS', '127.0.0.1:7233'),
   OPENROUTER_API_KEY: requireEnv('OPENROUTER_API_KEY'),
   // Cheap, fast default for the public demo; quality-per-cost over frontier capability.
-  AI_MODEL: envOr('AI_MODEL', 'google/gemini-2.5-flash-lite'),
+  AI_MODEL: envOr('AI_MODEL', 'mistralai/mistral-small-3.2-24b-instruct'),
   // Optional. Enables the AI Agent's web-search tool; agents run without it when unset.
   TAVILY_API_KEY: process.env['TAVILY_API_KEY'],
 };

--- a/deploy/ai-studio/.env.example
+++ b/deploy/ai-studio/.env.example
@@ -9,9 +9,14 @@ OPENROUTER_API_KEY=
 
 # --- LLM --------------------------------------------------------------------
 
-# WB-229 demo model. Cheap, EU-hosted, solid tool calling.
+# Demo model. Cheap, EU-hosted, solid tool calling.
 # ~$0.075/M input + $0.20/M output => ~$0.0004 per 3-call template run.
 AI_MODEL=mistralai/mistral-small-3.2-24b-instruct
+
+# Tavily web search (optional). Enables the AI Agent's "Web search" tool -
+# free key at https://tavily.com (~1000 searches/month). Leave empty to
+# disable: agents with web search toggled on still run, just without the tool.
+TAVILY_API_KEY=
 
 # --- abuse gate (per-IP, execute route) ---------------------------------------
 

--- a/deploy/ai-studio/docker-compose.yml
+++ b/deploy/ai-studio/docker-compose.yml
@@ -82,6 +82,9 @@ services:
       TRUST_PROXY: 'true'
       RATE_LIMIT_EXECUTE_PER_MINUTE: ${RATE_LIMIT_EXECUTE_PER_MINUTE:-10}
       RATE_LIMIT_EXECUTE_PER_DAY: ${RATE_LIMIT_EXECUTE_PER_DAY:-50}
+      # the backend calls the LLM itself for /api/visualize/adapt
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:?set OPENROUTER_API_KEY in deploy/ai-studio/.env}
+      AI_MODEL: ${AI_MODEL:-mistralai/mistral-small-3.2-24b-instruct}
     depends_on:
       app-db:
         condition: service_healthy

--- a/deploy/ai-studio/docker-compose.yml
+++ b/deploy/ai-studio/docker-compose.yml
@@ -114,6 +114,8 @@ services:
       TEMPORAL_ADDRESS: temporal:7233
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:?set OPENROUTER_API_KEY in deploy/ai-studio/.env}
       AI_MODEL: ${AI_MODEL:-mistralai/mistral-small-3.2-24b-instruct}
+      # optional - empty disables the AI Agent's web search tool
+      TAVILY_API_KEY: ${TAVILY_API_KEY:-}
     depends_on:
       app-db:
         condition: service_healthy


### PR DESCRIPTION
## What

Three gaps in how LLM configuration reaches the demo services, all silent in the UI:

**Backend never received `OPENROUTER_API_KEY`.** The adapt endpoint (`/api/visualize/adapt`) makes its LLM call in the backend process, but the compose passed the key only to the worker. Every adapt call answered `501 adapt_disabled`; the frontend swallows adapt failures and falls back to raw text, so "Adapt with AI" never worked on deployments while executions (worker-side LLM calls) kept working. The backend now gets the same `OPENROUTER_API_KEY` / `AI_MODEL` pair as the worker - no new secret needed on the host.

**`TAVILY_API_KEY` was never wired into the deploy.** The worker reads it to enable the AI Agent's web search tool; without it, agents with web search toggled on silently run without the tool. Now passed through the compose (optional, empty keeps it off) and documented in `.env.example`.

**Two different model defaults.** Backend and worker code defaulted to `google/gemini-2.5-flash-lite` while the deploy stack defaults to `mistralai/mistral-small-3.2-24b-instruct` - an unset `AI_MODEL` meant different models depending on where the process ran. Unified on the demo model everywhere (cheap, EU-hosted, solid tool calling); the deployed demo already runs it, so production behavior does not change.

## Deploy note

The deploy workflow only pulls images and recreates containers - it does not sync the compose file. After merging: update the compose on the host with this version, optionally add `TAVILY_API_KEY` to the host `.env` to enable web search, then `docker compose up -d --force-recreate backend worker`.