### PR TITLE
Trigger PR checks on the ds-2.0 integration branch

### DIFF
--- a/.github/workflows/pr-check-docs.yml
+++ b/.github/workflows/pr-check-docs.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches:
       - main
+      # DS 2.0 integration branch — same feedback as PRs to main.
+      - ds-2.0
     paths:
       - 'apps/docs/**'
       - 'packages/ui/**'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - main
+      # DS 2.0 integration branch — PRs targeting it need the same feedback
+      # as PRs to main (it all merges into main at the end of the migration).
+      - ds-2.0
 
 permissions:
   contents: read


### PR DESCRIPTION
Pre-step of the token-pipeline task. The DS 2.0 migration lands component work as PRs targeting a long-lived `ds-2.0` integration branch; `pr-check.yml` and `pr-check-docs.yml` trigger only on PRs to `main`, so those PRs would run with zero CI. Two-line trigger extension, no behavior change for PRs to `main`. Mergeable immediately.
