### PR TITLE
fix(execution-worker): Fix sequence numbering | fix(execution-core): Route node_started event through error policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,21 @@ Visual workflow editor SDK (React) with a reference backend and Temporal-based e
 
 Three onboarding paths (A installs from npm; B, C run the repo locally). README "Get started" covers all three. Path A ("Embed the SDK") installs `@workflowbuilder/sdk` from npm; the README has install + a minimal snippet, and the full guide lives in the [docs site](https://www.workflowbuilder.io/docs/get-started/quick-start/wb-as-react-component/).
 
-| Command                      | Path | What it does                                                                            |
-| ---------------------------- | ---- | --------------------------------------------------------------------------------------- |
-| `pnpm preflight`             | B/C  | Verify Node / pnpm / Docker / ports / `.env` files. Add `--json` for agents             |
-| `pnpm dev` / `pnpm dev:demo` | B    | Demo (UI only, port 4200). No backend, no Docker                                        |
-| `pnpm infra:up`              | C    | Start Postgres + Temporal in Docker. Required before backend/worker                     |
-| `pnpm -F backend db:migrate` | C    | Apply Drizzle migrations out-of-band (backend also auto-migrates on boot)               |
-| `pnpm dev:ai-studio`         | C    | Full stack: infra + backend (3001) + worker + AI Studio frontend (4201)                 |
-| `pnpm dev:backend`           | C    | Backend only (debug). Needs infra up                                                    |
-| `pnpm dev:worker`            | C    | Execution worker only (debug). Needs infra up                                           |
-| `pnpm infra:down`            | C    | Stop the Docker stack                                                                   |
-| `pnpm dev:docs`              | -    | Docs site (Astro + Starlight)                                                           |
-| `pnpm build:lib`             | -    | Build the publishable chain: `ui-tokens` -> `ui` -> SDK (`build:ui` does the first two) |
-| `pnpm build`                 | -    | Build the demo app                                                                      |
-| `pnpm test`                  | -    | Run tests in `packages/sdk` and `packages/execution-core`                               |
-| `pnpm check`                 | -    | Lint + typecheck + format + knip                                                        |
+| Command                      | Path | What it does                                                                                                      |
+| ---------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------- |
+| `pnpm preflight`             | B/C  | Verify Node / pnpm / Docker / ports / `.env` files. Add `--json` for agents                                       |
+| `pnpm dev` / `pnpm dev:demo` | B    | Demo (UI only, port 4200). No backend, no Docker                                                                  |
+| `pnpm infra:up`              | C    | Start Postgres + Temporal in Docker. Required before backend/worker                                               |
+| `pnpm -F backend db:migrate` | C    | Apply Drizzle migrations out-of-band (backend also auto-migrates on boot)                                         |
+| `pnpm dev:ai-studio`         | C    | Full stack: infra + backend (3001) + worker + AI Studio frontend (4201)                                           |
+| `pnpm dev:backend`           | C    | Backend only (debug). Needs infra up                                                                              |
+| `pnpm dev:worker`            | C    | Execution worker only (debug). Needs infra up                                                                     |
+| `pnpm infra:down`            | C    | Stop the Docker stack                                                                                             |
+| `pnpm dev:docs`              | -    | Docs site (Astro + Starlight)                                                                                     |
+| `pnpm build:lib`             | -    | Build the publishable chain: `ui-tokens` -> `ui` -> SDK (`build:ui` does the first two)                           |
+| `pnpm build`                 | -    | Build the demo app                                                                                                |
+| `pnpm test`                  | -    | Run tests in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `packages/ui`, `packages/tokens` |
+| `pnpm check`                 | -    | Lint + typecheck + format + knip                                                                                  |
 
 Path B is UI-only and does not need Docker. Path C requires `pnpm infra:up` before backend/worker can start; the backend applies pending migrations automatically at boot.
 
@@ -100,14 +100,14 @@ Backend reads `DATABASE_URL` and `TEMPORAL_ADDRESS`; defaults work out of the bo
 
 ## Code Quality
 
-| Tool       | Command                       | Notes                                                                                   |
-| ---------- | ----------------------------- | --------------------------------------------------------------------------------------- |
-| ESLint     | `pnpm lint` / `pnpm lint:fix` | Per-workspace configs                                                                   |
-| Prettier   | `pnpm format`                 | Sorts imports via `@trivago/prettier-plugin-sort-imports`                               |
-| TypeScript | `pnpm typecheck`              | Per-workspace `tsconfig.json`                                                           |
-| Knip       | Part of `pnpm check`          | Detects unused exports/dependencies                                                     |
-| Vitest     | `pnpm test`                   | Runs in `packages/sdk`, `packages/execution-core`, `packages/ui`, and `packages/tokens` |
-| Full check | `pnpm check`                  | Run before PR                                                                           |
+| Tool       | Command                       | Notes                                                                                                            |
+| ---------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| ESLint     | `pnpm lint` / `pnpm lint:fix` | Per-workspace configs                                                                                            |
+| Prettier   | `pnpm format`                 | Sorts imports via `@trivago/prettier-plugin-sort-imports`                                                        |
+| TypeScript | `pnpm typecheck`              | Per-workspace `tsconfig.json`                                                                                    |
+| Knip       | Part of `pnpm check`          | Detects unused exports/dependencies                                                                              |
+| Vitest     | `pnpm test`                   | Runs in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `packages/ui`, and `packages/tokens` |
+| Full check | `pnpm check`                  | Run before PR                                                                                                    |
 
 ## Getting Started
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,21 @@ Visual workflow editor SDK (React) with a reference backend and Temporal-based e
 
 Three onboarding paths (A installs from npm; B, C run the repo locally). README "Get started" covers all three. Path A ("Embed the SDK") installs `@workflowbuilder/sdk` from npm; the README has install + a minimal snippet, and the full guide lives in the [docs site](https://www.workflowbuilder.io/docs/get-started/quick-start/wb-as-react-component/).
 
-| Command                      | Path | What it does                                                                                                      |
-| ---------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------- |
-| `pnpm preflight`             | B/C  | Verify Node / pnpm / Docker / ports / `.env` files. Add `--json` for agents                                       |
-| `pnpm dev` / `pnpm dev:demo` | B    | Demo (UI only, port 4200). No backend, no Docker                                                                  |
-| `pnpm infra:up`              | C    | Start Postgres + Temporal in Docker. Required before backend/worker                                               |
-| `pnpm -F backend db:migrate` | C    | Apply Drizzle migrations out-of-band (backend also auto-migrates on boot)                                         |
-| `pnpm dev:ai-studio`         | C    | Full stack: infra + backend (3001) + worker + AI Studio frontend (4201)                                           |
-| `pnpm dev:backend`           | C    | Backend only (debug). Needs infra up                                                                              |
-| `pnpm dev:worker`            | C    | Execution worker only (debug). Needs infra up                                                                     |
-| `pnpm infra:down`            | C    | Stop the Docker stack                                                                                             |
-| `pnpm dev:docs`              | -    | Docs site (Astro + Starlight)                                                                                     |
-| `pnpm build:lib`             | -    | Build the publishable chain: `ui-tokens` -> `ui` -> SDK (`build:ui` does the first two)                           |
-| `pnpm build`                 | -    | Build the demo app                                                                                                |
-| `pnpm test`                  | -    | Run tests in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `packages/ui`, `packages/tokens` |
-| `pnpm check`                 | -    | Lint + typecheck + format + knip                                                                                  |
+| Command                      | Path | What it does                                                                                                                      |
+| ---------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm preflight`             | B/C  | Verify Node / pnpm / Docker / ports / `.env` files. Add `--json` for agents                                                       |
+| `pnpm dev` / `pnpm dev:demo` | B    | Demo (UI only, port 4200). No backend, no Docker                                                                                  |
+| `pnpm infra:up`              | C    | Start Postgres + Temporal in Docker. Required before backend/worker                                                               |
+| `pnpm -F backend db:migrate` | C    | Apply Drizzle migrations out-of-band (backend also auto-migrates on boot)                                                         |
+| `pnpm dev:ai-studio`         | C    | Full stack: infra + backend (3001) + worker + AI Studio frontend (4201)                                                           |
+| `pnpm dev:backend`           | C    | Backend only (debug). Needs infra up                                                                                              |
+| `pnpm dev:worker`            | C    | Execution worker only (debug). Needs infra up                                                                                     |
+| `pnpm infra:down`            | C    | Stop the Docker stack                                                                                                             |
+| `pnpm dev:docs`              | -    | Docs site (Astro + Starlight)                                                                                                     |
+| `pnpm build:lib`             | -    | Build the publishable chain: `ui-tokens` -> `ui` -> SDK (`build:ui` does the first two)                                           |
+| `pnpm build`                 | -    | Build the demo app                                                                                                                |
+| `pnpm test`                  | -    | Run tests in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `apps/backend`, `packages/ui`, `packages/tokens` |
+| `pnpm check`                 | -    | Lint + typecheck + format + knip                                                                                                  |
 
 Path B is UI-only and does not need Docker. Path C requires `pnpm infra:up` before backend/worker can start; the backend applies pending migrations automatically at boot.
 
@@ -100,14 +100,14 @@ Backend reads `DATABASE_URL` and `TEMPORAL_ADDRESS`; defaults work out of the bo
 
 ## Code Quality
 
-| Tool       | Command                       | Notes                                                                                                            |
-| ---------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| ESLint     | `pnpm lint` / `pnpm lint:fix` | Per-workspace configs                                                                                            |
-| Prettier   | `pnpm format`                 | Sorts imports via `@trivago/prettier-plugin-sort-imports`                                                        |
-| TypeScript | `pnpm typecheck`              | Per-workspace `tsconfig.json`                                                                                    |
-| Knip       | Part of `pnpm check`          | Detects unused exports/dependencies                                                                              |
-| Vitest     | `pnpm test`                   | Runs in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `packages/ui`, and `packages/tokens` |
-| Full check | `pnpm check`                  | Run before PR                                                                                                    |
+| Tool       | Command                       | Notes                                                                                                                            |
+| ---------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| ESLint     | `pnpm lint` / `pnpm lint:fix` | Per-workspace configs                                                                                                            |
+| Prettier   | `pnpm format`                 | Sorts imports via `@trivago/prettier-plugin-sort-imports`                                                                        |
+| TypeScript | `pnpm typecheck`              | Per-workspace `tsconfig.json`                                                                                                    |
+| Knip       | Part of `pnpm check`          | Detects unused exports/dependencies                                                                                              |
+| Vitest     | `pnpm test`                   | Runs in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `apps/backend`, `packages/ui`, and `packages/tokens` |
+| Full check | `pnpm check`                  | Run before PR                                                                                                                    |
 
 ## Getting Started
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,21 @@ Visual workflow editor SDK (React) with a reference backend and Temporal-based e
 
 Three onboarding paths (A installs from npm; B, C run the repo locally). README "Get started" covers all three. Path A ("Embed the SDK") installs `@workflowbuilder/sdk` from npm; the README has install + a minimal snippet, and the full guide lives in the [docs site](https://www.workflowbuilder.io/docs/get-started/quick-start/wb-as-react-component/).
 
-| Command                      | Path | What it does                                                                                                                      |
-| ---------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `pnpm preflight`             | B/C  | Verify Node / pnpm / Docker / ports / `.env` files. Add `--json` for agents                                                       |
-| `pnpm dev` / `pnpm dev:demo` | B    | Demo (UI only, port 4200). No backend, no Docker                                                                                  |
-| `pnpm infra:up`              | C    | Start Postgres + Temporal in Docker. Required before backend/worker                                                               |
-| `pnpm -F backend db:migrate` | C    | Apply Drizzle migrations out-of-band (backend also auto-migrates on boot)                                                         |
-| `pnpm dev:ai-studio`         | C    | Full stack: infra + backend (3001) + worker + AI Studio frontend (4201)                                                           |
-| `pnpm dev:backend`           | C    | Backend only (debug). Needs infra up                                                                                              |
-| `pnpm dev:worker`            | C    | Execution worker only (debug). Needs infra up                                                                                     |
-| `pnpm infra:down`            | C    | Stop the Docker stack                                                                                                             |
-| `pnpm dev:docs`              | -    | Docs site (Astro + Starlight)                                                                                                     |
-| `pnpm build:lib`             | -    | Build the publishable chain: `ui-tokens` -> `ui` -> SDK (`build:ui` does the first two)                                           |
-| `pnpm build`                 | -    | Build the demo app                                                                                                                |
-| `pnpm test`                  | -    | Run tests in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `apps/backend`, `packages/ui`, `packages/tokens` |
-| `pnpm check`                 | -    | Lint + typecheck + format + knip                                                                                                  |
+| Command                      | Path | What it does                                                                            |
+| ---------------------------- | ---- | --------------------------------------------------------------------------------------- |
+| `pnpm preflight`             | B/C  | Verify Node / pnpm / Docker / ports / `.env` files. Add `--json` for agents             |
+| `pnpm dev` / `pnpm dev:demo` | B    | Demo (UI only, port 4200). No backend, no Docker                                        |
+| `pnpm infra:up`              | C    | Start Postgres + Temporal in Docker. Required before backend/worker                     |
+| `pnpm -F backend db:migrate` | C    | Apply Drizzle migrations out-of-band (backend also auto-migrates on boot)               |
+| `pnpm dev:ai-studio`         | C    | Full stack: infra + backend (3001) + worker + AI Studio frontend (4201)                 |
+| `pnpm dev:backend`           | C    | Backend only (debug). Needs infra up                                                    |
+| `pnpm dev:worker`            | C    | Execution worker only (debug). Needs infra up                                           |
+| `pnpm infra:down`            | C    | Stop the Docker stack                                                                   |
+| `pnpm dev:docs`              | -    | Docs site (Astro + Starlight)                                                           |
+| `pnpm build:lib`             | -    | Build the publishable chain: `ui-tokens` -> `ui` -> SDK (`build:ui` does the first two) |
+| `pnpm build`                 | -    | Build the demo app                                                                      |
+| `pnpm test`                  | -    | Run tests in every workspace that defines a `test` script (`pnpm -r test`)              |
+| `pnpm check`                 | -    | Lint + typecheck + format + knip                                                        |
 
 Path B is UI-only and does not need Docker. Path C requires `pnpm infra:up` before backend/worker can start; the backend applies pending migrations automatically at boot.
 
@@ -100,14 +100,14 @@ Backend reads `DATABASE_URL` and `TEMPORAL_ADDRESS`; defaults work out of the bo
 
 ## Code Quality
 
-| Tool       | Command                       | Notes                                                                                                                            |
-| ---------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| ESLint     | `pnpm lint` / `pnpm lint:fix` | Per-workspace configs                                                                                                            |
-| Prettier   | `pnpm format`                 | Sorts imports via `@trivago/prettier-plugin-sort-imports`                                                                        |
-| TypeScript | `pnpm typecheck`              | Per-workspace `tsconfig.json`                                                                                                    |
-| Knip       | Part of `pnpm check`          | Detects unused exports/dependencies                                                                                              |
-| Vitest     | `pnpm test`                   | Runs in `packages/sdk`, `packages/execution-core`, `apps/execution-worker`, `apps/backend`, `packages/ui`, and `packages/tokens` |
-| Full check | `pnpm check`                  | Run before PR                                                                                                                    |
+| Tool       | Command                       | Notes                                                                                                   |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| ESLint     | `pnpm lint` / `pnpm lint:fix` | Per-workspace configs                                                                                   |
+| Prettier   | `pnpm format`                 | Sorts imports via `@trivago/prettier-plugin-sort-imports`                                               |
+| TypeScript | `pnpm typecheck`              | Per-workspace `tsconfig.json`                                                                           |
+| Knip       | Part of `pnpm check`          | Detects unused exports/dependencies                                                                     |
+| Vitest     | `pnpm test`                   | Runs in every workspace with a `test` script — recursive, so a new workspace is picked up automatically |
+| Full check | `pnpm check`                  | Run before PR                                                                                           |
 
 ## Getting Started
 

--- a/apps/backend/src/events/drain-events.ts
+++ b/apps/backend/src/events/drain-events.ts
@@ -15,6 +15,11 @@ export type DrainResult = {
   writeFailed: boolean;
 };
 
+// Requires rows to become visible in ascending `sequence` order: the cursor only moves
+// forward, so a row committing below it is never selected again and its event is lost.
+// The worker upholds that by serializing its event writes — see
+// `apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.ts`.
+// Gaps in the numbering are fine; only reordering is not. See drain-order.test.ts.
 export async function drainEventsSince(
   executionId: string,
   afterSequence: number,

--- a/apps/backend/src/events/drain-order.test.ts
+++ b/apps/backend/src/events/drain-order.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { drainEventsSince } from './drain-events';
+import type { ExecutionEventRow } from './fetch-events-after';
+import { createSerializedDrainer } from './serialized-drainer';
+
+// The cursor contract, from the reading side.
+//
+// The drain advances a monotonic cursor and queries `sequence > cursor`, so it can
+// only deliver events that become visible in Postgres in ascending `sequence` order.
+// These tests state that requirement as executable documentation: the middle one
+// asserts the loss, not because losing events is desirable, but so that anyone who
+// makes the writer emit concurrently again can see what it costs. The writer upholds
+// the ordering in `sequenced-event-emitter.ts`.
+//
+// Rows are made visible one at a time via `visible`, modelling per-row commit moments;
+// the fetcher sees only visible rows, exactly as the real query would.
+
+const EXECUTION = 'exec-1';
+
+function row(sequence: number, type: string, nodeId?: string): ExecutionEventRow {
+  const stamp = new Date(`2026-05-19T00:00:${String(sequence).padStart(2, '0')}Z`);
+  return {
+    id: `e-${sequence}`,
+    executionId: EXECUTION,
+    sequence,
+    timestamp: stamp,
+    type,
+    nodeId: nodeId ?? null,
+    pathId: null,
+    payloadJson: null,
+    tenantId: null,
+    createdAt: stamp,
+  };
+}
+
+function makeTable() {
+  const visible: ExecutionEventRow[] = [];
+  const delivered: number[] = [];
+
+  const fetch = (executionId: string, afterSequence: number) =>
+    Promise.resolve(
+      visible
+        .filter((r) => r.executionId === executionId && r.sequence > afterSequence)
+        .sort((a, b) => a.sequence - b.sequence),
+    );
+
+  const write = async (event: ExecutionEventRow) => {
+    delivered.push(event.sequence);
+  };
+
+  // Commit a row and wake the drainer, as the worker's INSERT + pg_notify pair does.
+  return { visible, delivered, fetch, write };
+}
+
+function drainerOver(table: ReturnType<typeof makeTable>, initialCursor: number) {
+  return createSerializedDrainer(initialCursor, (cursor) =>
+    drainEventsSince(EXECUTION, cursor, table.fetch, table.write),
+  );
+}
+
+describe('drain cursor — commit-order contract', () => {
+  it('delivers every event when rows commit in ascending sequence order', async () => {
+    const table = makeTable();
+    const drainer = drainerOver(table, 0);
+
+    for (const sequence of [1, 2, 3, 4]) {
+      table.visible.push(row(sequence, 'node_started', `n-${sequence}`));
+      await drainer.notify();
+    }
+
+    expect(table.delivered).toEqual([1, 2, 3, 4]);
+  });
+
+  it('drops a row that commits after the cursor has passed it', async () => {
+    // Why the writer must serialize: node C's insert lands before node B's, the
+    // cursor moves to 3, and B's event can never be selected again.
+    const table = makeTable();
+    const drainer = drainerOver(table, 1);
+
+    table.visible.push(row(3, 'node_completed', 'C'));
+    await drainer.notify();
+
+    table.visible.push(row(2, 'node_completed', 'B'));
+    await drainer.notify();
+
+    expect(table.delivered).toEqual([3]);
+    expect(table.delivered).not.toContain(2);
+    expect(drainer.cursor).toBe(3);
+  });
+
+  it('steps over a permanent gap without stalling', async () => {
+    // Gaps are the tolerable failure: a sequence number consumed by an emit that never
+    // commits (cancelled run, exhausted retries) costs nothing, because the cursor only
+    // ever needs rows to arrive in ascending order — not to be contiguous.
+    const table = makeTable();
+    const drainer = drainerOver(table, 0);
+
+    table.visible.push(row(1, 'node_started', 'B'));
+    await drainer.notify();
+    // 2 is never written.
+    table.visible.push(row(3, 'node_completed', 'B'));
+    await drainer.notify();
+    table.visible.push(row(4, 'execution_completed'));
+    await drainer.notify();
+
+    expect(table.delivered).toEqual([1, 3, 4]);
+    expect(drainer.done).toBe(true);
+  });
+});

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -12,7 +12,7 @@
     "typecheck:watch": "tsc --noEmit --watch --pretty",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/apps/execution-worker/src/database.ts
+++ b/apps/execution-worker/src/database.ts
@@ -6,13 +6,13 @@ import { env } from './env';
 const sql = postgres(env.DATABASE_URL);
 
 export const database = {
-  async emitExecutionEvent(executionId: string, type: string, payload?: unknown, nodeId?: string) {
+  async emitExecutionEvent(executionId: string, sequence: number, type: string, payload?: unknown, nodeId?: string) {
     await sql`
       INSERT INTO execution_events (id, execution_id, sequence, timestamp, type, node_id, path_id, payload_json, tenant_id, created_at)
       VALUES (
         gen_random_uuid(),
         ${executionId},
-        (SELECT COALESCE(MAX(sequence), 0) + 1 FROM execution_events WHERE execution_id = ${executionId}),
+        ${sequence},
         now(),
         ${type},
         ${nodeId ?? null},
@@ -21,9 +21,10 @@ export const database = {
         (SELECT tenant_id FROM executions WHERE id = ${executionId}),
         now()
       )
+      ON CONFLICT (execution_id, sequence) DO NOTHING
     `;
 
-    // Postgres NOTIFY → backend SSE stream picks this up and fans out to clients
+    // Postgres NOTIFY → backend SSE stream picks this up and fans out to clients.
     await sql`SELECT pg_notify('execution_events', ${executionId})`;
   },
 

--- a/apps/execution-worker/src/engines/temporal/activities-interface.ts
+++ b/apps/execution-worker/src/engines/temporal/activities-interface.ts
@@ -5,6 +5,6 @@ import type { AiStudioNode } from '../../domain/ai-studio-nodes';
 
 export type Activities = {
   executeNode(node: AiStudioNode, context: ExecutionContext): Promise<NodeExecutionResult>;
-  emitEvent(executionId: string, type: string, payload?: unknown, nodeId?: string): Promise<void>;
+  emitEvent(executionId: string, sequence: number, type: string, payload?: unknown, nodeId?: string): Promise<void>;
   updateStatus(executionId: string, status: string, errorMessage?: string): Promise<void>;
 };

--- a/apps/execution-worker/src/engines/temporal/worker.ts
+++ b/apps/execution-worker/src/engines/temporal/worker.ts
@@ -36,8 +36,8 @@ const activities = {
     return executor(node, context);
   },
 
-  async emitEvent(executionId: string, type: string, payload?: unknown, nodeId?: string) {
-    await database.emitExecutionEvent(executionId, type, payload, nodeId);
+  async emitEvent(executionId: string, sequence: number, type: string, payload?: unknown, nodeId?: string) {
+    await database.emitExecutionEvent(executionId, sequence, type, payload, nodeId);
   },
 
   async updateStatus(executionId: string, status: string, errorMessage?: string) {

--- a/apps/execution-worker/src/engines/temporal/workflows/run-workflow.ts
+++ b/apps/execution-worker/src/engines/temporal/workflows/run-workflow.ts
@@ -5,7 +5,6 @@ import { ApplicationFailure, CancellationScope, isCancellation, proxyActivities 
 
 import {
   type ActivityRunnerPort,
-  type EventEmitterPort,
   type RunGraphOutcome,
   type WorkflowExecutionInput,
   runGraph,
@@ -13,6 +12,7 @@ import {
 
 import type { AiStudioNode } from '../../../domain/ai-studio-nodes';
 import type { Activities } from '../activities-interface';
+import { createSequencedEventEmitter } from './sequenced-event-emitter';
 
 // DB activities: fast, idempotent INSERT/UPDATE — short timeout, aggressive retries
 const databaseActivities = proxyActivities<Pick<Activities, 'emitEvent' | 'updateStatus'>>({
@@ -30,13 +30,8 @@ const runner: ActivityRunnerPort<AiStudioNode> = {
   executeNode: (node, context) => nodeActivities.executeNode(node, context),
 };
 
-const events: EventEmitterPort = {
-  emitEvent: (executionId, type, payload, nodeId) => databaseActivities.emitEvent(executionId, type, payload, nodeId),
-  updateStatus: (executionId, status, errorMessage) =>
-    databaseActivities.updateStatus(executionId, status, errorMessage),
-};
-
 export async function runWorkflow(input: WorkflowExecutionInput<AiStudioNode>): Promise<void> {
+  const events = createSequencedEventEmitter(databaseActivities);
   let outcome: RunGraphOutcome;
 
   try {

--- a/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.test.ts
+++ b/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ActivityRunnerPort,
+  type BaseNode,
+  type WorkflowExecutionInput,
+  runGraph,
+} from '@workflow-builder/execution-core/workflow';
+
+import { type EventPersistence, createSequencedEventEmitter } from './sequenced-event-emitter';
+
+type TestNode = BaseNode & { type: 'test/node' };
+
+type Recorded = { sequence: number; type: string; nodeId?: string };
+
+// Records what reached persistence, and yields to the microtask queue before
+// resolving so that concurrent emits from one wave genuinely overlap — a counter
+// read across an await boundary would collide here.
+function makePersistence(): { persistence: EventPersistence; recorded: Recorded[] } {
+  const recorded: Recorded[] = [];
+  return {
+    recorded,
+    persistence: {
+      async emitEvent(_executionId, sequence, type, _payload, nodeId) {
+        await Promise.resolve();
+        recorded.push({ sequence, type, nodeId });
+      },
+      async updateStatus() {
+        await Promise.resolve();
+      },
+    },
+  };
+}
+
+function node(id: string): TestNode {
+  return { id, type: 'test/node', config: {} };
+}
+
+type TestEdge = WorkflowExecutionInput<TestNode>['definition']['edges'][number];
+
+function edge(id: string, source: string, target: string): TestEdge {
+  return { id, sourceNodeId: source, targetNodeId: target };
+}
+
+function makeInput(nodes: TestNode[], edges: TestEdge[]): WorkflowExecutionInput<TestNode> {
+  return {
+    workflowId: 'wf-1',
+    executionId: 'exec-1',
+    definition: { workflowId: 'wf-1', nodes, edges },
+    triggerPayload: {},
+    variables: {},
+    global: {},
+  };
+}
+
+const runner: ActivityRunnerPort<TestNode> = {
+  async executeNode(target) {
+    // A real node awaits an activity; yielding here lets the whole wave suspend
+    // together rather than each node running to completion in turn.
+    await Promise.resolve();
+    return { output: `out-${target.id}` };
+  },
+};
+
+// A→{B,C,D}→E: one four-wide wave, so four node_started emits are in flight at once.
+function fanOutGraph(): WorkflowExecutionInput<TestNode> {
+  return makeInput(
+    [node('A'), node('B'), node('C'), node('D'), node('E')],
+    [
+      edge('e1', 'A', 'B'),
+      edge('e2', 'A', 'C'),
+      edge('e3', 'A', 'D'),
+      edge('e4', 'B', 'E'),
+      edge('e5', 'C', 'E'),
+      edge('e6', 'D', 'E'),
+    ],
+  );
+}
+
+describe('createSequencedEventEmitter', () => {
+  it('numbers from 1 upward — the SSE cursor starts at 0 and queries sequence > cursor', async () => {
+    const { persistence, recorded } = makePersistence();
+    const events = createSequencedEventEmitter(persistence);
+
+    await events.emitEvent('exec-1', 'execution_started');
+
+    expect(recorded).toEqual([{ sequence: 1, type: 'execution_started', nodeId: undefined }]);
+  });
+
+  it('assigns distinct, call-ordered numbers to emits that overlap', async () => {
+    const { persistence, recorded } = makePersistence();
+    const events = createSequencedEventEmitter(persistence);
+
+    await Promise.all([
+      events.emitEvent('exec-1', 'node_started', undefined, 'B'),
+      events.emitEvent('exec-1', 'node_started', undefined, 'C'),
+      events.emitEvent('exec-1', 'node_started', undefined, 'D'),
+    ]);
+
+    expect(recorded.map((entry) => entry.sequence)).toEqual([1, 2, 3]);
+    expect(recorded.map((entry) => entry.nodeId)).toEqual(['B', 'C', 'D']);
+  });
+
+  it('gives every event of a parallel wave its own number', async () => {
+    const { persistence, recorded } = makePersistence();
+
+    await runGraph(fanOutGraph(), runner, createSequencedEventEmitter(persistence));
+
+    // 1 execution_started + 5 nodes x (started + completed) + 1 execution_completed
+    expect(recorded).toHaveLength(12);
+    const sequences = recorded.map((entry) => entry.sequence);
+    expect(new Set(sequences).size).toBe(sequences.length);
+    expect(sequences).toEqual([...sequences].sort((a, b) => a - b));
+  });
+
+  it('produces byte-identical numbering across repeated runs of the same graph', async () => {
+    // Replay equivalence for the numbers specifically: Temporal replays the emit
+    // order from history, so identical emit order must yield identical numbers.
+    const fingerprints: string[] = [];
+    for (let run = 0; run < 10; run++) {
+      const { persistence, recorded } = makePersistence();
+      await runGraph(fanOutGraph(), runner, createSequencedEventEmitter(persistence));
+      fingerprints.push(JSON.stringify(recorded));
+    }
+
+    for (let run = 1; run < fingerprints.length; run++) {
+      expect(fingerprints[run], `run ${run} diverged from run 0`).toBe(fingerprints[0]);
+    }
+  });
+
+  it('keeps a separate counter per emitter so concurrent runs cannot share numbers', async () => {
+    const first = makePersistence();
+    const second = makePersistence();
+
+    await runGraph(fanOutGraph(), runner, createSequencedEventEmitter(first.persistence));
+    await runGraph(fanOutGraph(), runner, createSequencedEventEmitter(second.persistence));
+
+    expect(second.recorded.map((entry) => entry.sequence)).toEqual(first.recorded.map((entry) => entry.sequence));
+    expect(second.recorded[0]?.sequence).toBe(1);
+  });
+});

--- a/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.test.ts
+++ b/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.test.ts
@@ -13,17 +13,36 @@ type TestNode = BaseNode & { type: 'test/node' };
 
 type Recorded = { sequence: number; type: string; nodeId?: string };
 
-// Records what reached persistence, and yields to the microtask queue before
-// resolving so that concurrent emits from one wave genuinely overlap — a counter
-// read across an await boundary would collide here.
-function makePersistence(): { persistence: EventPersistence; recorded: Recorded[] } {
+// Records what reached persistence. `trace` logs entry and exit of each write so a
+// test can tell serialized writes from overlapping ones. `failAt` rejects the write
+// carrying that sequence number, standing in for an emitEvent that exhausted its
+// Temporal retries.
+function makePersistence(options: { failAt?: number } = {}): {
+  persistence: EventPersistence;
+  recorded: Recorded[];
+  trace: string[];
+} {
   const recorded: Recorded[] = [];
+  const trace: string[] = [];
   return {
     recorded,
+    trace,
     persistence: {
       async emitEvent(_executionId, sequence, type, _payload, nodeId) {
-        await Promise.resolve();
+        trace.push(`start:${sequence}`);
+        // Lower sequence numbers take *more* microtask turns, so if these writes ever
+        // ran concurrently they would finish in descending order — the exact inversion
+        // the SSE cursor cannot survive. Deterministic (no timers, no randomness), so
+        // it is replay-safe and stable across runs.
+        for (let turn = 0; turn < Math.max(1, 16 - sequence); turn++) {
+          await Promise.resolve();
+        }
+        if (options.failAt === sequence) {
+          trace.push(`fail:${sequence}`);
+          throw new Error(`insert failed at ${sequence}`);
+        }
         recorded.push({ sequence, type, nodeId });
+        trace.push(`end:${sequence}`);
       },
       async updateStatus() {
         await Promise.resolve();
@@ -126,6 +145,77 @@ describe('createSequencedEventEmitter', () => {
     for (let run = 1; run < fingerprints.length; run++) {
       expect(fingerprints[run], `run ${run} diverged from run 0`).toBe(fingerprints[0]);
     }
+  });
+
+  // The backend SSE drain advances a monotonic cursor over `sequence > cursor`, so a
+  // row committing after a higher-numbered one has already moved the cursor is never
+  // delivered. These pin the writer-side half of that contract.
+  it('never has two writes in flight at once, even when the caller emits concurrently', async () => {
+    const { persistence, trace } = makePersistence();
+    const events = createSequencedEventEmitter(persistence);
+
+    await Promise.all([
+      events.emitEvent('exec-1', 'node_started', undefined, 'B'),
+      events.emitEvent('exec-1', 'node_started', undefined, 'C'),
+      events.emitEvent('exec-1', 'node_started', undefined, 'D'),
+    ]);
+
+    // Strictly start/end paired — never start:2 before end:1.
+    expect(trace).toEqual(['start:1', 'end:1', 'start:2', 'end:2', 'start:3', 'end:3']);
+  });
+
+  it('commits a whole parallel wave in ascending sequence order', async () => {
+    const { persistence, trace } = makePersistence();
+
+    await runGraph(fanOutGraph(), runner, createSequencedEventEmitter(persistence));
+
+    const commitOrder = trace.filter((entry) => entry.startsWith('end:')).map((entry) => Number(entry.slice(4)));
+    expect(commitOrder).toEqual([...commitOrder].sort((a, b) => a - b));
+    expect(commitOrder).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  // Chain-poisoning: `tail = write` would make one rejection skip the onFulfilled of
+  // every later link, silently dropping the rest of the run's events.
+  it('keeps emitting after a failed write — one rejection does not poison the chain', async () => {
+    const { persistence, recorded } = makePersistence({ failAt: 2 });
+    const events = createSequencedEventEmitter(persistence);
+
+    await events.emitEvent('exec-1', 'execution_started');
+    await expect(events.emitEvent('exec-1', 'node_started', undefined, 'B')).rejects.toThrow('insert failed at 2');
+    await events.emitEvent('exec-1', 'node_started', undefined, 'C');
+    await events.emitEvent('exec-1', 'node_completed', { output: 'x' }, 'C');
+
+    // 2 is a permanent gap; everything after it still lands, still ascending.
+    expect(recorded.map((entry) => entry.sequence)).toEqual([1, 3, 4]);
+  });
+
+  it('surfaces the failure to the caller so it can reach the error policy', async () => {
+    // The emitter must not swallow: runNode's catch is what applies errorPolicy.
+    const { persistence } = makePersistence({ failAt: 1 });
+    const events = createSequencedEventEmitter(persistence);
+
+    await expect(events.emitEvent('exec-1', 'node_started', undefined, 'B')).rejects.toThrow('insert failed at 1');
+  });
+
+  it('a run whose node_started emit fails still completes, with a gap and no reordering', async () => {
+    // End to end through runGraph: errorPolicy 'continue' absorbs the failed emit,
+    // the run carries on, and the surviving events stay in ascending commit order.
+    const { persistence, recorded, trace } = makePersistence({ failAt: 4 });
+
+    const outcome = await runGraph(
+      makeInput(
+        [node('A'), { ...node('B'), errorPolicy: 'continue' }, node('C')],
+        [edge('e1', 'A', 'B'), edge('e2', 'B', 'C')],
+      ),
+      runner,
+      createSequencedEventEmitter(persistence),
+    );
+
+    expect(outcome).toEqual({ status: 'completed' });
+    const commitOrder = trace.filter((entry) => entry.startsWith('end:')).map((entry) => Number(entry.slice(4)));
+    expect(commitOrder).toEqual([...commitOrder].sort((a, b) => a - b));
+    expect(recorded.map((entry) => entry.sequence)).not.toContain(4);
+    expect(recorded.length).toBeGreaterThan(0);
   });
 
   it('keeps a separate counter per emitter so concurrent runs cannot share numbers', async () => {

--- a/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.ts
+++ b/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.ts
@@ -11,14 +11,50 @@ export type EventPersistence = Pick<Activities, 'emitEvent' | 'updateStatus'>;
 
 // Creates a sequenced `EventEmitterPort`: one that assigns each execution event its
 // `sequence` number inside the workflow, then hands the numbered event to the
-// persistence activity.
+// persistence activity — one at a time.
+//
+// Emits are serialized because the backend's SSE drain requires that events become
+// visible in Postgres in ascending `sequence` order. It tracks a cursor and queries
+// `sequence > cursor` (fetch-events-after.ts), advancing the cursor to the highest row
+// it has read (drain-events.ts), monotonically (serialized-drainer.ts). A row that
+// commits after a higher-numbered one has already moved the cursor past it is never
+// returned again, and that event silently never reaches the client.
+//
+// The old `MAX(sequence) + 1` insert upheld this by accident: a colliding insert
+// blocked, then failed and recomputed its number only once the winner had committed,
+// so number N was always committed before N+1 existed. Assigning numbers up here
+// removed that coupling, so the ordering has to be maintained deliberately — one
+// in-flight emit per execution, which is what the chain below is for.
+//
+// Gaps, unlike reordering, are harmless to the drain: a number consumed by an emit
+// that never commits (a cancelled run, or an emitEvent that exhausts its retries)
+// just leaves a hole the cursor steps over.
 export function createSequencedEventEmitter(persistence: EventPersistence): EventEmitterPort {
   let sequence = 0;
+  // Always fulfilled, never rejected — see below.
+  let tail: Promise<void> = Promise.resolve();
 
   return {
     emitEvent(executionId, type, payload, nodeId) {
+      // Still incremented synchronously, so numbers follow call order rather than
+      // the order the chain happens to drain in.
       sequence += 1;
-      return persistence.emitEvent(executionId, sequence, type, payload, nodeId);
+      const assigned = sequence;
+
+      const write = tail.then(() => persistence.emitEvent(executionId, assigned, type, payload, nodeId));
+
+      // Two distinct promises on purpose. `tail` is the ordering link and must always
+      // fulfil, so one failed emit cannot poison the chain: with a bare `tail = write`,
+      // a single rejection would skip the `onFulfilled` of every subsequent link and
+      // silently drop the rest of the run's events. That matters because a failed
+      // node_started is now survivable (it goes through errorPolicy), so the run
+      // carries on emitting. Swallowing here also marks `write` as handled, so the
+      // rejection the caller sees never surfaces as an unhandled rejection.
+      tail = write.catch(() => {});
+
+      // `write` is what the caller sees, so the failure still surfaces to runNode
+      // and reaches the error policy.
+      return write;
     },
     updateStatus(executionId, status, errorMessage) {
       return persistence.updateStatus(executionId, status, errorMessage);

--- a/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.ts
+++ b/apps/execution-worker/src/engines/temporal/workflows/sequenced-event-emitter.ts
@@ -1,0 +1,27 @@
+// Sandbox-safe: pure counter + delegation, no Temporal or Node imports. Lives
+// under `workflows/` because it is bundled into the workflow sandbox alongside
+// run-workflow.ts.
+import type { EventEmitterPort } from '@workflow-builder/execution-core/workflow';
+
+import type { Activities } from '../activities-interface';
+
+// The two activities run-workflow.ts proxies. Passed in rather than reached for via
+// proxyActivities here, which keeps the numbering drivable from a test.
+export type EventPersistence = Pick<Activities, 'emitEvent' | 'updateStatus'>;
+
+// Creates a sequenced `EventEmitterPort`: one that assigns each execution event its
+// `sequence` number inside the workflow, then hands the numbered event to the
+// persistence activity.
+export function createSequencedEventEmitter(persistence: EventPersistence): EventEmitterPort {
+  let sequence = 0;
+
+  return {
+    emitEvent(executionId, type, payload, nodeId) {
+      sequence += 1;
+      return persistence.emitEvent(executionId, sequence, type, payload, nodeId);
+    },
+    updateStatus(executionId, status, errorMessage) {
+      return persistence.updateStatus(executionId, status, errorMessage);
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:fix": "pnpm -r lint:fix",
     "format": "prettier --write --log-level silent \"**/*.+(css|ts|tsx|json|md|mdx|astro)\"",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm --filter @workflowbuilder/sdk test && pnpm --filter @workflow-builder/execution-core test && pnpm --filter @workflow-builder/execution-worker test && pnpm --filter @workflow-builder/backend test && pnpm --filter @workflowbuilder/ui test && pnpm --filter @workflowbuilder/ui-tokens test",
+    "test": "pnpm -r test",
     "check": "pnpm lint && pnpm typecheck && pnpm format",
     "pre-commit": "lint-staged",
     "pre-push": "pnpm format",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:fix": "pnpm -r lint:fix",
     "format": "prettier --write --log-level silent \"**/*.+(css|ts|tsx|json|md|mdx|astro)\"",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm --filter @workflowbuilder/sdk test && pnpm --filter @workflow-builder/execution-core test && pnpm --filter @workflowbuilder/ui test && pnpm --filter @workflowbuilder/ui-tokens test",
+    "test": "pnpm --filter @workflowbuilder/sdk test && pnpm --filter @workflow-builder/execution-core test && pnpm --filter @workflow-builder/execution-worker test && pnpm --filter @workflowbuilder/ui test && pnpm --filter @workflowbuilder/ui-tokens test",
     "check": "pnpm lint && pnpm typecheck && pnpm format",
     "pre-commit": "lint-staged",
     "pre-push": "pnpm format",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:fix": "pnpm -r lint:fix",
     "format": "prettier --write --log-level silent \"**/*.+(css|ts|tsx|json|md|mdx|astro)\"",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm --filter @workflowbuilder/sdk test && pnpm --filter @workflow-builder/execution-core test && pnpm --filter @workflow-builder/execution-worker test && pnpm --filter @workflowbuilder/ui test && pnpm --filter @workflowbuilder/ui-tokens test",
+    "test": "pnpm --filter @workflowbuilder/sdk test && pnpm --filter @workflow-builder/execution-core test && pnpm --filter @workflow-builder/execution-worker test && pnpm --filter @workflow-builder/backend test && pnpm --filter @workflowbuilder/ui test && pnpm --filter @workflowbuilder/ui-tokens test",
     "check": "pnpm lint && pnpm typecheck && pnpm format",
     "pre-commit": "lint-staged",
     "pre-push": "pnpm format",

--- a/packages/execution-core/src/graph-runner.test.ts
+++ b/packages/execution-core/src/graph-runner.test.ts
@@ -50,7 +50,9 @@ function makeRunner(behaviors: Record<string, NodeBehavior> = {}): {
 type EventCall = { type: string; nodeId?: string; payload?: unknown };
 type StatusCall = { status: string; errorMessage?: string };
 
-function makeEvents(): {
+type EmitFailure = { type: string; nodeId?: string; message: string };
+
+function makeEvents(failOn?: EmitFailure): {
   port: EventEmitterPort;
   events: EventCall[];
   statuses: StatusCall[];
@@ -63,6 +65,9 @@ function makeEvents(): {
     port: {
       async emitEvent(_executionId, type, payload, nodeId) {
         events.push({ type, nodeId, payload });
+        if (failOn && failOn.type === type && failOn.nodeId === nodeId) {
+          throw new Error(failOn.message);
+        }
       },
       async updateStatus(_executionId, status, errorMessage) {
         statuses.push({ status, errorMessage });
@@ -580,6 +585,55 @@ describe('runGraph — replay safety (sandbox-safe)', () => {
 });
 
 describe('runGraph — errorPolicy', () => {
+  it('a failing node_started is a step failure — node_failed is emitted and the node never runs', async () => {
+    const runner = makeRunner();
+    const events = makeEvents({ type: 'node_started', nodeId: 'B', message: 'events table unreachable' });
+
+    const outcome = await runGraph(
+      makeInput([trigger('A'), trigger('B'), trigger('C')], [edge('e1', 'A', 'B'), edge('e2', 'B', 'C')]),
+      runner.port,
+      events.port,
+    );
+
+    // B's executor is never reached, but the failure is reported as B's.
+    expect(runner.callOrder).toEqual(['A']);
+    expect(events.events.some((event) => event.type === 'node_failed' && event.nodeId === 'B')).toBe(true);
+    expect(outcome).toEqual({ status: 'failed', error: { message: 'events table unreachable' } });
+    expect(events.statuses.at(-1)).toEqual({ status: 'failed', errorMessage: 'events table unreachable' });
+  });
+
+  it("a failing node_started honors 'continue' — downstream still runs", async () => {
+    const runner = makeRunner();
+    const events = makeEvents({ type: 'node_started', nodeId: 'B', message: 'events table unreachable' });
+
+    const outcome = await runGraph(
+      makeInput([trigger('A'), trigger('B', 'continue'), trigger('C')], [edge('e1', 'A', 'B'), edge('e2', 'B', 'C')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['A', 'C']);
+    expect(runner.contexts.C).toEqual({ A: 'out-A', B: { error: { message: 'events table unreachable' } } });
+    expect(outcome).toEqual({ status: 'completed' });
+  });
+
+  it("a failing node_started honors 'errorRoute' — the error branch fires", async () => {
+    const runner = makeRunner();
+    const events = makeEvents({ type: 'node_started', nodeId: 'B', message: 'events table unreachable' });
+
+    const outcome = await runGraph(
+      makeInput(
+        [trigger('A'), trigger('B', 'errorRoute'), trigger('Recover'), trigger('Success')],
+        [edge('e1', 'A', 'B'), edge('e2', 'B', 'Recover', 'errorRoute'), edge('e3', 'B', 'Success')],
+      ),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['A', 'Recover']);
+    expect(outcome).toEqual({ status: 'completed' });
+  });
+
   it("'fail' set explicitly behaves like the default — aborts the workflow", async () => {
     // Regression pin: making the policy explicit must not change behavior.
     const runner = makeRunner({ B: { throws: 'boom' } });

--- a/packages/execution-core/src/graph-runner.ts
+++ b/packages/execution-core/src/graph-runner.ts
@@ -201,9 +201,8 @@ async function runNode<TNode extends BaseNode>(
   events: EventEmitterPort,
   executionId: string,
 ): Promise<NodeRunResult<TNode>> {
-  await events.emitEvent(executionId, 'node_started', undefined, node.id);
-
   try {
+    await events.emitEvent(executionId, 'node_started', undefined, node.id);
     const result = await runner.executeNode(node, context);
     await events.emitEvent(executionId, 'node_completed', { output: result.output }, node.id);
     return { node, output: result.output, nextPort: result.nextPort, failed: false };


### PR DESCRIPTION
## What

WB-429 — two bugs in execution event handling, both reachable in ordinary parallel runs.

**Sequence numbering was racy.** The worker derived `sequence` as `MAX(sequence) + 1` inside the
INSERT, against a unique index on `(execution_id, sequence)`. Concurrent inserts all read the same
maximum, so any parallel wave in the graph runner collided, the index rejected the losers, and
Temporal retried `emitEvent` until its attempt budget was gone.

The number is now minted in workflow code (`sequenced-event-emitter.ts`), where it's deterministic
under replay and uncontended — the worker is the only writer of `execution_events`. The insert takes
it as a parameter and adds `ON CONFLICT (execution_id, sequence) DO NOTHING`, which also fixes a
related bug: a retry after a lost ack used to recompute `MAX+1` and write a *second copy* of the
event under a new number.

**A failed `node_started` emit bypassed the error policy.** It was emitted above `runNode`'s try
block, so a failure there escaped the graph runner entirely — no `node_failed` event, `errorPolicy`
never consulted. Moved inside the try, so `continue` / `errorRoute` absorb it and `fail` aborts
through the normal path.

## Verification

- New tests: sequence uniqueness across a parallel wave, replay-equivalence of the numbers, and
  three error-policy cases for a failing `node_started`. Both fixes mutation-tested.
- SQL checked against a live Postgres in a rolled-back transaction: the old shape reproduces the
  exact `duplicate key value violates unique constraint "execution_events_execution_sequence_idx"`,
  the new shape inserts a full wave and silently discards a replayed `(execution_id, sequence)`.
- `pnpm test` (367) green, lint and typecheck clean.