### PR TITLE
Token pipeline prep (1/2): collision guard, codemod map, usage rewriter

### DIFF
--- a/.github/workflows/pr-check-docs.yml
+++ b/.github/workflows/pr-check-docs.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches:
       - main
-      # DS 2.0 integration branch — same feedback as PRs to main.
+      # Long-lived DS 2.0 integration branch; merges into main at the end.
       - ds-2.0
     paths:
       - 'apps/docs/**'

--- a/.github/workflows/pr-check-docs.yml
+++ b/.github/workflows/pr-check-docs.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches:
       - main
+      # DS 2.0 integration branch — same feedback as PRs to main.
+      - ds-2.0
     paths:
       - 'apps/docs/**'
       - 'packages/ui/**'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -145,3 +145,10 @@ jobs:
         # build:ui builds @workflowbuilder/ui-tokens first, then ui, then runs
         # the check:built-css guard.
         run: pnpm build:ui
+
+      - name: Codemod map reproducibility
+        # codemod-map.json is a committed artifact; it must match what its
+        # generator produces from the checked-in designer changelog.
+        run: |
+          pnpm --filter @workflowbuilder/ui-tokens codemod:map
+          git diff --exit-code -- packages/tokens/codemod-map.json

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,8 +11,7 @@ on:
   pull_request:
     branches:
       - main
-      # DS 2.0 integration branch — PRs targeting it need the same feedback
-      # as PRs to main (it all merges into main at the end of the migration).
+      # Long-lived DS 2.0 integration branch; merges into main at the end.
       - ds-2.0
 
 permissions:
@@ -150,8 +149,6 @@ jobs:
         run: pnpm build:ui
 
       - name: Codemod map reproducibility
-        # codemod-map.json is a committed artifact; it must match what its
-        # generator produces from the checked-in designer changelog.
         run: |
           pnpm --filter @workflowbuilder/ui-tokens codemod:map
           git diff --exit-code -- packages/tokens/codemod-map.json

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - main
+      # DS 2.0 integration branch — PRs targeting it need the same feedback
+      # as PRs to main (it all merges into main at the end of the migration).
+      - ds-2.0
 
 permissions:
   contents: read

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,7 @@
 apps/icons/src/utils/icons.gen.ts
 # Astro auto-generated content collections + types (gitignored, regenerated on build/dev)
 **/.astro/
+# Designer changelog checked in verbatim — reformatting corrupted token paths in emphasis markers
+packages/tokens/migration/
+# Generated artifact — byte format owned by its generator (CI checks reproducibility)
+packages/tokens/codemod-map.json

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,7 +1,15 @@
+import { fileURLToPath } from 'node:url';
+
+// Workspace lint-staged configs re-export this file and run commands from
+// their own directory; prettier reads .prettierignore only from the cwd,
+// so the root ignore file must be passed explicitly.
+const prettierIgnore = fileURLToPath(new URL('./.prettierignore', import.meta.url));
+
 /**
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  '*.{ts,tsx,js,json,css,astro,md,mdx}': (files) => `prettier --write --log-level=silent ${files.join(' ')}`,
+  '*.{ts,tsx,js,json,css,astro,md,mdx}': (files) =>
+    `prettier --write --log-level=silent --ignore-path ${prettierIgnore} ${files.join(' ')}`,
   '*.{ts,tsx}': [(files) => `eslint --max-warnings=0 --fix ${files.join(' ')}`, () => `tsc --noEmit`],
 };

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -45,3 +45,24 @@ pnpm --filter @workflowbuilder/ui-tokens test
 ```
 
 Vitest unit tests (currently `src/to-file-name.spec.ts` and `src/manifest.spec.ts`).
+
+## DS 2.0 migration tooling
+
+The DS 2.0 rename map lives in `migration/2026-06-15-ds2-migration-map.md`
+(the designer changelog, checked in verbatim). Two scripts turn it into code
+changes — the migration fixes usages at the source instead of shipping a
+compatibility bridge:
+
+```bash
+node scripts/build-codemod-map.mjs   # md → codemod-map.json (renames, removed, prefix rules)
+node scripts/codemod-usages.mjs      # dry-run: var(--ax-…) → var(--wb-…) plan
+node scripts/codemod-usages.mjs --write
+```
+
+`codemod-map.json` is the reviewable artifact: 144 renames, 38 removals with
+replacements, primitive prefix rules, and a `manual` list for names that have
+no 1:1 target (chips factory, state-split nav-button) — the codemod reports
+those instead of rewriting them. Rows the parser cannot resolve land in
+`unparsed`, never dropped silently. The `dimensions` section stays empty until
+the 2.0 export lands; value→token pairs for the Numerals scale are generated
+against the real export in the pipeline-switch PR.

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -48,21 +48,26 @@ Vitest unit tests (currently `src/to-file-name.spec.ts` and `src/manifest.spec.t
 
 ## DS 2.0 migration tooling
 
-The DS 2.0 rename map lives in `migration/2026-06-15-ds2-migration-map.md`
-(the designer changelog, checked in verbatim). Two scripts turn it into code
-changes — the migration fixes usages at the source instead of shipping a
-compatibility bridge:
+The DS 2.0 rename map lives in `migration/2026-06-15-ds2-migration-map.md` —
+the designer changelog checked in verbatim (guarded by `.prettierignore`;
+reformatting corrupts token paths inside emphasis markers). Two scripts turn
+it into code changes — the migration fixes usages at the source instead of
+shipping a compatibility bridge:
 
 ```bash
-node scripts/build-codemod-map.mjs   # md → codemod-map.json (renames, removed, prefix rules)
-node scripts/codemod-usages.mjs      # dry-run: var(--ax-…) → var(--wb-…) plan
-node scripts/codemod-usages.mjs --write
+pnpm --filter @workflowbuilder/ui-tokens codemod:map    # md → codemod-map.json
+pnpm --filter @workflowbuilder/ui-tokens codemod:apply  # dry-run: var(--ax-…) → var(--wb-…) plan
+pnpm --filter @workflowbuilder/ui-tokens codemod:apply -- --write
 ```
 
-`codemod-map.json` is the reviewable artifact: 144 renames, 38 removals with
-replacements, primitive prefix rules, and a `manual` list for names that have
-no 1:1 target (chips factory, state-split nav-button) — the codemod reports
-those instead of rewriting them. Rows the parser cannot resolve land in
-`unparsed`, never dropped silently. The `dimensions` section stays empty until
-the 2.0 export lands; value→token pairs for the Numerals scale are generated
-against the real export in the pipeline-switch PR.
+`codemod-map.json` is the reviewable artifact — CI regenerates it and fails
+on any diff, so it can never drift from the changelog. Contents: 144 renames,
+37 removals (32 with a replacement, 5 without), primitive prefix rules, and a
+`manual` list for names with no 1:1 target (the chips factory) — the codemod
+reports those for hand-editing instead of rewriting them. The parser never
+guesses: an ambiguous row lands in `unparsed` (build fails) unless a human
+resolved it in the generator's `RESOLVED_BY_HAND` table. The `dimensions`
+section stays empty until the 2.0 export lands; value→token pairs for the
+Numerals scale are generated against the real export in the pipeline-switch
+PR — the codemod's dry-run reports those usages as "unmapped but defined in
+today's dist" so the gap stays visible.

--- a/packages/tokens/codemod-map.json
+++ b/packages/tokens/codemod-map.json
@@ -1,0 +1,1241 @@
+{
+  "$source": "migration/2026-06-15-ds2-migration-map.md",
+  "$generatedBy": "scripts/build-codemod-map.mjs",
+  "prefixRules": [
+    {
+      "oldCssPrefix": "--ax-colors-",
+      "newCssPrefix": "--wb-colors-"
+    }
+  ],
+  "manual": [
+    {
+      "pattern": "--ax-chips-*",
+      "reason": "Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task (WB-489)."
+    },
+    {
+      "pattern": "--ax-nav-button-bg-primary-hover",
+      "reason": "One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task (WB-490)."
+    }
+  ],
+  "renames": [
+    {
+      "old": "wb/txt-primary-default",
+      "new": "wb/ui/text/default",
+      "oldCss": "--ax-txt-primary-default",
+      "newCss": "--wb-ui-text-default"
+    },
+    {
+      "old": "wb/txt-primary-inverse",
+      "new": "wb/ui/text/inverse-default",
+      "oldCss": "--ax-txt-primary-inverse",
+      "newCss": "--wb-ui-text-inverse-default"
+    },
+    {
+      "old": "wb/txt-primary-disabled",
+      "new": "wb/ui/text/disabled",
+      "oldCss": "--ax-txt-primary-disabled",
+      "newCss": "--wb-ui-text-disabled",
+      "valueChanged": true,
+      "note": "Light: `gray-100-75` → `gray-900-30`, fix"
+    },
+    {
+      "old": "wb/txt-primary-white",
+      "new": "wb/ui/text/onaccent-default",
+      "oldCss": "--ax-txt-primary-white",
+      "newCss": "--wb-ui-text-onaccent-default"
+    },
+    {
+      "old": "wb/txt-secondary-default",
+      "new": "wb/ui/text/subtle-default",
+      "oldCss": "--ax-txt-secondary-default",
+      "newCss": "--wb-ui-text-subtle-default"
+    },
+    {
+      "old": "wb/txt-secondary-inverse",
+      "new": "wb/ui/text/inverse-subtle-default",
+      "oldCss": "--ax-txt-secondary-inverse",
+      "newCss": "--wb-ui-text-inverse-subtle-default"
+    },
+    {
+      "old": "wb/txt-tertiary-default",
+      "new": "wb/ui/text/muted-default",
+      "oldCss": "--ax-txt-tertiary-default",
+      "newCss": "--wb-ui-text-muted-default"
+    },
+    {
+      "old": "wb/txt-quaternary-default",
+      "new": "wb/ui/text/ghost-default",
+      "oldCss": "--ax-txt-quaternary-default",
+      "newCss": "--wb-ui-text-ghost-default"
+    },
+    {
+      "old": "wb/txt-tooltip-bw",
+      "new": "wb/ui/text/tooltip-default",
+      "oldCss": "--ax-txt-tooltip-bw",
+      "newCss": "--wb-ui-text-tooltip-default"
+    },
+    {
+      "old": "wb/txt-tooltip-blue",
+      "new": "wb/ui/text/tooltip-accent-default",
+      "oldCss": "--ax-txt-tooltip-blue",
+      "newCss": "--wb-ui-text-tooltip-accent-default"
+    },
+    {
+      "old": "wb/txt-ghost-primary-default",
+      "new": "wb/ui/text/action-default",
+      "oldCss": "--ax-txt-ghost-primary-default",
+      "newCss": "--wb-ui-text-action-default",
+      "valueChanged": true,
+      "note": "brand `#3969FF`"
+    },
+    {
+      "old": "wb/txt-ghost-primary-disabled",
+      "new": "wb/ui/text/action-disabled",
+      "oldCss": "--ax-txt-ghost-primary-disabled",
+      "newCss": "--wb-ui-text-action-disabled"
+    },
+    {
+      "old": "wb/txt-error-default",
+      "new": "wb/ui/text/critical-default",
+      "oldCss": "--ax-txt-error-default",
+      "newCss": "--wb-ui-text-critical-default",
+      "valueChanged": true,
+      "note": "red refreshed"
+    },
+    {
+      "old": "wb/txt-destructive-disabled",
+      "new": "wb/ui/text/critical-disabled",
+      "oldCss": "--ax-txt-destructive-disabled",
+      "newCss": "--wb-ui-text-critical-disabled"
+    },
+    {
+      "old": "wb/txt-success-default",
+      "new": "wb/ui/text/success-default",
+      "oldCss": "--ax-txt-success-default",
+      "newCss": "--wb-ui-text-success-default",
+      "valueChanged": true,
+      "note": "green refreshed"
+    },
+    {
+      "old": "wb/txt-ghost-success-disabled",
+      "new": "wb/ui/text/success-disabled",
+      "oldCss": "--ax-txt-ghost-success-disabled",
+      "newCss": "--wb-ui-text-success-disabled"
+    },
+    {
+      "old": "wb/txt-info-default",
+      "new": "wb/ui/text/info-default",
+      "oldCss": "--ax-txt-info-default",
+      "newCss": "--wb-ui-text-info-default",
+      "valueChanged": true,
+      "note": "acc1 refreshed"
+    },
+    {
+      "old": "wb/txt-warning-default",
+      "new": "wb/ui/text/warning-default",
+      "oldCss": "--ax-txt-warning-default",
+      "newCss": "--wb-ui-text-warning-default",
+      "valueChanged": true,
+      "note": "orange refreshed"
+    },
+    {
+      "old": "wb/txt-ghost-warning-disabled",
+      "new": "wb/ui/text/warning-disabled",
+      "oldCss": "--ax-txt-ghost-warning-disabled",
+      "newCss": "--wb-ui-text-warning-disabled"
+    },
+    {
+      "old": "wb/icon-primary-default",
+      "new": "wb/ui/icon/action-default",
+      "oldCss": "--ax-icon-primary-default",
+      "newCss": "--wb-ui-icon-action-default"
+    },
+    {
+      "old": "wb/icon-txt-default",
+      "new": "wb/ui/icon/default",
+      "oldCss": "--ax-icon-txt-default",
+      "newCss": "--wb-ui-icon-default",
+      "note": "via interim `onsurface-default`, merged 2026-06-10; codeSyntax `--wb-icon-txt-default` now lives on `icon/default`"
+    },
+    {
+      "old": "wb/icon-txt-inverse",
+      "new": "wb/ui/icon/inverse-default",
+      "oldCss": "--ax-icon-txt-inverse",
+      "newCss": "--wb-ui-icon-inverse-default"
+    },
+    {
+      "old": "wb/icon-disabled",
+      "new": "wb/ui/icon/disabled",
+      "oldCss": "--ax-icon-disabled",
+      "newCss": "--wb-ui-icon-disabled"
+    },
+    {
+      "old": "wb/icon-error-default",
+      "new": "wb/ui/icon/critical-default",
+      "oldCss": "--ax-icon-error-default",
+      "newCss": "--wb-ui-icon-critical-default",
+      "valueChanged": true,
+      "note": "acc2 → red"
+    },
+    {
+      "old": "wb/icon-success-default",
+      "new": "wb/ui/icon/success-default",
+      "oldCss": "--ax-icon-success-default",
+      "newCss": "--wb-ui-icon-success-default",
+      "valueChanged": true,
+      "note": "acc3 → green"
+    },
+    {
+      "old": "wb/icon-warning-default",
+      "new": "wb/ui/icon/warning-default",
+      "oldCss": "--ax-icon-warning-default",
+      "newCss": "--wb-ui-icon-warning-default",
+      "valueChanged": true,
+      "note": "acc5 → orange"
+    },
+    {
+      "old": "wb/ui-stroke-primary-default",
+      "new": "wb/ui/stroke/default",
+      "oldCss": "--ax-ui-stroke-primary-default",
+      "newCss": "--wb-ui-stroke-default"
+    },
+    {
+      "old": "wb/ui-stroke-secondary-default",
+      "new": "wb/ui/stroke/subtle",
+      "oldCss": "--ax-ui-stroke-secondary-default",
+      "newCss": "--wb-ui-stroke-subtle"
+    },
+    {
+      "old": "wb/ui-stroke-primary-focus",
+      "new": "wb/ui/stroke/focus",
+      "oldCss": "--ax-ui-stroke-primary-focus",
+      "newCss": "--wb-ui-stroke-focus",
+      "valueChanged": true,
+      "note": "acc1 refreshed"
+    },
+    {
+      "old": "wb/ui-stroke-primary-highlight",
+      "new": "wb/ui/stroke/highlight",
+      "oldCss": "--ax-ui-stroke-primary-highlight",
+      "newCss": "--wb-ui-stroke-highlight"
+    },
+    {
+      "old": "wb/ui-separator-primary-default",
+      "new": "wb/ui/stroke/divider",
+      "oldCss": "--ax-ui-separator-primary-default",
+      "newCss": "--wb-ui-stroke-divider"
+    },
+    {
+      "old": "wb/ui-bg-primary-default",
+      "new": "wb/ui/bg/base",
+      "oldCss": "--ax-ui-bg-primary-default",
+      "newCss": "--wb-ui-bg-base"
+    },
+    {
+      "old": "wb/ui-bg-secondary-default",
+      "new": "wb/ui/bg/elevated",
+      "oldCss": "--ax-ui-bg-secondary-default",
+      "newCss": "--wb-ui-bg-elevated"
+    },
+    {
+      "old": "wb/ui-bg-tertiary-default",
+      "new": "wb/ui/bg/inset",
+      "oldCss": "--ax-ui-bg-tertiary-default",
+      "newCss": "--wb-ui-bg-inset"
+    },
+    {
+      "old": "wb/ui-canvas-dots-default",
+      "new": "wb/ui/bg/canvas-dots",
+      "oldCss": "--ax-ui-canvas-dots-default",
+      "newCss": "--wb-ui-bg-canvas-dots"
+    },
+    {
+      "old": "wb/ui-bg-tertiary-selected",
+      "new": "wb/components/selector/fill-checked",
+      "oldCss": "--ax-ui-bg-tertiary-selected",
+      "newCss": "--wb-components-selector-fill-checked"
+    },
+    {
+      "old": "wb/focus-ring-element",
+      "new": "wb/ui/focus-ring",
+      "oldCss": "--ax-focus-ring-element",
+      "newCss": "--wb-ui-focus-ring",
+      "valueChanged": true,
+      "note": "flattened single token, 2026-06-10; acc1 refreshed"
+    },
+    {
+      "old": "wb/button-primary-bg-default",
+      "new": "wb/components/button/solid/primary/default",
+      "oldCss": "--ax-button-primary-bg-default",
+      "newCss": "--wb-components-button-solid-primary-default",
+      "valueChanged": true,
+      "note": "acc1 `#3969FF`"
+    },
+    {
+      "old": "wb/button-primary-bg-hover",
+      "new": "wb/components/button/solid/primary/hover",
+      "oldCss": "--ax-button-primary-bg-hover",
+      "newCss": "--wb-components-button-solid-primary-hover",
+      "valueChanged": true,
+      "note": "acc1 `#3969FF`"
+    },
+    {
+      "old": "wb/button-primary-bg-active",
+      "new": "wb/components/button/solid/primary/active",
+      "oldCss": "--ax-button-primary-bg-active",
+      "newCss": "--wb-components-button-solid-primary-active",
+      "valueChanged": true,
+      "note": "acc1 `#3969FF`"
+    },
+    {
+      "old": "wb/button-primary-bg-focus",
+      "new": "wb/components/button/solid/primary/focus",
+      "oldCss": "--ax-button-primary-bg-focus",
+      "newCss": "--wb-components-button-solid-primary-focus",
+      "valueChanged": true,
+      "note": "acc1 `#3969FF`"
+    },
+    {
+      "old": "wb/button-primary-bg-loading",
+      "new": "wb/components/button/solid/primary/loading",
+      "oldCss": "--ax-button-primary-bg-loading",
+      "newCss": "--wb-components-button-solid-primary-loading",
+      "valueChanged": true,
+      "note": "acc1 `#3969FF`"
+    },
+    {
+      "old": "wb/button-primary-bg-disabled",
+      "new": "wb/components/button/solid/disabled",
+      "oldCss": "--ax-button-primary-bg-disabled",
+      "newCss": "--wb-components-button-solid-disabled"
+    },
+    {
+      "old": "wb/button-gray-bg-default",
+      "new": "wb/components/button/solid/gray/default",
+      "oldCss": "--ax-button-gray-bg-default",
+      "newCss": "--wb-components-button-solid-gray-default"
+    },
+    {
+      "old": "wb/button-gray-bg-hover",
+      "new": "wb/components/button/solid/gray/hover",
+      "oldCss": "--ax-button-gray-bg-hover",
+      "newCss": "--wb-components-button-solid-gray-hover"
+    },
+    {
+      "old": "wb/button-gray-bg-active",
+      "new": "wb/components/button/solid/gray/active",
+      "oldCss": "--ax-button-gray-bg-active",
+      "newCss": "--wb-components-button-solid-gray-active"
+    },
+    {
+      "old": "wb/button-gray-bg-focus",
+      "new": "wb/components/button/solid/gray/focus",
+      "oldCss": "--ax-button-gray-bg-focus",
+      "newCss": "--wb-components-button-solid-gray-focus"
+    },
+    {
+      "old": "wb/button-gray-bg-loading",
+      "new": "wb/components/button/solid/gray/loading",
+      "oldCss": "--ax-button-gray-bg-loading",
+      "newCss": "--wb-components-button-solid-gray-loading"
+    },
+    {
+      "old": "wb/button-red-bg-default",
+      "new": "wb/components/button/solid/critical/default",
+      "oldCss": "--ax-button-red-bg-default",
+      "newCss": "--wb-components-button-solid-critical-default",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-red-bg-hover",
+      "new": "wb/components/button/solid/critical/hover",
+      "oldCss": "--ax-button-red-bg-hover",
+      "newCss": "--wb-components-button-solid-critical-hover",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-red-bg-active",
+      "new": "wb/components/button/solid/critical/active",
+      "oldCss": "--ax-button-red-bg-active",
+      "newCss": "--wb-components-button-solid-critical-active",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-red-bg-focus",
+      "new": "wb/components/button/solid/critical/focus",
+      "oldCss": "--ax-button-red-bg-focus",
+      "newCss": "--wb-components-button-solid-critical-focus",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-red-bg-loading",
+      "new": "wb/components/button/solid/critical/loading",
+      "oldCss": "--ax-button-red-bg-loading",
+      "newCss": "--wb-components-button-solid-critical-loading",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-green-bg-default",
+      "new": "wb/components/button/solid/success/default",
+      "oldCss": "--ax-button-green-bg-default",
+      "newCss": "--wb-components-button-solid-success-default",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-green-bg-hover",
+      "new": "wb/components/button/solid/success/hover",
+      "oldCss": "--ax-button-green-bg-hover",
+      "newCss": "--wb-components-button-solid-success-hover",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-green-bg-active",
+      "new": "wb/components/button/solid/success/active",
+      "oldCss": "--ax-button-green-bg-active",
+      "newCss": "--wb-components-button-solid-success-active",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-green-bg-focus",
+      "new": "wb/components/button/solid/success/focus",
+      "oldCss": "--ax-button-green-bg-focus",
+      "newCss": "--wb-components-button-solid-success-focus",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-green-bg-loading",
+      "new": "wb/components/button/solid/success/loading",
+      "oldCss": "--ax-button-green-bg-loading",
+      "newCss": "--wb-components-button-solid-success-loading",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-orange-bg-default",
+      "new": "wb/components/button/solid/warning/default",
+      "oldCss": "--ax-button-orange-bg-default",
+      "newCss": "--wb-components-button-solid-warning-default",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-orange-bg-hover",
+      "new": "wb/components/button/solid/warning/hover",
+      "oldCss": "--ax-button-orange-bg-hover",
+      "newCss": "--wb-components-button-solid-warning-hover",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-orange-bg-active",
+      "new": "wb/components/button/solid/warning/active",
+      "oldCss": "--ax-button-orange-bg-active",
+      "newCss": "--wb-components-button-solid-warning-active",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-orange-bg-focus",
+      "new": "wb/components/button/solid/warning/focus",
+      "oldCss": "--ax-button-orange-bg-focus",
+      "newCss": "--wb-components-button-solid-warning-focus",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-orange-bg-loading",
+      "new": "wb/components/button/solid/warning/loading",
+      "oldCss": "--ax-button-orange-bg-loading",
+      "newCss": "--wb-components-button-solid-warning-loading",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-ghost-primary-bg-default",
+      "new": "wb/components/button/ghost/primary/default",
+      "oldCss": "--ax-button-ghost-primary-bg-default",
+      "newCss": "--wb-components-button-ghost-primary-default",
+      "valueChanged": true,
+      "note": "primary now flows through `brand/*`, acc1 refreshed"
+    },
+    {
+      "old": "wb/button-ghost-primary-bg-hover",
+      "new": "wb/components/button/ghost/primary/hover",
+      "oldCss": "--ax-button-ghost-primary-bg-hover",
+      "newCss": "--wb-components-button-ghost-primary-hover",
+      "valueChanged": true,
+      "note": "primary now flows through `brand/*`, acc1 refreshed"
+    },
+    {
+      "old": "wb/button-ghost-primary-bg-active",
+      "new": "wb/components/button/ghost/primary/active",
+      "oldCss": "--ax-button-ghost-primary-bg-active",
+      "newCss": "--wb-components-button-ghost-primary-active",
+      "valueChanged": true,
+      "note": "primary now flows through `brand/*`, acc1 refreshed"
+    },
+    {
+      "old": "wb/button-ghost-primary-bg-focus",
+      "new": "wb/components/button/ghost/primary/focus",
+      "oldCss": "--ax-button-ghost-primary-bg-focus",
+      "newCss": "--wb-components-button-ghost-primary-focus",
+      "valueChanged": true,
+      "note": "primary now flows through `brand/*`, acc1 refreshed"
+    },
+    {
+      "old": "wb/button-ghost-primary-bg-loading",
+      "new": "wb/components/button/ghost/primary/loading",
+      "oldCss": "--ax-button-ghost-primary-bg-loading",
+      "newCss": "--wb-components-button-ghost-primary-loading",
+      "valueChanged": true,
+      "note": "primary now flows through `brand/*`, acc1 refreshed"
+    },
+    {
+      "old": "wb/button-ghost-primary-bg-disabled",
+      "new": "wb/components/button/ghost/primary/disabled",
+      "oldCss": "--ax-button-ghost-primary-bg-disabled",
+      "newCss": "--wb-components-button-ghost-primary-disabled",
+      "valueChanged": true,
+      "note": "primary now flows through `brand/*`, acc1 refreshed"
+    },
+    {
+      "old": "wb/button-ghost-primary-stroke-default",
+      "new": "wb/components/button/ghost/primary/stroke-default",
+      "oldCss": "--ax-button-ghost-primary-stroke-default",
+      "newCss": "--wb-components-button-ghost-primary-stroke-default",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/button-ghost-success-bg-default",
+      "new": "wb/components/button/ghost/success/default",
+      "oldCss": "--ax-button-ghost-success-bg-default",
+      "newCss": "--wb-components-button-ghost-success-default"
+    },
+    {
+      "old": "wb/button-ghost-success-bg-hover",
+      "new": "wb/components/button/ghost/success/hover",
+      "oldCss": "--ax-button-ghost-success-bg-hover",
+      "newCss": "--wb-components-button-ghost-success-hover"
+    },
+    {
+      "old": "wb/button-ghost-success-bg-active",
+      "new": "wb/components/button/ghost/success/active",
+      "oldCss": "--ax-button-ghost-success-bg-active",
+      "newCss": "--wb-components-button-ghost-success-active"
+    },
+    {
+      "old": "wb/button-ghost-success-bg-focus",
+      "new": "wb/components/button/ghost/success/focus",
+      "oldCss": "--ax-button-ghost-success-bg-focus",
+      "newCss": "--wb-components-button-ghost-success-focus"
+    },
+    {
+      "old": "wb/button-ghost-success-bg-loading",
+      "new": "wb/components/button/ghost/success/loading",
+      "oldCss": "--ax-button-ghost-success-bg-loading",
+      "newCss": "--wb-components-button-ghost-success-loading"
+    },
+    {
+      "old": "wb/button-ghost-success-bg-disabled",
+      "new": "wb/components/button/ghost/success/disabled",
+      "oldCss": "--ax-button-ghost-success-bg-disabled",
+      "newCss": "--wb-components-button-ghost-success-disabled"
+    },
+    {
+      "old": "wb/button-ghost-success-stroke-default",
+      "new": "wb/components/button/ghost/success/stroke-default",
+      "oldCss": "--ax-button-ghost-success-stroke-default",
+      "newCss": "--wb-components-button-ghost-success-stroke-default"
+    },
+    {
+      "old": "wb/button-ghost-warning-bg-default",
+      "new": "wb/components/button/ghost/warning/default",
+      "oldCss": "--ax-button-ghost-warning-bg-default",
+      "newCss": "--wb-components-button-ghost-warning-default"
+    },
+    {
+      "old": "wb/button-ghost-warning-bg-hover",
+      "new": "wb/components/button/ghost/warning/hover",
+      "oldCss": "--ax-button-ghost-warning-bg-hover",
+      "newCss": "--wb-components-button-ghost-warning-hover"
+    },
+    {
+      "old": "wb/button-ghost-warning-bg-active",
+      "new": "wb/components/button/ghost/warning/active",
+      "oldCss": "--ax-button-ghost-warning-bg-active",
+      "newCss": "--wb-components-button-ghost-warning-active"
+    },
+    {
+      "old": "wb/button-ghost-warning-bg-focus",
+      "new": "wb/components/button/ghost/warning/focus",
+      "oldCss": "--ax-button-ghost-warning-bg-focus",
+      "newCss": "--wb-components-button-ghost-warning-focus"
+    },
+    {
+      "old": "wb/button-ghost-warning-bg-loading",
+      "new": "wb/components/button/ghost/warning/loading",
+      "oldCss": "--ax-button-ghost-warning-bg-loading",
+      "newCss": "--wb-components-button-ghost-warning-loading"
+    },
+    {
+      "old": "wb/button-ghost-warning-bg-disabled",
+      "new": "wb/components/button/ghost/warning/disabled",
+      "oldCss": "--ax-button-ghost-warning-bg-disabled",
+      "newCss": "--wb-components-button-ghost-warning-disabled"
+    },
+    {
+      "old": "wb/button-ghost-warning-stroke-default",
+      "new": "wb/components/button/ghost/warning/stroke-default",
+      "oldCss": "--ax-button-ghost-warning-stroke-default",
+      "newCss": "--wb-components-button-ghost-warning-stroke-default"
+    },
+    {
+      "old": "wb/button-ghost-destructive-bg-default",
+      "new": "wb/components/button/ghost/critical/default",
+      "oldCss": "--ax-button-ghost-destructive-bg-default",
+      "newCss": "--wb-components-button-ghost-critical-default"
+    },
+    {
+      "old": "wb/button-ghost-destructive-bg-hover",
+      "new": "wb/components/button/ghost/critical/hover",
+      "oldCss": "--ax-button-ghost-destructive-bg-hover",
+      "newCss": "--wb-components-button-ghost-critical-hover"
+    },
+    {
+      "old": "wb/button-ghost-destructive-bg-active",
+      "new": "wb/components/button/ghost/critical/active",
+      "oldCss": "--ax-button-ghost-destructive-bg-active",
+      "newCss": "--wb-components-button-ghost-critical-active"
+    },
+    {
+      "old": "wb/button-ghost-destructive-bg-focus",
+      "new": "wb/components/button/ghost/critical/focus",
+      "oldCss": "--ax-button-ghost-destructive-bg-focus",
+      "newCss": "--wb-components-button-ghost-critical-focus"
+    },
+    {
+      "old": "wb/button-ghost-destructive-bg-loading",
+      "new": "wb/components/button/ghost/critical/loading",
+      "oldCss": "--ax-button-ghost-destructive-bg-loading",
+      "newCss": "--wb-components-button-ghost-critical-loading"
+    },
+    {
+      "old": "wb/button-ghost-destructive-bg-disabled",
+      "new": "wb/components/button/ghost/critical/disabled",
+      "oldCss": "--ax-button-ghost-destructive-bg-disabled",
+      "newCss": "--wb-components-button-ghost-critical-disabled"
+    },
+    {
+      "old": "wb/button-ghost-destructive-stroke-default",
+      "new": "wb/components/button/ghost/critical/stroke-default",
+      "oldCss": "--ax-button-ghost-destructive-stroke-default",
+      "newCss": "--wb-components-button-ghost-critical-stroke-default"
+    },
+    {
+      "old": "wb/input-stroke-primary-default",
+      "new": "wb/components/text-field/stroke-default",
+      "oldCss": "--ax-input-stroke-primary-default",
+      "newCss": "--wb-components-text-field-stroke-default"
+    },
+    {
+      "old": "wb/input-stroke-primary-focus",
+      "new": "wb/components/text-field/stroke-focus",
+      "oldCss": "--ax-input-stroke-primary-focus",
+      "newCss": "--wb-components-text-field-stroke-focus",
+      "valueChanged": true,
+      "note": "acc1 refreshed"
+    },
+    {
+      "old": "wb/input-stroke-primary-error",
+      "new": "wb/components/text-field/stroke-critical",
+      "oldCss": "--ax-input-stroke-primary-error",
+      "newCss": "--wb-components-text-field-stroke-critical",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/input-stroke-primary-success",
+      "new": "wb/components/text-field/stroke-success",
+      "oldCss": "--ax-input-stroke-primary-success",
+      "newCss": "--wb-components-text-field-stroke-success",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/input-bg-primary-error",
+      "new": "wb/components/text-field/bg-primary-critical",
+      "oldCss": "--ax-input-bg-primary-error",
+      "newCss": "--wb-components-text-field-bg-primary-critical",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/input-bg-primary-success",
+      "new": "wb/components/text-field/bg-primary-success",
+      "oldCss": "--ax-input-bg-primary-success",
+      "newCss": "--wb-components-text-field-bg-primary-success",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/nav-button-bg-primary-hover",
+      "new": "wb/components/nav-button/bg-primary-hover",
+      "oldCss": "--ax-nav-button-bg-primary-hover",
+      "newCss": "--wb-components-nav-button-bg-primary-hover",
+      "note": "see section 10 — this one old token split into three new state tokens"
+    },
+    {
+      "old": "wb/nav-button-icon-primary-default",
+      "new": "wb/components/nav-button/icon-primary-default",
+      "oldCss": "--ax-nav-button-icon-primary-default",
+      "newCss": "--wb-components-nav-button-icon-primary-default",
+      "valueChanged": true,
+      "note": "pressed: brand `#3969FF`"
+    },
+    {
+      "old": "wb/nav-button-icon-primary-hover",
+      "new": "wb/components/nav-button/icon-primary-hover",
+      "oldCss": "--ax-nav-button-icon-primary-hover",
+      "newCss": "--wb-components-nav-button-icon-primary-hover",
+      "valueChanged": true,
+      "note": "pressed: brand `#3969FF`"
+    },
+    {
+      "old": "wb/nav-button-icon-primary-active",
+      "new": "wb/components/nav-button/icon-primary-active",
+      "oldCss": "--ax-nav-button-icon-primary-active",
+      "newCss": "--wb-components-nav-button-icon-primary-active",
+      "valueChanged": true,
+      "note": "pressed: brand `#3969FF`"
+    },
+    {
+      "old": "wb/nav-button-icon-primary-pressed",
+      "new": "wb/components/nav-button/icon-primary-pressed",
+      "oldCss": "--ax-nav-button-icon-primary-pressed",
+      "newCss": "--wb-components-nav-button-icon-primary-pressed",
+      "valueChanged": true,
+      "note": "pressed: brand `#3969FF`"
+    },
+    {
+      "old": "wb/nav-button-icon-primary-disabled",
+      "new": "wb/components/nav-button/icon-primary-disabled",
+      "oldCss": "--ax-nav-button-icon-primary-disabled",
+      "newCss": "--wb-components-nav-button-icon-primary-disabled",
+      "valueChanged": true,
+      "note": "pressed: brand `#3969FF`"
+    },
+    {
+      "old": "wb/snackbar-bg-information",
+      "new": "wb/components/snackbar/bg-info",
+      "oldCss": "--ax-snackbar-bg-information",
+      "newCss": "--wb-components-snackbar-bg-info"
+    },
+    {
+      "old": "wb/snackbar-bg-warning",
+      "new": "wb/components/snackbar/bg-warning",
+      "oldCss": "--ax-snackbar-bg-warning",
+      "newCss": "--wb-components-snackbar-bg-warning"
+    },
+    {
+      "old": "wb/snackbar-bg-success",
+      "new": "wb/components/snackbar/bg-success",
+      "oldCss": "--ax-snackbar-bg-success",
+      "newCss": "--wb-components-snackbar-bg-success"
+    },
+    {
+      "old": "wb/snackbar-bg-error",
+      "new": "wb/components/snackbar/bg-critical",
+      "oldCss": "--ax-snackbar-bg-error",
+      "newCss": "--wb-components-snackbar-bg-critical"
+    },
+    {
+      "old": "wb/dropzone-bg-default",
+      "new": "wb/components/dropzone/bg-default",
+      "oldCss": "--ax-dropzone-bg-default",
+      "newCss": "--wb-components-dropzone-bg-default"
+    },
+    {
+      "old": "wb/dropzone-bg-hover",
+      "new": "wb/components/dropzone/bg-hover",
+      "oldCss": "--ax-dropzone-bg-hover",
+      "newCss": "--wb-components-dropzone-bg-hover"
+    },
+    {
+      "old": "wb/dropzone-bg-dragging",
+      "new": "wb/components/dropzone/bg-dragging",
+      "oldCss": "--ax-dropzone-bg-dragging",
+      "newCss": "--wb-components-dropzone-bg-dragging"
+    },
+    {
+      "old": "wb/dropzone-bg-error",
+      "new": "wb/components/dropzone/bg-critical",
+      "oldCss": "--ax-dropzone-bg-error",
+      "newCss": "--wb-components-dropzone-bg-critical"
+    },
+    {
+      "old": "wb/dropzone-stroke-default",
+      "new": "wb/components/dropzone/stroke-default",
+      "oldCss": "--ax-dropzone-stroke-default",
+      "newCss": "--wb-components-dropzone-stroke-default"
+    },
+    {
+      "old": "wb/dropzone-stroke-hover",
+      "new": "wb/components/dropzone/stroke-hover",
+      "oldCss": "--ax-dropzone-stroke-hover",
+      "newCss": "--wb-components-dropzone-stroke-hover"
+    },
+    {
+      "old": "wb/dropzone-stroke-dragging",
+      "new": "wb/components/dropzone/stroke-dragging",
+      "oldCss": "--ax-dropzone-stroke-dragging",
+      "newCss": "--wb-components-dropzone-stroke-dragging"
+    },
+    {
+      "old": "wb/dropzone-stroke-error",
+      "new": "wb/components/dropzone/stroke-critical",
+      "oldCss": "--ax-dropzone-stroke-error",
+      "newCss": "--wb-components-dropzone-stroke-critical"
+    },
+    {
+      "old": "wb/tooltip-bg-default",
+      "new": "wb/components/tooltip/bg-default",
+      "oldCss": "--ax-tooltip-bg-default",
+      "newCss": "--wb-components-tooltip-bg-default"
+    },
+    {
+      "old": "wb/tooltip-bg-blue",
+      "new": "wb/components/tooltip/bg-info",
+      "oldCss": "--ax-tooltip-bg-blue",
+      "newCss": "--wb-components-tooltip-bg-info",
+      "valueChanged": true,
+      "note": "no more literal color in the name; acc1 refreshed"
+    },
+    {
+      "old": "wb/pt-bg-primary-default",
+      "new": "wb/components/tour/bg-primary-default",
+      "oldCss": "--ax-pt-bg-primary-default",
+      "newCss": "--wb-components-tour-bg-primary-default"
+    },
+    {
+      "old": "wb/pt-stroke-primary-default",
+      "new": "wb/components/tour/stroke-default",
+      "oldCss": "--ax-pt-stroke-primary-default",
+      "newCss": "--wb-components-tour-stroke-default"
+    },
+    {
+      "old": "wb/tab-stroke-default",
+      "new": "wb/components/tab/stroke-default",
+      "oldCss": "--ax-tab-stroke-default",
+      "newCss": "--wb-components-tab-stroke-default"
+    },
+    {
+      "old": "wb/tab-stroke-hover",
+      "new": "wb/components/tab/stroke-hover",
+      "oldCss": "--ax-tab-stroke-hover",
+      "newCss": "--wb-components-tab-stroke-hover"
+    },
+    {
+      "old": "wb/tab-stroke-active",
+      "new": "wb/components/tab/stroke-active",
+      "oldCss": "--ax-tab-stroke-active",
+      "newCss": "--wb-components-tab-stroke-active"
+    },
+    {
+      "old": "wb/avatar-fill-default",
+      "new": "wb/components/avatar/fill-default",
+      "oldCss": "--ax-avatar-fill-default",
+      "newCss": "--wb-components-avatar-fill-default"
+    },
+    {
+      "old": "wb/avatar-stroke-default",
+      "new": "wb/components/avatar/stroke-default",
+      "oldCss": "--ax-avatar-stroke-default",
+      "newCss": "--wb-components-avatar-stroke-default"
+    },
+    {
+      "old": "wb/datepicker-bg-primary",
+      "new": "wb/components/datepicker/bg-primary",
+      "oldCss": "--ax-datepicker-bg-primary",
+      "newCss": "--wb-components-datepicker-bg-primary",
+      "valueChanged": true,
+      "note": "acc1-600 → acc1-500, plus acc1 refreshed"
+    },
+    {
+      "old": "wb/datepicker-bg-secondary",
+      "new": "wb/components/datepicker/bg-secondary",
+      "oldCss": "--ax-datepicker-bg-secondary",
+      "newCss": "--wb-components-datepicker-bg-secondary"
+    },
+    {
+      "old": "wb/scrollbar-bg-default",
+      "new": "wb/components/scrollbar/bg-default",
+      "oldCss": "--ax-scrollbar-bg-default",
+      "newCss": "--wb-components-scrollbar-bg-default"
+    },
+    {
+      "old": "wb/chips-neutral-txt",
+      "new": "wb/components/chips/solid-text",
+      "oldCss": "--ax-chips-neutral-txt",
+      "newCss": "--wb-components-chips-solid-text"
+    },
+    {
+      "old": "wb/badge-notify-error-bg-default",
+      "new": "wb/canvas/badge-notify/critical-bg-default",
+      "oldCss": "--ax-badge-notify-error-bg-default",
+      "newCss": "--wb-canvas-badge-notify-critical-bg-default"
+    },
+    {
+      "old": "wb/badge-notify-error-ico-default",
+      "new": "wb/canvas/badge-notify/critical-icon",
+      "oldCss": "--ax-badge-notify-error-ico-default",
+      "newCss": "--wb-canvas-badge-notify-critical-icon",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/badge-notify-success-bg-default",
+      "new": "wb/canvas/badge-notify/success-bg-default",
+      "oldCss": "--ax-badge-notify-success-bg-default",
+      "newCss": "--wb-canvas-badge-notify-success-bg-default",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/badge-notify-success-ico-default",
+      "new": "wb/canvas/badge-notify/success-icon",
+      "oldCss": "--ax-badge-notify-success-ico-default",
+      "newCss": "--wb-canvas-badge-notify-success-icon",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/badge-notify-warning-bg-default",
+      "new": "wb/canvas/badge-notify/warning-bg-default",
+      "oldCss": "--ax-badge-notify-warning-bg-default",
+      "newCss": "--wb-canvas-badge-notify-warning-bg-default",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/badge-notify-warning-ico-default",
+      "new": "wb/canvas/badge-notify/warning-icon",
+      "oldCss": "--ax-badge-notify-warning-ico-default",
+      "newCss": "--wb-canvas-badge-notify-warning-icon",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/widget-swatches-acc1",
+      "new": "wb/canvas/widget-swatches/acc1",
+      "oldCss": "--ax-widget-swatches-acc1",
+      "newCss": "--wb-canvas-widget-swatches-acc1"
+    },
+    {
+      "old": "wb/widget-swatches-acc2",
+      "new": "wb/canvas/widget-swatches/acc2",
+      "oldCss": "--ax-widget-swatches-acc2",
+      "newCss": "--wb-canvas-widget-swatches-acc2"
+    },
+    {
+      "old": "wb/widget-swatches-acc3",
+      "new": "wb/canvas/widget-swatches/acc3",
+      "oldCss": "--ax-widget-swatches-acc3",
+      "newCss": "--wb-canvas-widget-swatches-acc3"
+    },
+    {
+      "old": "wb/widget-swatches-acc4",
+      "new": "wb/canvas/widget-swatches/acc4",
+      "oldCss": "--ax-widget-swatches-acc4",
+      "newCss": "--wb-canvas-widget-swatches-acc4"
+    },
+    {
+      "old": "wb/widget-swatches-acc5",
+      "new": "wb/canvas/widget-swatches/acc5",
+      "oldCss": "--ax-widget-swatches-acc5",
+      "newCss": "--wb-canvas-widget-swatches-acc5"
+    },
+    {
+      "old": "wb/widget-swatches-acc6",
+      "new": "wb/canvas/widget-swatches/acc6",
+      "oldCss": "--ax-widget-swatches-acc6",
+      "newCss": "--wb-canvas-widget-swatches-acc6"
+    },
+    {
+      "old": "wb/focus-ring-node-active",
+      "new": "wb/canvas/node/focus-active",
+      "oldCss": "--ax-focus-ring-node-active",
+      "newCss": "--wb-canvas-node-focus-active",
+      "valueChanged": true,
+      "note": "acc1 refreshed"
+    },
+    {
+      "old": "wb/focus-ring-node-error",
+      "new": "wb/canvas/node/focus-critical",
+      "oldCss": "--ax-focus-ring-node-error",
+      "newCss": "--wb-canvas-node-focus-critical",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/focus-ring-node-success",
+      "new": "wb/canvas/node/focus-success",
+      "oldCss": "--ax-focus-ring-node-success",
+      "newCss": "--wb-canvas-node-focus-success",
+      "valueChanged": true
+    },
+    {
+      "old": "wb/focus-ring-node-warning",
+      "new": "wb/canvas/node/focus-warning",
+      "oldCss": "--ax-focus-ring-node-warning",
+      "newCss": "--wb-canvas-node-focus-warning",
+      "valueChanged": true
+    }
+  ],
+  "removed": [
+    {
+      "old": "wb/dropdown-bg-primary-default",
+      "replacement": "wb/ui/bg/base",
+      "oldCss": "--ax-dropdown-bg-primary-default",
+      "replacementCss": "--wb-ui-bg-base",
+      "note": "dropdown panels"
+    },
+    {
+      "old": "wb/dropdown-bg-secondary-default",
+      "replacement": "wb/ui/bg/inset",
+      "oldCss": "--ax-dropdown-bg-secondary-default",
+      "replacementCss": "--wb-ui-bg-inset",
+      "note": "embedded options"
+    },
+    {
+      "old": "wb/node-bg-primary-default",
+      "replacement": "wb/canvas/node/bg-primary-default",
+      "oldCss": "--ax-node-bg-primary-default",
+      "replacementCss": "--wb-canvas-node-bg-primary-default",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-bg-primary-hover",
+      "replacement": "wb/canvas/node/bg-primary-hover",
+      "oldCss": "--ax-node-bg-primary-hover",
+      "replacementCss": "--wb-canvas-node-bg-primary-hover",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-bg-primary-active",
+      "replacement": "wb/canvas/node/bg-primary-active",
+      "oldCss": "--ax-node-bg-primary-active",
+      "replacementCss": "--wb-canvas-node-bg-primary-active",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-bg-primary-disabled",
+      "replacement": "wb/canvas/node/bg-primary-disabled",
+      "oldCss": "--ax-node-bg-primary-disabled",
+      "replacementCss": "--wb-canvas-node-bg-primary-disabled",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-bg-secondary-default",
+      "replacement": "wb/canvas/node/bg-secondary-default",
+      "oldCss": "--ax-node-bg-secondary-default",
+      "replacementCss": "--wb-canvas-node-bg-secondary-default",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-stroke-primary-default",
+      "replacement": "wb/canvas/node/stroke-default",
+      "oldCss": "--ax-node-stroke-primary-default",
+      "replacementCss": "--wb-canvas-node-stroke-default",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-stroke-primary-hover",
+      "replacement": "wb/canvas/node/stroke-hover",
+      "oldCss": "--ax-node-stroke-primary-hover",
+      "replacementCss": "--wb-canvas-node-stroke-hover",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-icon-primary-default",
+      "replacement": "wb/canvas/node/icon-primary",
+      "oldCss": "--ax-node-icon-primary-default",
+      "replacementCss": "--wb-canvas-node-icon-primary",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-icon-primary-disabled",
+      "replacement": "wb/ui/icon/disabled",
+      "oldCss": "--ax-node-icon-primary-disabled",
+      "replacementCss": "--wb-ui-icon-disabled",
+      "rebuilt": true,
+      "note": "none — handled by `wb/ui/icon/disabled`"
+    },
+    {
+      "old": "wb/node-txt-disabled",
+      "replacement": "wb/canvas/node/text-disabled",
+      "oldCss": "--ax-node-txt-disabled",
+      "replacementCss": "--wb-canvas-node-text-disabled",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-port-fill-default",
+      "replacement": "wb/canvas/port/fill-default",
+      "oldCss": "--ax-node-port-fill-default",
+      "replacementCss": "--wb-canvas-port-fill-default",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-port-fill-active",
+      "replacement": "wb/canvas/port/fill-active",
+      "oldCss": "--ax-node-port-fill-active",
+      "replacementCss": "--wb-canvas-port-fill-active",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-port-stroke-default",
+      "replacement": "wb/canvas/port/stroke-default",
+      "oldCss": "--ax-node-port-stroke-default",
+      "replacementCss": "--wb-canvas-port-stroke-default",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/node-port-stroke-active",
+      "replacement": "wb/canvas/port/stroke-active",
+      "oldCss": "--ax-node-port-stroke-active",
+      "replacementCss": "--wb-canvas-port-stroke-active",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/edge-primary-default",
+      "replacement": "wb/canvas/edge/stroke-default",
+      "oldCss": "--ax-edge-primary-default",
+      "replacementCss": "--wb-canvas-edge-stroke-default",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/edge-primary-hover",
+      "replacement": "wb/canvas/edge/stroke-hover",
+      "oldCss": "--ax-edge-primary-hover",
+      "replacementCss": "--wb-canvas-edge-stroke-hover",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/edge-primary-active",
+      "replacement": "wb/canvas/edge/stroke-active",
+      "oldCss": "--ax-edge-primary-active",
+      "replacementCss": "--wb-canvas-edge-stroke-active",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/edge-primary-disabled",
+      "replacement": "wb/canvas/edge/stroke-disabled",
+      "oldCss": "--ax-edge-primary-disabled",
+      "replacementCss": "--wb-canvas-edge-stroke-disabled",
+      "rebuilt": true
+    },
+    {
+      "old": "wb/edge-primary-error",
+      "replacement": "wb/canvas/edge/stroke-critical",
+      "oldCss": "--ax-edge-primary-error",
+      "replacementCss": "--wb-canvas-edge-stroke-critical",
+      "rebuilt": true,
+      "valueChanged": true
+    },
+    {
+      "old": "wb/edge-primary-success",
+      "replacement": "wb/canvas/edge/stroke-success",
+      "oldCss": "--ax-edge-primary-success",
+      "replacementCss": "--wb-canvas-edge-stroke-success",
+      "rebuilt": true,
+      "valueChanged": true
+    },
+    {
+      "old": "wb/edge-primary-warning",
+      "replacement": "wb/canvas/edge/stroke-warning",
+      "oldCss": "--ax-edge-primary-warning",
+      "replacementCss": "--wb-canvas-edge-stroke-warning",
+      "rebuilt": true,
+      "valueChanged": true
+    },
+    {
+      "old": "wb/shadow",
+      "replacement": "wb/shadow/ui/color",
+      "oldCss": "--ax-shadow",
+      "replacementCss": "--wb-shadow-ui-color"
+    },
+    {
+      "old": "wb/snackbar-bg-default",
+      "replacement": "snackbar/stroke-*",
+      "oldCss": "--ax-snackbar-bg-default",
+      "replacementCss": "--wb-snackbar-stroke"
+    },
+    {
+      "old": "wb/tab-stroke-line",
+      "replacement": "wb/ui/stroke/*",
+      "oldCss": "--ax-tab-stroke-line",
+      "replacementCss": "--wb-ui-stroke"
+    },
+    {
+      "old": "wb/icon-black",
+      "replacement": "wb/ui/icon/default",
+      "oldCss": "--ax-icon-black",
+      "replacementCss": "--wb-ui-icon-default"
+    },
+    {
+      "old": "wb/icon-white",
+      "replacement": "wb/ui/icon/default",
+      "oldCss": "--ax-icon-white",
+      "replacementCss": "--wb-ui-icon-default"
+    },
+    {
+      "old": "wb/dropdown-bg-destructive-default",
+      "replacement": null,
+      "oldCss": "--ax-dropdown-bg-destructive-default",
+      "replacementCss": null
+    },
+    {
+      "old": "wb/dropdown-bg-destructive-hover",
+      "replacement": null,
+      "oldCss": "--ax-dropdown-bg-destructive-hover",
+      "replacementCss": null
+    },
+    {
+      "old": "wb/dropdown-bg-secondary-active",
+      "replacement": null,
+      "oldCss": "--ax-dropdown-bg-secondary-active",
+      "replacementCss": null
+    },
+    {
+      "old": "wb/button-gray-bg-disabled",
+      "replacement": "wb/components/button/solid/disabled",
+      "oldCss": "--ax-button-gray-bg-disabled",
+      "replacementCss": "--wb-components-button-solid-disabled"
+    },
+    {
+      "old": "wb/button-green-bg-disabled",
+      "replacement": "wb/components/button/solid/disabled",
+      "oldCss": "--ax-button-green-bg-disabled",
+      "replacementCss": "--wb-components-button-solid-disabled"
+    },
+    {
+      "old": "wb/button-red-bg-disabled",
+      "replacement": "wb/components/button/solid/disabled",
+      "oldCss": "--ax-button-red-bg-disabled",
+      "replacementCss": "--wb-components-button-solid-disabled"
+    },
+    {
+      "old": "wb/txt-destuctive-default",
+      "replacement": "txt-error-default",
+      "oldCss": "--ax-txt-destuctive-default",
+      "replacementCss": "--wb-txt-error-default",
+      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling"
+    },
+    {
+      "old": "1592:58782",
+      "replacement": "txt-error-default",
+      "oldCss": "--ax-1592-58782",
+      "replacementCss": "--wb-txt-error-default",
+      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling"
+    },
+    {
+      "old": "wb/txt-destructive-default",
+      "replacement": "txt-error-default",
+      "oldCss": "--ax-txt-destructive-default",
+      "replacementCss": "--wb-txt-error-default",
+      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling"
+    },
+    {
+      "old": "wb/ui/icon/onsurface-default",
+      "replacement": "wb/ui/icon/default",
+      "oldCss": "--ax-ui-icon-onsurface-default",
+      "replacementCss": "--wb-ui-icon-default",
+      "note": "2026-06-10"
+    }
+  ],
+  "dimensions": [],
+  "unparsed": []
+}

--- a/packages/tokens/codemod-map.json
+++ b/packages/tokens/codemod-map.json
@@ -11,10 +11,6 @@
     {
       "pattern": "--ax-chips-*",
       "reason": "Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task."
-    },
-    {
-      "pattern": "--ax-nav-button-bg-primary-hover",
-      "reason": "One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task."
     }
   ],
   "renames": [
@@ -679,7 +675,6 @@
       "new": "wb/components/nav-button/icon-primary-default",
       "oldCss": "--ax-nav-button-icon-primary-default",
       "newCss": "--wb-components-nav-button-icon-primary-default",
-      "valueChanged": true,
       "note": "pressed: brand `#3969FF`"
     },
     {
@@ -687,7 +682,6 @@
       "new": "wb/components/nav-button/icon-primary-hover",
       "oldCss": "--ax-nav-button-icon-primary-hover",
       "newCss": "--wb-components-nav-button-icon-primary-hover",
-      "valueChanged": true,
       "note": "pressed: brand `#3969FF`"
     },
     {
@@ -695,7 +689,6 @@
       "new": "wb/components/nav-button/icon-primary-active",
       "oldCss": "--ax-nav-button-icon-primary-active",
       "newCss": "--wb-components-nav-button-icon-primary-active",
-      "valueChanged": true,
       "note": "pressed: brand `#3969FF`"
     },
     {
@@ -711,7 +704,6 @@
       "new": "wb/components/nav-button/icon-primary-disabled",
       "oldCss": "--ax-nav-button-icon-primary-disabled",
       "newCss": "--wb-components-nav-button-icon-primary-disabled",
-      "valueChanged": true,
       "note": "pressed: brand `#3969FF`"
     },
     {
@@ -1149,27 +1141,30 @@
     },
     {
       "old": "wb/snackbar-bg-default",
-      "replacement": "snackbar/stroke-*",
+      "replacement": null,
       "oldCss": "--ax-snackbar-bg-default",
-      "replacementCss": "--wb-snackbar-stroke"
+      "replacementCss": null
     },
     {
       "old": "wb/tab-stroke-line",
-      "replacement": "wb/ui/stroke/*",
+      "replacement": null,
       "oldCss": "--ax-tab-stroke-line",
-      "replacementCss": "--wb-ui-stroke"
+      "replacementCss": null
     },
     {
       "old": "wb/icon-black",
       "replacement": "wb/ui/icon/default",
       "oldCss": "--ax-icon-black",
-      "replacementCss": "--wb-ui-icon-default"
+      "replacementCss": "--wb-ui-icon-default",
+      "resolvedByHand": true
     },
     {
       "old": "wb/icon-white",
-      "replacement": "wb/ui/icon/default",
+      "replacement": "wb/ui/icon/onaccent-default",
       "oldCss": "--ax-icon-white",
-      "replacementCss": "--wb-ui-icon-default"
+      "replacementCss": "--wb-ui-icon-onaccent-default",
+      "resolvedByHand": true,
+      "note": "onaccent icon token — verify the exact name against the 2.0 export"
     },
     {
       "old": "wb/dropdown-bg-destructive-default",
@@ -1209,31 +1204,27 @@
     },
     {
       "old": "wb/txt-destuctive-default",
-      "replacement": "txt-error-default",
+      "replacement": "wb/ui/text/critical-default",
       "oldCss": "--ax-txt-destuctive-default",
-      "replacementCss": "--wb-txt-error-default",
-      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling"
-    },
-    {
-      "old": "1592:58782",
-      "replacement": "txt-error-default",
-      "oldCss": "--ax-1592-58782",
-      "replacementCss": "--wb-txt-error-default",
-      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling"
+      "replacementCss": "--wb-ui-text-critical-default",
+      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling",
+      "resolvedByHand": true
     },
     {
       "old": "wb/txt-destructive-default",
-      "replacement": "txt-error-default",
+      "replacement": "wb/ui/text/critical-default",
       "oldCss": "--ax-txt-destructive-default",
-      "replacementCss": "--wb-txt-error-default",
-      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling"
+      "replacementCss": "--wb-ui-text-critical-default",
+      "note": "ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling",
+      "resolvedByHand": true
     },
     {
       "old": "wb/ui/icon/onsurface-default",
       "replacement": "wb/ui/icon/default",
       "oldCss": "--ax-ui-icon-onsurface-default",
       "replacementCss": "--wb-ui-icon-default",
-      "note": "2026-06-10"
+      "note": "2026-06-10",
+      "resolvedByHand": true
     }
   ],
   "dimensions": [],

--- a/packages/tokens/codemod-map.json
+++ b/packages/tokens/codemod-map.json
@@ -10,11 +10,11 @@
   "manual": [
     {
       "pattern": "--ax-chips-*",
-      "reason": "Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task (WB-489)."
+      "reason": "Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task."
     },
     {
       "pattern": "--ax-nav-button-bg-primary-hover",
-      "reason": "One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task (WB-490)."
+      "reason": "One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task."
     }
   ],
   "renames": [

--- a/packages/tokens/migration/2026-06-15-ds2-migration-map.md
+++ b/packages/tokens/migration/2026-06-15-ds2-migration-map.md
@@ -1,0 +1,673 @@
+# WB Design System — Developer Migration Changelog
+
+## Old DS → New DS (WB 2.0)
+
+|                                     |                                                                                                                                                                                                                                                                      |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Old system (production, source)** | `Dv3nOrLqTgGEU7QB2SRDSL` — _WB · UI · Design System_ — [Figma link](https://www.figma.com/design/Dv3nOrLqTgGEU7QB2SRDSL/WB---UI---Design-System)                                                                                                                     |
+| **New system (target)**             | `hfT6zrYS948n8LrEK9y3Wh` — _WB 2.0 · UI · Design System_ — [Figma link](https://www.figma.com/design/hfT6zrYS948n8LrEK9y3Wh/WB-2.0---UI---Design-System--in-progress-)                                                                                               |
+| **Baseline comparison**             | 2026-05-29 (variable-by-variable diff, matched by internal ID)                                                                                                                                                                                                       |
+| **Revisions folded in**             | 2026-06-10 (component domain restructure, `acc1` refresh, Nav Button rebind) · 2026-06-12 (drifted `wb/canvas/*` leaf names re-aligned: `-default` suffixes restored on 10 tokens by ID — names in this document were and remain correct)                            |
+| **Compiled & live-verified**        | 2026-06-12 — collection counts, mode names, collection IDs, Tokens domain breakdown, and key values re-read directly from both Figma files via the Plugin API (see Appendix — Verification log)                                                                      |
+| **Status**                          | **SINGLE SOURCE OF TRUTH.** This document supersedes all prior Polish-language changelogs (`wb-ds-changelog-dev-migration.md`, `wb-ds-changelog-dev-2026-06-10.md`). In case of any discrepancy with earlier documents or mapping files, **this document prevails.** |
+
+**Purpose.** This is the single reference for re-pointing the entire codebase (CSS variables, Style Dictionary / Tokens Studio export, component props, enums, class names) from the old design system to the new one. All mappings were verified directly in the live Figma files, variable by variable, by internal ID.
+
+> **How to read this document.** Variable renames in Figma preserve the internal ID, which made an exact diff possible: shared ID = rename, ID only in the old file = removed, ID only in the new file = added. Section 7 is the full 1:1 rename map — the heart of the migration. All "new" names in this document are the **final names after the 2026-06-10 restructure**; you do not need to apply two rounds of renames. The `⚠` marker means the **value/appearance changes**, not just the name.
+
+---
+
+## 1. TL;DR — the changes that touch code
+
+1. **Collection architecture 3 → 4.** Old: `Primitives` + `Tokens` + `Numerals`. New: `Primitives` + `Tokens` + `Canvas` + `Effects`. The `Numerals` collection (dimensions) was dissolved and split.
+2. **Full Tokens taxonomy replacement.** Flat dash-joined names (`wb/txt-primary-default`) → three top-level slash-namespace domains: `wb/ui/*` (global semantics), `wb/components/*` (per-component tokens), `wb/canvas/*` (canvas/diagram elements). Every single token name changed.
+3. **Status terminology unified.** `error` → `critical`, `destructive` → `critical`, `information` → `info`. Abbreviations expanded: `txt` → `text`, `ico` / `icon-txt` → `icon`. This applies to token names, component variant labels, and should be mirrored in code enums and CSS classes.
+4. **`red` / `green` / `orange` palettes fully refreshed** in Primitives (new hex values) and extended from a 100–400 scale to a full 50–950 scale. This changes the appearance of **every** status token.
+5. **⚠ `acc1` (brand blue) fully refreshed (2026-06-10).** Anchor `acc1-500` = **`#3969FF`** (was `#1096E7`), for WCAG AA compliance of primary actions. Changes the appearance of every primary/brand element.
+6. **Single source of truth for statuses.** Functional tokens (badge, edge, node focus, icons) re-pointed from accents `acc2/acc3/acc5` to the named families `red/green/orange`. 12 tokens actually change color.
+7. **New semantic brand layer `wb/ui/brand/*`** (9 tokens) — the lead color now flows through a full Component → Semantic → Primitive chain instead of components aliasing `acc1` directly.
+8. **`input` component → `text-field`; chips rebuilt as a "factory"** (the per-accent `chips-acc1..5-*` matrix is gone).
+9. **Shadows and focus rings moved to the `Effects` collection** plus Effect Styles in a slash hierarchy (`shadow/ui/*`, `shadow/canvas/*`). The single `wb/shadow` token no longer exists.
+10. **Typography rebuilt** — from `Heading/H1..12` + `Paragraph/P1..12` to a Material-3-style ramp (`Display / Headline / Title / Body / Label / Node` × `Emphasized`). No name or ID continuity; manual remapping required.
+
+---
+
+## 2. The numbers
+
+| Collection / asset   | Old               | New (verified 2026-06-12)                                     | Delta                      |
+| -------------------- | ----------------- | ------------------------------------------------------------- | -------------------------- |
+| Primitives           | 154 (colors only) | 264 (colors + dimensions + `transparent`)                     | +110                       |
+| Tokens (Light/Dark)  | 207               | 200 — `wb/ui/*` 55 · `wb/components/*` 105 · `wb/canvas/*` 40 | −7                         |
+| Numerals             | 316               | — (dissolved)                                                 | −316                       |
+| Canvas (dimensions)  | —                 | 56                                                            | +56                        |
+| Effects (Light/Dark) | —                 | 29                                                            | +29                        |
+| Text Styles          | 38                | 39                                                            | +1 (full name replacement) |
+| Effect Styles        | 10                | 10                                                            | 0 (renamed)                |
+
+**Change volume in Tokens:** 146 renames (2026-05-29 taxonomy) + 103 restructured paths (2026-06-10) · 61 removed by ID (+3 more on 2026-06-10) · 52 added by ID (+5 Nav Button backgrounds on 2026-06-10).
+
+---
+
+## 3. Collection architecture
+
+### Old layout
+
+```
+Primitives (154, 1 mode)        → colors only (gray, blue, green, orange, red, acc1–acc5)
+Tokens     (207, Light/Dark)    → semantic color layer, flat dash-joined names
+Numerals   (316, 1 mode)        → dimensions: 266× token-spacing/token-radius with values
+                                   baked per component (e.g. button-xl-h-pad-1) + 50 primitives
+```
+
+### New layout
+
+```
+Primitives (264, "Mode 1")      → colors (full 50–950 scales) + dimension primitives
+                                   (space/*, radius/*, size/*, font-size/*) + transparent
+Tokens     (200, Light/Dark)    → color semantics in three domains:
+                                     wb/ui/*          = global foundations + brand layer
+                                     wb/components/*  = per-component tokens
+                                     wb/canvas/*      = canvas elements (node, port, edge, badge…)
+Canvas     (56, "value")        → canvas element dimensions (node/port/edge/widget) → space/radius/size
+Effects    (29, light/dark)     → shadow geometry components (x/y/blur/spread) + 1 shadow color
+```
+
+**Collection IDs (verified 2026-06-12):**
+
+| Collection | Old file                         | New file                                                        |
+| ---------- | -------------------------------- | --------------------------------------------------------------- |
+| Primitives | `VariableCollectionId:17:332`    | `VariableCollectionId:17:332` _(same — the new file is a fork)_ |
+| Tokens     | `VariableCollectionId:17:391`    | `VariableCollectionId:17:391` _(same)_                          |
+| Numerals   | `VariableCollectionId:2666:3363` | — (dissolved)                                                   |
+| Canvas     | —                                | `VariableCollectionId:7266:20`                                  |
+| Effects    | —                                | `VariableCollectionId:9126:20`                                  |
+
+**Implication for code:** if your build exports variables per collection (Style Dictionary / Tokens Studio / custom export), add two new sources (`Canvas`, `Effects`) and remove `Numerals`. The `Primitives` and `Tokens` collection IDs are identical in both files (see table above), which helps diffing — but every variable name changed regardless.
+
+**Architectural rule worth knowing:** `wb/canvas/*` tokens alias **directly to Primitives**, deliberately bypassing the `wb/ui/*` semantic layer. The canvas is allowed to evolve independently of the UI. Do not "normalize" canvas tokens through UI semantics in code.
+
+---
+
+## 4. Naming conventions and terminology (find-replace rules)
+
+| Rule                | Old                                     | New                                                                                                                          |
+| ------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Domain              | none                                    | `wb/ui/*` (UI), `wb/components/*` (components), or `wb/canvas/*` (canvas)                                                    |
+| Hierarchy separator | flat dash                               | slash namespace                                                                                                              |
+| Component tokens    | `wb/{component}-*`                      | `wb/components/{component}/*`                                                                                                |
+| Text                | `txt`                                   | `text`                                                                                                                       |
+| Icon                | `ico`, `icon-txt`                       | `icon`                                                                                                                       |
+| Error status        | `error`                                 | `critical`                                                                                                                   |
+| Destructive action  | `destructive`                           | `critical`                                                                                                                   |
+| Info status         | `information`                           | `info`                                                                                                                       |
+| Text hierarchy      | `primary/secondary/tertiary/quaternary` | roles: `default/subtle/muted/ghost`                                                                                          |
+| Backgrounds         | `ui-bg-primary/secondary/tertiary`      | `ui/bg/base/elevated/inset`                                                                                                  |
+| Input               | `input-*`                               | `text-field-*`                                                                                                               |
+| Pin tooltip / tour  | `pt-*`                                  | `tour/*`                                                                                                                     |
+| Button leaf         | `{variant}-{color}-bg-{state}`          | nested path `{variant}/{color}/{state}` (fill is the default role; non-fill roles named explicitly, e.g. `…/stroke-default`) |
+
+Additional rules:
+
+- **`-default` suffixes are kept system-wide** (deliberate decision for searchability). `no suffix = default state` is _not_ the convention here — `default` is always explicit on default-state tokens within stateful families (single-state role tokens like `canvas/node/icon-primary`, `canvas/node/text`, `canvas/node/decor-primary` carry no state suffix by design). _Note: a temporary drift was detected on 2026-06-12 — ten `wb/canvas/_`default-state tokens had lost their`-default` suffix in the file; restored by ID the same day. If any token export was generated from the drifted state, regenerate it.\*
+- Leaf names are flat and dash-joined (`ui/icon/action-default`, not `ui/icon/action/default`).
+- **Typo cleanup:** the old system contains a misspelled token `wb/txt-destuctive-default` (missing "r") — `VariableID:1592:58782`, Tokens collection, old file. Verified **still present under the misspelled name on 2026-06-12**; a manual in-place rename to `wb/txt-destructive-default` is scheduled (rename preserves the ID, so both spellings are the same token). Whichever spelling your legacy export carries, it was a **duplicate of `wb/txt-error-default`** and has **no counterpart in the new system** — it merged into `wb/ui/text/critical-default`. Remove the key from code either way. The new file contains zero occurrences of either spelling (verified).
+- For the 2026-06-10 restructure specifically, two global transforms cover almost everything: `wb/ui/components/` → `wb/components/` (all component tokens) and the button leaf transformation above. If you had already started consuming the interim `wb.ui.components.*` paths, re-point them.
+
+---
+
+## 5. Primitives — color value changes
+
+This is the most important section for visual regression: changing a hex in Primitives **propagates to every aliasing token**, even when that token itself was never touched.
+
+### 5.1 `red` / `green` / `orange` refresh ⚠ BREAKING (visually)
+
+The old palettes were narrow (100–400) with muted hexes. The new ones are full 50–950 scales in the Tailwind/M3 style, with more vivid bases.
+
+| Primitive    | Old hex           | New hex               |
+| ------------ | ----------------- | --------------------- |
+| `red-400`    | `#962929` (brick) | `#e02020` (vivid red) |
+| `red-500`    | `#7d0000`         | `#c41a1a`             |
+| `red-100`    | `#f7e9e9`         | `#fee2e2`             |
+| `green-400`  | `#007c29`         | `#16a34a`             |
+| `green-300`  | `#29974e`         | `#4ade80`             |
+| `green-100`  | `#e9f7ee`         | `#dcfce7`             |
+| `orange-400` | `#e59800`         | `#f59e0b`             |
+| `orange-300` | `#ffaf10`         | `#fcd34d`             |
+| `orange-100` | `#f7f2e9`         | `#fef3c7`             |
+
+- `red`, `green`, `orange` extended to the full scale **50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950** (previously only 100–400 for green/orange, 100–600 for red).
+- `blue` extended to **50–950** (was 100–600 + 350).
+
+### 5.2 `acc1` (brand blue) refresh ⚠ BREAKING (visually) — revision 2026-06-10
+
+**Motivation:** the old `acc1-500` (`#1096E7`) gave a white-text contrast of **3.21 — below WCAG AA** for normal text, so the default state of the primary button was inaccessible. The new palette is anchored at `acc1-500` = **`#3969FF`** (white text 4.53 ✓ AA). The primary button now passes full AA on default/hover/active **without shifting the ramp** (`brand/fill*` still aliases 500/600/700).
+
+| Primitive  | Old hex   | New hex   | White-text contrast (new) |
+| ---------- | --------- | --------- | ------------------------- |
+| `acc1-50`  | `#F0F8FF` | `#EDF2FF` | — (tints)                 |
+| `acc1-100` | `#E0F0FE` | `#CCD9FF` | —                         |
+| `acc1-200` | `#BBE2FC` | `#99B3FF` | —                         |
+| `acc1-300` | `#5FBEFA` | `#6B90FF` | 2.98                      |
+| `acc1-400` | `#3AB0F6` | `#527DFF` | 3.66 (AA-large)           |
+| `acc1-500` | `#1096E7` | `#3969FF` | **4.53 ✓ AA**             |
+| `acc1-600` | `#0477C5` | `#144CF5` | **6.21 ✓ AA**             |
+| `acc1-700` | `#045FA0` | `#0F3FCC` | **8.07 ✓ AA**             |
+| `acc1-800` | `#085184` | `#11349C` | 10.53 (AAA)               |
+| `acc1-900` | `#0D446D` | `#132C76` | 12.73 (AAA)               |
+| `acc1-950` | `#092B48` | `#111F4B` | 15.89 (AAA)               |
+
+Alpha variants follow the base (alpha preserved): `acc1-500-{10,20,30,40,50}` → `#3969FF` at the respective opacity; `acc1-950-{10..50}` → `#111F4B`. **21 value changes in total.** Names and IDs are unchanged — this is a pure value change.
+
+**Propagation:** everything aliasing `acc1` directly or via `brand/*` — solid and ghost primary buttons, `text/action`, `text/info`, `icon/info`, `stroke/info`, focus rings (`acc1-500-40`), datepicker primary, chips `inset-outline`, info tooltip, logo (`brand/identity`). Bonus: `#3969FF` as link text on white also passes AA at 4.53.
+
+**Visual regression required:** Buttons (solid + ghost primary), Text field focus, Datepicker, UI element focus rings, logo/identity, links.
+
+### 5.3 New alpha steps and helpers (Added)
+
+- `red-400-40` `#e0202066`, `green-400-40` `#16a34a66`, `orange-400-40` `#f59e0b66` — 40% alpha, used by node focus rings (so they alias named families, not accents).
+- `gray-100-85` `#ffffffd9` — used by chips `overlay-outline`.
+- Full alpha series for `green/orange/red-400-{10,20,30,50}` and `acc3/acc4/acc5-950-{10..50}`.
+- `wb/colors/transparent` `rgba(0,0,0,0)` (2026-06-10) — reusable transparency primitive, used by no-fill component states (e.g. Nav Button default/disabled backgrounds). In CSS: `background: transparent`.
+
+### 5.4 Value fixes
+
+- `gray-900-75` corrected `#07070880` → `#070708bf` (the old value was bugged — 75% was actually 50%).
+
+### 5.5 `acc2–acc5` unchanged
+
+`acc2–acc5` values are untouched, but `acc2/acc3/acc5` **stop feeding status tokens** — they remain only in `canvas/widget-swatches/*`.
+
+---
+
+## 6. Status colors — single source of truth ⚠ (color change in 12 tokens)
+
+The most important semantic change. In the old system the same status had two sources in Primitives (e.g. critical = `red-*` in some tokens, `acc2-*` in others — different hexes). In the new system, `critical/success/warning` alias **exclusively** to `red/green/orange`.
+
+| Token (new name)                            | Old alias           | New alias        |
+| ------------------------------------------- | ------------------- | ---------------- |
+| `wb/canvas/badge-notify/critical-icon`      | `acc2-50`           | `red-50`         |
+| `wb/canvas/badge-notify/success-bg-default` | `acc3-500`          | `green-500`      |
+| `wb/canvas/badge-notify/success-icon`       | `acc3-50`           | `green-50`       |
+| `wb/canvas/badge-notify/warning-bg-default` | `acc5-500`          | `orange-500`     |
+| `wb/canvas/badge-notify/warning-icon`       | `acc5-50`           | `orange-50`      |
+| `wb/canvas/edge/stroke-success`             | `acc3-500/400`      | `green-500/400`  |
+| `wb/canvas/edge/stroke-warning`             | `acc5-500/400`      | `orange-500/400` |
+| `wb/canvas/node/focus-critical`             | `acc2-500-40`       | `red-400-40`     |
+| `wb/canvas/node/focus-success`              | `acc3-500-40`       | `green-400-40`   |
+| `wb/canvas/node/focus-warning`              | `acc5-500-40`       | `orange-400-40`  |
+| `wb/ui/icon/success-default`                | `acc3-600/500`      | `green-400/100`  |
+| `wb/ui/icon/warning-default`                | `acc5-500/acc5-400` | `orange-400/100` |
+
+---
+
+## 7. Tokens — full rename map (OLD NAME → FINAL NEW NAME)
+
+> General rule: renames were done by ID, so bindings inside the Figma components migrated automatically. **In code you must re-point manually.** Where the value also changes (via sections 5–6), the row carries `⚠`. All target names below are the final, post-2026-06-10 names.
+
+### 7.1 Foundations — Text (`txt-*` → `ui/text/*`)
+
+| Old                             | New                                                                   |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `wb/txt-primary-default`        | `wb/ui/text/default`                                                  |
+| `wb/txt-primary-inverse`        | `wb/ui/text/inverse-default`                                          |
+| `wb/txt-primary-disabled`       | `wb/ui/text/disabled` ⚠ _(Light: `gray-100-75` → `gray-900-30`, fix)_ |
+| `wb/txt-primary-white`          | `wb/ui/text/onaccent-default`                                         |
+| `wb/txt-secondary-default`      | `wb/ui/text/subtle-default`                                           |
+| `wb/txt-secondary-inverse`      | `wb/ui/text/inverse-subtle-default`                                   |
+| `wb/txt-tertiary-default`       | `wb/ui/text/muted-default`                                            |
+| `wb/txt-quaternary-default`     | `wb/ui/text/ghost-default`                                            |
+| `wb/txt-tooltip-bw`             | `wb/ui/text/tooltip-default`                                          |
+| `wb/txt-tooltip-blue`           | `wb/ui/text/tooltip-accent-default`                                   |
+| `wb/txt-ghost-primary-default`  | `wb/ui/text/action-default` ⚠ _(brand `#3969FF`)_                     |
+| `wb/txt-ghost-primary-disabled` | `wb/ui/text/action-disabled`                                          |
+| `wb/txt-error-default`          | `wb/ui/text/critical-default` ⚠ _(red refreshed)_                     |
+| `wb/txt-destructive-disabled`   | `wb/ui/text/critical-disabled`                                        |
+| `wb/txt-success-default`        | `wb/ui/text/success-default` ⚠ _(green refreshed)_                    |
+| `wb/txt-ghost-success-disabled` | `wb/ui/text/success-disabled`                                         |
+| `wb/txt-info-default`           | `wb/ui/text/info-default` ⚠ _(acc1 refreshed)_                        |
+| `wb/txt-warning-default`        | `wb/ui/text/warning-default` ⚠ _(orange refreshed)_                   |
+| `wb/txt-ghost-warning-disabled` | `wb/ui/text/warning-disabled`                                         |
+
+### 7.2 Foundations — Icon (`icon-*` → `ui/icon/*`)
+
+| Old                       | New                                                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wb/icon-primary-default` | `wb/ui/icon/action-default`                                                                                                                 |
+| `wb/icon-txt-default`     | `wb/ui/icon/default` _(via interim `onsurface-default`, merged 2026-06-10; codeSyntax `--wb-icon-txt-default` now lives on `icon/default`)_ |
+| `wb/icon-txt-inverse`     | `wb/ui/icon/inverse-default`                                                                                                                |
+| `wb/icon-disabled`        | `wb/ui/icon/disabled`                                                                                                                       |
+| `wb/icon-error-default`   | `wb/ui/icon/critical-default` ⚠ _(acc2 → red)_                                                                                              |
+| `wb/icon-success-default` | `wb/ui/icon/success-default` ⚠ _(acc3 → green)_                                                                                             |
+| `wb/icon-warning-default` | `wb/ui/icon/warning-default` ⚠ _(acc5 → orange)_                                                                                            |
+
+### 7.3 Foundations — Stroke / Background / Focus
+
+| Old                               | New                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------ |
+| `wb/ui-stroke-primary-default`    | `wb/ui/stroke/default`                                                         |
+| `wb/ui-stroke-secondary-default`  | `wb/ui/stroke/subtle`                                                          |
+| `wb/ui-stroke-primary-focus`      | `wb/ui/stroke/focus` ⚠ _(acc1 refreshed)_                                      |
+| `wb/ui-stroke-primary-highlight`  | `wb/ui/stroke/highlight`                                                       |
+| `wb/ui-separator-primary-default` | `wb/ui/stroke/divider`                                                         |
+| `wb/ui-bg-primary-default`        | `wb/ui/bg/base`                                                                |
+| `wb/ui-bg-secondary-default`      | `wb/ui/bg/elevated`                                                            |
+| `wb/ui-bg-tertiary-default`       | `wb/ui/bg/inset`                                                               |
+| `wb/ui-canvas-dots-default`       | `wb/ui/bg/canvas-dots`                                                         |
+| `wb/ui-bg-tertiary-selected`      | `wb/components/selector/fill-checked`                                          |
+| `wb/focus-ring-element`           | `wb/ui/focus-ring` _(flattened single token, 2026-06-10)_ ⚠ _(acc1 refreshed)_ |
+
+### 7.4 Button — solid (`button-{primary,gray,red,green,orange}-*`)
+
+> Color → status mapping: `red → critical`, `green → success`, `orange → warning`. **Disabled state consolidated**: four separate disabled tokens (`primary/gray/red/green`) → one shared `solid/disabled`. The shared disabled sits at the variant level, not the color level — intentional.
+
+| Old                                                         | New                                                                                            |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `wb/button-primary-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/primary/{default,hover,active,focus,loading}` ⚠ _(acc1 `#3969FF`)_ |
+| `wb/button-primary-bg-disabled`                             | `wb/components/button/solid/disabled`                                                          |
+| `wb/button-gray-bg-{default,hover,active,focus,loading}`    | `wb/components/button/solid/gray/{…}`                                                          |
+| `wb/button-gray-bg-disabled`                                | `wb/components/button/solid/disabled` _(consolidated)_                                         |
+| `wb/button-red-bg-{default,hover,active,focus,loading}`     | `wb/components/button/solid/critical/{…}` ⚠                                                    |
+| `wb/button-red-bg-disabled`                                 | `wb/components/button/solid/disabled` _(consolidated)_                                         |
+| `wb/button-green-bg-{default,hover,active,focus,loading}`   | `wb/components/button/solid/success/{…}` ⚠                                                     |
+| `wb/button-green-bg-disabled`                               | `wb/components/button/solid/disabled` _(consolidated)_                                         |
+| `wb/button-orange-bg-{default,hover,active,focus,loading}`  | `wb/components/button/solid/warning/{…}` ⚠                                                     |
+
+⚠ **Solid critical/success/warning color logic changed.** Old `button-green-bg-default` = `green-300`, hover = `green-400`. New `solid/success/default` = `green-500`, hover = `green-600`, active = `green-700` — full saturation plus correct darkening across states. Critical (`red-500/600/700`) and warning (`orange-500/600/700`) follow the same pattern. Button appearance changes noticeably.
+
+### 7.5 Button — ghost (`button-ghost-{primary,success,warning,destructive}-*`)
+
+| Old                                                                        | New                                                                                                                                           |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wb/button-ghost-primary-bg-{default,hover,active,focus,loading,disabled}` | `wb/components/button/ghost/primary/{default,hover,active,focus,loading,disabled}` ⚠ _(primary now flows through `brand/_`, acc1 refreshed)\* |
+| `wb/button-ghost-primary-stroke-default`                                   | `wb/components/button/ghost/primary/stroke-default` ⚠                                                                                         |
+| `wb/button-ghost-success-bg-{…}`                                           | `wb/components/button/ghost/success/{…}`                                                                                                      |
+| `wb/button-ghost-success-stroke-default`                                   | `wb/components/button/ghost/success/stroke-default`                                                                                           |
+| `wb/button-ghost-warning-bg-{…}`                                           | `wb/components/button/ghost/warning/{…}`                                                                                                      |
+| `wb/button-ghost-warning-stroke-default`                                   | `wb/components/button/ghost/warning/stroke-default`                                                                                           |
+| `wb/button-ghost-destructive-bg-{…}`                                       | `wb/components/button/ghost/critical/{…}`                                                                                                     |
+| `wb/button-ghost-destructive-stroke-default`                               | `wb/components/button/ghost/critical/stroke-default`                                                                                          |
+
+In Style Dictionary terms, the button moved from a flat string to a nested structure: `wb.button-primary-bg-loading` → `wb.components.button.solid.primary.loading`.
+
+### 7.6 Input → Text Field
+
+| Old                               | New                                                          |
+| --------------------------------- | ------------------------------------------------------------ |
+| `wb/input-stroke-primary-default` | `wb/components/text-field/stroke-default`                    |
+| `wb/input-stroke-primary-focus`   | `wb/components/text-field/stroke-focus` ⚠ _(acc1 refreshed)_ |
+| `wb/input-stroke-primary-error`   | `wb/components/text-field/stroke-critical` ⚠                 |
+| `wb/input-stroke-primary-success` | `wb/components/text-field/stroke-success` ⚠                  |
+| `wb/input-bg-primary-error`       | `wb/components/text-field/bg-primary-critical` ⚠             |
+| `wb/input-bg-primary-success`     | `wb/components/text-field/bg-primary-success` ⚠              |
+
+### 7.7 Other UI components
+
+| Old                                                                  | New                                                                                                                   |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `wb/nav-button-bg-primary-hover`                                     | `wb/components/nav-button/bg-primary-hover` _(see section 10 — this one old token split into three new state tokens)_ |
+| `wb/nav-button-icon-primary-{default,hover,active,pressed,disabled}` | `wb/components/nav-button/icon-primary-{…}` ⚠ _(pressed: brand `#3969FF`)_                                            |
+| `wb/snackbar-bg-information`                                         | `wb/components/snackbar/bg-info`                                                                                      |
+| `wb/snackbar-bg-warning`                                             | `wb/components/snackbar/bg-warning`                                                                                   |
+| `wb/snackbar-bg-success`                                             | `wb/components/snackbar/bg-success`                                                                                   |
+| `wb/snackbar-bg-error`                                               | `wb/components/snackbar/bg-critical`                                                                                  |
+| `wb/dropzone-bg-{default,hover,dragging}`                            | `wb/components/dropzone/bg-{default,hover,dragging}`                                                                  |
+| `wb/dropzone-bg-error`                                               | `wb/components/dropzone/bg-critical`                                                                                  |
+| `wb/dropzone-stroke-{default,hover,dragging}`                        | `wb/components/dropzone/stroke-{…}`                                                                                   |
+| `wb/dropzone-stroke-error`                                           | `wb/components/dropzone/stroke-critical`                                                                              |
+| `wb/dropdown-bg-primary-default`                                     | **removed** → use `wb/ui/bg/base` _(dropdown panels)_                                                                 |
+| `wb/dropdown-bg-secondary-default`                                   | **removed** → use `wb/ui/bg/inset` _(embedded options)_                                                               |
+| `wb/tooltip-bg-default`                                              | `wb/components/tooltip/bg-default`                                                                                    |
+| `wb/tooltip-bg-blue`                                                 | `wb/components/tooltip/bg-info` _(no more literal color in the name)_ ⚠ _(acc1 refreshed)_                            |
+| `wb/pt-bg-primary-default`                                           | `wb/components/tour/bg-primary-default`                                                                               |
+| `wb/pt-stroke-primary-default`                                       | `wb/components/tour/stroke-default`                                                                                   |
+| `wb/tab-stroke-{default,hover,active}`                               | `wb/components/tab/stroke-{…}`                                                                                        |
+| `wb/avatar-fill-default`                                             | `wb/components/avatar/fill-default`                                                                                   |
+| `wb/avatar-stroke-default`                                           | `wb/components/avatar/stroke-default`                                                                                 |
+| `wb/datepicker-bg-primary`                                           | `wb/components/datepicker/bg-primary` ⚠ _(acc1-600 → acc1-500, plus acc1 refreshed)_                                  |
+| `wb/datepicker-bg-secondary`                                         | `wb/components/datepicker/bg-secondary`                                                                               |
+| `wb/scrollbar-bg-default`                                            | `wb/components/scrollbar/bg-default`                                                                                  |
+| `wb/chips-neutral-txt`                                               | `wb/components/chips/solid-text`                                                                                      |
+
+### 7.8 Canvas — badge-notify, widget-swatches, node focus
+
+> These three groups were **moved into the `canvas/*` domain** (IDs preserved, so it's a rename, not a rebuild). Terminology: `error → critical`, `ico → icon`.
+
+| Old                                   | New                                                |
+| ------------------------------------- | -------------------------------------------------- |
+| `wb/badge-notify-error-bg-default`    | `wb/canvas/badge-notify/critical-bg-default`       |
+| `wb/badge-notify-error-ico-default`   | `wb/canvas/badge-notify/critical-icon` ⚠           |
+| `wb/badge-notify-success-bg-default`  | `wb/canvas/badge-notify/success-bg-default` ⚠      |
+| `wb/badge-notify-success-ico-default` | `wb/canvas/badge-notify/success-icon` ⚠            |
+| `wb/badge-notify-warning-bg-default`  | `wb/canvas/badge-notify/warning-bg-default` ⚠      |
+| `wb/badge-notify-warning-ico-default` | `wb/canvas/badge-notify/warning-icon` ⚠            |
+| `wb/widget-swatches-acc1..6`          | `wb/canvas/widget-swatches/acc1..6`                |
+| `wb/focus-ring-node-active`           | `wb/canvas/node/focus-active` ⚠ _(acc1 refreshed)_ |
+| `wb/focus-ring-node-error`            | `wb/canvas/node/focus-critical` ⚠                  |
+| `wb/focus-ring-node-success`          | `wb/canvas/node/focus-success` ⚠                   |
+| `wb/focus-ring-node-warning`          | `wb/canvas/node/focus-warning` ⚠                   |
+
+---
+
+## 8. Tokens — removed (64) and their replacements
+
+> Some of these are a **rebuild in the `canvas/*` domain** (old IDs deleted, new ones created). Functional continuity is preserved, but both the name **and the ID** changed — in code, treat them as a rename plus a possible value change.
+
+### 8.1 Canvas: node / port / edge — rebuilt as `canvas/*` (Removed → re-created)
+
+| Old token (removed)                                  | New equivalent (created)                    |
+| ---------------------------------------------------- | ------------------------------------------- |
+| `wb/node-bg-primary-{default,hover,active,disabled}` | `wb/canvas/node/bg-primary-{…}`             |
+| `wb/node-bg-secondary-default`                       | `wb/canvas/node/bg-secondary-default`       |
+| `wb/node-stroke-primary-{default,hover}`             | `wb/canvas/node/stroke-{default,hover}`     |
+| `wb/node-icon-primary-default`                       | `wb/canvas/node/icon-primary`               |
+| `wb/node-icon-primary-disabled`                      | _(none — handled by `wb/ui/icon/disabled`)_ |
+| `wb/node-txt-disabled`                               | `wb/canvas/node/text-disabled`              |
+| `wb/node-port-fill-{default,active}`                 | `wb/canvas/port/fill-{default,active}`      |
+| `wb/node-port-stroke-{default,active}`               | `wb/canvas/port/stroke-{default,active}`    |
+| `wb/edge-primary-default`                            | `wb/canvas/edge/stroke-default`             |
+| `wb/edge-primary-hover`                              | `wb/canvas/edge/stroke-hover`               |
+| `wb/edge-primary-active`                             | `wb/canvas/edge/stroke-active`              |
+| `wb/edge-primary-disabled`                           | `wb/canvas/edge/stroke-disabled`            |
+| `wb/edge-primary-error`                              | `wb/canvas/edge/stroke-critical` ⚠          |
+| `wb/edge-primary-success`                            | `wb/canvas/edge/stroke-success` ⚠           |
+| `wb/edge-primary-warning`                            | `wb/canvas/edge/stroke-warning` ⚠           |
+
+New additions in `canvas/node/*` on top of the rebuild: `bg-content-default`, `text` (default), `text-subtle`, `decor-primary` (see section 9).
+
+### 8.2 Chips — full rebuild as a "factory" (Removed)
+
+The entire old per-accent matrix is gone: `chips-neutral-{bg,icon,x}` + `chips-acc1..5-{bg,stroke,txt,icon,x}` (28 variables). Only `chips-neutral-txt` survives, renamed to `chips/solid-text`. The new model (section 9.3) is 4 tokens: `solid`, `solid-text`, `overlay-outline`, `inset-outline`, with accent color composed via mix/accent at the component level. **This is a breaking change for any code that references `chips-accN-*` — chip coloring logic must be rebuilt.**
+
+### 8.3 Other removals
+
+| Removed token                                                                                                                             | Reason / replacement                                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `wb/shadow`                                                                                                                               | moved to the **Effects** collection → `wb/shadow/ui/color`                                                                                                                     |
+| `wb/snackbar-bg-default`                                                                                                                  | neutral snackbar now uses a foundation background; separate `snackbar/stroke-*` tokens were added                                                                              |
+| `wb/tab-stroke-line`                                                                                                                      | removed (tab line via `wb/ui/stroke/*`)                                                                                                                                        |
+| `wb/icon-black`, `wb/icon-white`                                                                                                          | removed (literal colors; use `wb/ui/icon/default` / `onaccent`)                                                                                                                |
+| `wb/dropdown-bg-destructive-default`, `…-hover`                                                                                           | removed (destructive dropdown variant retired)                                                                                                                                 |
+| `wb/dropdown-bg-secondary-active`                                                                                                         | removed                                                                                                                                                                        |
+| `wb/button-gray-bg-disabled`, `wb/button-green-bg-disabled`, `wb/button-red-bg-disabled`                                                  | consolidated into `wb/components/button/solid/disabled`                                                                                                                        |
+| `wb/txt-destuctive-default` _(ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling)_ | typo-duplicate of `txt-error-default`, merged into `wb/ui/text/critical-default`                                                                                               |
+| `wb/dropdown-bg-primary-default`, `wb/dropdown-bg-secondary-default` _(2026-06-10)_                                                       | pass-through tokens deleted after re-pointing all consumers — panels → `wb/ui/bg/base`, embedded options → `wb/ui/bg/inset`. **Do not introduce `dropdown/*` keys into code.** |
+| `wb/ui/icon/onsurface-default` _(2026-06-10)_                                                                                             | redundant duplicate of `wb/ui/icon/default` (same value and role) — merged; legacy `icon-txt-default` maps to `wb/ui/icon/default`                                             |
+
+---
+
+## 9. Tokens — added (57)
+
+### 9.1 Semantic brand layer `wb/ui/brand/*` (9, NEW)
+
+The missing link for the lead color. Primary components now alias `brand/*`, not `acc1` directly. This is a thin, role-named abstraction — if the brand color ever changes again, only the `brand/*` aliases move.
+
+| Token                            | Alias         | Role                                                                                                        |
+| -------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| `wb/ui/brand/fill`               | `acc1-500`    | primary surface (default)                                                                                   |
+| `wb/ui/brand/fill-hover`         | `acc1-600`    | primary hover                                                                                               |
+| `wb/ui/brand/fill-active`        | `acc1-700`    | primary pressed                                                                                             |
+| `wb/ui/brand/fill-subtle`        | `acc1-500-10` | ghost-primary background                                                                                    |
+| `wb/ui/brand/fill-subtle-hover`  | `acc1-500-20` | ghost hover                                                                                                 |
+| `wb/ui/brand/fill-subtle-active` | `acc1-500-30` | ghost pressed                                                                                               |
+| `wb/ui/brand/border`             | `acc1-500`    | primary outline/accent                                                                                      |
+| `wb/ui/brand/text-on`            | `gray-100`    | text on brand surface (mode-independent; verified AA on all primary button states after the `acc1` refresh) |
+| `wb/ui/brand/identity`           | `acc1-500`    | logo / brand identity                                                                                       |
+
+### 9.2 UI foundations (NEW)
+
+- `wb/ui/bg/app` (`gray-200`/`gray-900`) — application background (new level).
+- `wb/ui/bg/canvas` (`gray-100`/`gray-800`) — canvas background.
+- `wb/ui/bg/fill-{default,hover,active,disabled}` — interactive fills (new family).
+- `wb/ui/icon/default` (`gray-900`/`gray-100`) — default icon color.
+- `wb/ui/icon/subtle-default` (`gray-500`) — subtle icon.
+- `wb/ui/icon/info-default` (`acc1-800`/`acc1-300`) — info icon.
+- `wb/ui/stroke/info` (`acc1-500`/`acc1-400`), `wb/ui/stroke/warning` (`orange-300`/`orange-100`).
+
+### 9.3 Chips factory (NEW)
+
+- `wb/components/chips/solid` (`gray-300`/`gray-650`)
+- `wb/components/chips/overlay-outline` (`gray-100-85`/`gray-900-75`) — for chips placed over imagery
+- `wb/components/chips/inset-outline` (`→ brand/border`) — Outline variant stroke and label/icon accent
+- (`chips/solid-text` is the renamed `chips-neutral-txt`)
+
+### 9.4 Snackbar strokes (NEW)
+
+- `wb/components/snackbar/stroke-{default,info,warning,success,critical}` — the old snackbar only had backgrounds; outlines are new.
+
+### 9.5 Canvas — node / port / edge (NEW by ID)
+
+24 `canvas/node/*`, `canvas/port/*`, `canvas/edge/*` tokens — the rebuild of old `node-*`/`edge-*` (section 8.1) plus genuinely new ones: `canvas/node/bg-content-default`, `canvas/node/text`, `canvas/node/text-subtle`, `canvas/node/decor-primary`.
+
+### 9.6 Nav Button state set (NEW, 2026-06-10)
+
+| Token                                          | Light →                | Dark →                 | Scopes                   |
+| ---------------------------------------------- | ---------------------- | ---------------------- | ------------------------ |
+| `wb/components/nav-button/bg-primary-default`  | `→ colors/transparent` | `→ colors/transparent` | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-pressed`  | `→ gray-900-5`         | `→ gray-100-5`         | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-active`   | `→ ui/brand/fill`      | `→ ui/brand/fill`      | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-focus`    | `→ gray-900-5`         | `→ gray-100-5`         | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-disabled` | `→ colors/transparent` | `→ colors/transparent` | `FRAME_FILL, SHAPE_FILL` |
+
+The pre-existing `bg-primary-hover` completes the set — all 6 background states are now tokenized: default · hover · pressed · active · focus · disabled, alongside the 5 icon states (`icon-primary-{default,hover,active,pressed,disabled}`; Focus reuses `icon-primary-default` deliberately). Note: `bg-primary-pressed` and `bg-primary-focus` currently share the hover value (`gray-900-5`) — a candidate for differentiation, pending design decision.
+
+---
+
+## 10. Nav Button — legacy remote bindings → local tokens (2026-06-10)
+
+The Nav Button component in the new file was discovered still hanging on **remote variables from the old, legacy DS library** (flat names). All 402 bindings are now local (0 remote). For code that consumed the old flat names, the mapping is **state-dependent**, because one old variable served three states:
+
+| Legacy (old DS, remote)                                              | → New local token                                                     |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `wb/nav-button-icon-primary-default`                                 | `wb/components/nav-button/icon-primary-default`                       |
+| `wb/nav-button-icon-primary-hover`                                   | `wb/components/nav-button/icon-primary-hover`                         |
+| `wb/nav-button-icon-primary-active`                                  | `wb/components/nav-button/icon-primary-active`                        |
+| `wb/nav-button-icon-primary-pressed`                                 | `wb/components/nav-button/icon-primary-pressed` ⚠ _(brand `#3969FF`)_ |
+| `wb/nav-button-icon-primary-disabled`                                | `wb/components/nav-button/icon-primary-disabled`                      |
+| `wb/nav-button-bg-primary-hover` _(Hover state)_                     | `wb/components/nav-button/bg-primary-hover`                           |
+| `wb/nav-button-bg-primary-hover` _(Pressed state)_                   | `wb/components/nav-button/bg-primary-pressed`                         |
+| `wb/nav-button-bg-primary-hover` _(Focus state)_                     | `wb/components/nav-button/bg-primary-focus`                           |
+| `wb/button-primary-bg-default` _(Active background)_                 | `wb/components/nav-button/bg-primary-active` ⚠ _(brand `#3969FF`)_    |
+| `wb/ui-bg-primary-default` _(white focus inner ring)_                | `wb/ui/bg/base`                                                       |
+| `wb/pt-stroke-primary-default` _(focus ring, "No background" style)_ | `wb/ui/stroke/focus`                                                  |
+
+**Visual changes (intended):** Active background and Pressed icon now use the new brand `#3969FF` instead of the stale legacy `#1096E7`. All other states changed source only (remote → local) with identical results. Placeholder icon fills (`#ffffff`) inside the swap slot remain unbound on purpose — a real icon brings its own color; do not treat them as Nav Button tokens.
+
+> ⚠ **Watch-out for other components:** the same legacy-remote binding pattern may exist elsewhere in the file. A file-wide remote-binding audit is recommended before/while migrating each component.
+
+---
+
+## 11. Dimensions — Numerals → Primitives + Canvas
+
+The old `Numerals` collection (316 variables: `token-spacing/*` and `token-radius/*` with values baked per component, e.g. `button-xl-h-pad-1`, plus 50 primitives) was **dissolved** and replaced with a two-layer model:
+
+### 11.1 Dimension primitives in `Primitives` (NEW)
+
+The naming is centesimal: **100 = 8px** (base of the scale), so `space-50` = 4px, `space-200` = 16px, etc.
+
+- `wb/space/*` — scale: 0, 25 (2px), 37, 50 (4px), 62, 75, 87, 100 (8px), 112, 125, 137, 150, 175, 200 (16px), 250 (20px), 300, 400, 500, 600, 700 (56px), 800, 1000, 1200, plus `negative-{50,100,200}`. Scope: `GAP`.
+  - The off-grid steps (`62/87/112/125/137`) are retained deliberately — they serve canvas zoom-level math. Do not round them to the grid.
+- `wb/radius/*` — 0, 25, 50, 75, 100, 125, 150, 200, 250, 300, `full` (9999). Scope: `CORNER_RADIUS`.
+- `wb/size/*` — 12 (1px), 25, 37, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 1000, 1200, 1600. Scope: `WIDTH_HEIGHT`.
+- `wb/font-size/*` — 125 (10px) … 450 (36px).
+
+There is no "Semantic Numerals" tier and there are no density modes — this is a deliberately primitive-only dimension scale.
+
+### 11.2 `Canvas` collection (56, NEW) — canvas element dimensions
+
+Dimension tokens for `node/port/edge/widget`, aliasing `space/*`, `radius/*`, `size/*`. All 56 variables are FLOAT (verified — no color variables in this collection; canvas colors live in `Tokens → wb/canvas/*`). Verified structure:
+
+- `canvas/node/*` (16) — `gap-{sm,md,lg}`, `gap-inner`, `inset`, `shell-radius`, `content-radius`, `head-{gap,h-pad,v-pad,radius,icon,icon-radius}`, `badge-{h-pad,v-pad,radius}`
+- `canvas/port/*` (2) — `gap`, `offset`
+- `canvas/edge/*` (19) — `stroke-{regular,bold}`, `corner-radius`, `padding`, `label/gap`, plus the edge-label size set `label/{xs,s,m}-{h-pad-N,v-pad-N,radius}`
+- `canvas/widget/*` (19) — `{s,m,l}-{pad,gap,radius}`, `element-radius`, `paragraph-{pad,gap}`, and nested widget-button sizes `button/{xxxs,xxs,xs}-*`
+
+### 11.3 The spacing model — two layers
+
+- **UI:** components bind `space/*` / `radius/*` primitives **directly** (no more component-baked `token-spacing/button-xl-h-pad-1`).
+- **Canvas:** dedicated tokens in the `Canvas` collection.
+
+**Implication for code:** every reference to the old `wb/token-spacing/*` or `wb/token-radius/*` is obsolete. UI spacing → `space/*`; canvas dimensions → the `Canvas` collection.
+
+---
+
+## 12. Shadows and focus — Effect Styles + Effects collection
+
+### 12.1 Effect Styles — renamed into a slash hierarchy (10 → 10)
+
+| Old                  | New                                |
+| -------------------- | ---------------------------------- |
+| `shadow-xs`          | `shadow/ui/xs`                     |
+| `shadow-s`           | `shadow/ui/s`                      |
+| `shadow-m`           | `shadow/ui/m`                      |
+| `shadow-l`           | `shadow/ui/l`                      |
+| `shadow-xl`          | `shadow/ui/xl`                     |
+| `focus-ring-element` | `shadow/ui/focus-element`          |
+| `focus-ring-active`  | `shadow/canvas/focus-node/active`  |
+| `focus-ring-warning` | `shadow/canvas/focus-node/warning` |
+| `focus-ring-error`   | `shadow/canvas/focus-node/error`   |
+| `focus-ring-success` | `shadow/canvas/focus-node/success` |
+
+> Note: the Effect Style `focus-node/error` keeps the old `error` term (color tokens already use `critical`) — a known naming mismatch, pending closure (verified still named `error` on 2026-06-12). If you build a code-side enum, prefer `critical` and map the style name.
+
+### 12.2 New `Effects` collection (29 variables, `light`/`dark` modes)
+
+Shadows decomposed into FLOAT variables (enables binding plus a shared color):
+
+- `wb/shadow/ui/{xs,s,m,l,xl}/{x,y,blur,spread}` — 5 sizes × 4 geometry components.
+- `wb/shadow/ui/focus-element/{x,y,blur,spread}` (spread 2).
+- `wb/shadow/canvas/focus-node/{x,y,blur,spread}` (spread 4).
+- `wb/shadow/ui/color` [COLOR] → `gray-900-20` (light) / `gray-900-50` (dark) — the one canonical UI shadow color (replaces the old `wb/shadow` from Tokens).
+
+UI reference values: xs `y4 blur8 spread−2`, s `y8 blur16 spread−4`, m `y12 blur24 spread−6`, l `y16 blur32 spread−8`, xl `y24 blur48 spread−12`.
+
+### 12.3 Known limitation — Effect Style color binding (open)
+
+The Effect Styles' own color properties are **not yet bound to variables** (hardcoded RGBA inside the styles); dark-mode color binding is pending (pilot planned on `shadow/ui/m` first). For code, the source of truth for the shadow color is `wb/shadow/ui/color` in the Effects collection — bind to that, not to the RGBA snapshot in the style. Additionally, a large inline-shadow backlog remains in the design file (~800 custom one-offs plus 49 border-simulation shadows on toggles/checkboxes); these are not part of the tokenized shadow system and should not be reverse-engineered into tokens.
+
+---
+
+## 13. Typography — Text Styles (full replacement, 38 → 39)
+
+The old and new name sets are **disjoint** — this is not a rename, it's a new ramp. Every typography class in code requires manual mapping.
+
+| Old system (38)                                                 | New system (39)                                        |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| `Heading/H1` … `Heading/H12`                                    | `Display/{S,M,L}`, `Headline/{S,M,L}`, `Title/{S,M,L}` |
+| `Paragraph/P1` … `Paragraph/P12`                                | `Body/{S,M,L}`                                         |
+| `Button/Button {Large,Medium,Small,XtraSmall}` + `Txt` variants | (covered by `Label/*`)                                 |
+| `Label/{Medium,Small,XtraSmall}`                                | `Label/{S,M,L,XL}`                                     |
+| `KeyShortcut/Txt {Large,Medium,Small}`                          | (map onto `Label/*` or `UI/Code`)                      |
+| —                                                               | `Node/{S,M,L}` _(new family for the canvas)_           |
+| —                                                               | every family has an `… Emphasized` variant             |
+| —                                                               | `UI/Code`                                              |
+
+**Implication:** typography is the most manual part of the migration — there is no ID or name continuity. Recommended: build a mapping table from old H/P numbers to new roles (e.g. `Heading/H1` → `Display/L`, `Paragraph/P3` → `Body/M`) based on the real font sizes in both files before re-pointing.
+
+---
+
+## 14. Component library changes relevant to code (props / API)
+
+These are Figma component changes that should be mirrored in component APIs, Storybook controls, and design-to-code mappings.
+
+### 14.1 Property naming convention (Polaris-style)
+
+All rebuilt components follow one convention:
+
+- **BOOLEAN** properties carry clean names controlling visibility: `Prefix icon`, `Suffix icon`, `Label`, `Help text`, `Required`.
+- **TEXT** and **INSTANCE_SWAP** properties carry the `↪️` prefix: `↪️ Label`, `↪️ Prefix icon`, `↪️ Suffix icon`, `↪️ Icon`, `↪️ Help content`, `↪️ Value content`.
+- The `↪️` prefix is a Figma-panel affordance only — strip it when mapping to code props.
+
+### 14.2 Button family
+
+- Layout is no longer driven by mutually exclusive BOOL-VARIANT flags (`Text only`, `Icon + Text`, `Text + Icon`, `Icon + Text + Icon`, `Icon Square`, `Icon Round`). It is now composed via `Prefix icon` / `Suffix icon` booleans plus instance swaps, and a `Shape` variant axis: `Default` (text button) / `Square` / `Round` (icon-only).
+- Variant axes: `Color` (Primary, Secondary, Success, Warning, Critical, Ghost-Primary, Ghost-Secondary, Ghost-Success, Ghost-Warning, Ghost-Critical — 10), `Size` (XL, L, M, S, XS — 5), `State` (Default, Hover, Active, Focus, Loading, Disabled — 6; icon shapes have no Loading), `Shape` (Default, Square, Round).
+- Geometry reference for icon shapes: Square cornerRadius 4/4/6/8/8 for XS/S/M/L/XL; Round cornerRadius 9999.
+- ⚠ Solid critical/success/warning buttons change appearance (full-saturation 500/600/700 ramp, section 7.4); all primary buttons change appearance (`#3969FF`).
+
+### 14.3 Text inputs
+
+- `Input` is now the **Text field** family: `Text field`, `Multiline field`, and the new **Number field** (Size L/M/S × 8 states) with a Polaris-style Stepper (two independent segments, 4 states each). The Stepper lives only in Number field — it was removed from Text field.
+- The transient `border-focus` layer was removed from all field variants — focus is expressed via `stroke-focus` + focus shadow, not an extra border node.
+
+### 14.4 Status vocabulary in variant labels
+
+Variant property values across 10 components (419 variants) were renamed to match the token vocabulary: `Error` → `Critical`, `Destructive` → `Critical`, `Information` → `Info`. Mirror this in code enums, CSS state classes, and any design-to-code variant mapping. There are zero occurrences of the full word `information` left in the file.
+
+### 14.5 Nav Button v2
+
+Rebuilt as a 252-variant set with the full tokenized state model from section 9.6/10. Direct instances were migrated; a tail of nested instances inside other components may still point at the deprecated component inside the design file (Plugin API limitation) — irrelevant for code, but relevant if you scrape the file programmatically.
+
+---
+
+## 15. Breaking changes — summary for code
+
+1. **All 207 old token names changed** (146 renamed + 61 removed/rebuilt). No old `wb/{txt|icon|ui-bg|button|node|edge|...}-*` path will resolve.
+2. **Value changes independent of renames:** the `red/green/orange` refresh plus status unification (sections 5–6) changes the appearance of every critical/success/warning element, even where the token was not renamed.
+3. **`acc1` — new values:** the entire brand blue palette was replaced (anchor `#3969FF`, section 5.2). Pure value change — names and IDs unchanged — but every primary/brand element looks different; visual regression required.
+4. **Component domain:** all component tokens live under `wb/components/*` (not `wb/ui/components/*` — if you consumed the interim paths, re-point). Button uses nested `wb/components/button/{variant}/{color}/{state}`. `wb/ui/focus-ring/element` → `wb/ui/focus-ring`.
+5. **Chips:** the per-accent model (`chips-accN-*`) is gone — chip coloring logic must be rebuilt around the 4-token factory.
+6. **Input → Text Field:** name change plus component API change (section 14.3).
+7. **`error`/`destructive`/`information` → `critical`/`info`** in token names, state enums, CSS classes, and variant labels.
+8. **Shadows:** `wb/shadow` (Tokens) no longer exists — use Effect Styles `shadow/ui/*` or the `Effects` collection variables.
+9. **Dimensions:** `wb/token-spacing/*` and `wb/token-radius/*` (Numerals) no longer exist — move to `space/*`/`radius/*` (UI) and the `Canvas` collection (canvas).
+10. **Typography:** new ramp (`Display/Headline/Title/Body/Label/Node`) — full remapping of typography classes.
+11. **Do not introduce removed keys:** `dropdown/bg-primary-default`, `dropdown/bg-secondary-default` (→ `ui/bg/base` / `ui/bg/inset`), `icon/onsurface-default` (→ `icon/default`), `txt-destuctive-default` (typo).
+
+---
+
+## 16. Recommended migration order (checklist)
+
+1. [ ] Update the token export pipeline (Style Dictionary / Tokens Studio): add the `Canvas` and `Effects` collections, drop `Numerals`.
+2. [ ] Replace **Primitives** (colors: full `red/green/orange/blue` scales with new hexes; **`acc1` per section 5.2**; dimension primitives `space/radius/size/font-size`; `transparent`). This is the foundation — everything else depends on it.
+3. [ ] Introduce the `ui/brand/*` layer and re-point primary onto it.
+4. [ ] Apply the rename map from section 7 (find-replace, ideally scripted from the tables). Two global transforms cover most cases: component prefix → `wb/components/`, button leaf → `{variant}/{color}/{state}`.
+5. [ ] Handle the removals/rebuilds from section 8 (chips factory, node/edge/port under `canvas/*`, `solid/disabled` consolidation, deleted dropdown keys).
+6. [ ] Add the new tokens from section 9 (brand layer, UI foundations, chips factory, snackbar strokes, canvas additions, nav-button state set).
+7. [ ] Re-point Nav Button consumers using the state-dependent mapping in section 10.
+8. [ ] Re-point shadows onto Effect Styles / the `Effects` collection (section 12); bind shadow color to `wb/shadow/ui/color`.
+9. [ ] Remap typography (section 13) — requires a manual H/P → role table.
+10. [ ] Migrate `error/destructive/information` → `critical/info` in enums, classes, and variant mappings (sections 4, 14.4).
+11. [ ] Update component APIs to the Polaris-style prop model (section 14).
+12. [ ] **Visual regression:** all critical/success/warning surfaces (new hexes), solid buttons (full-saturation 500/600/700), **everything primary/brand** (`#3969FF`: solid+ghost primary buttons, links/`text-action`, Text field focus, UI focus rings, logo/`brand/identity`, info tooltip/icon/stroke), datepicker primary, chips, node focus rings, Nav Button Active/Pressed.
+
+---
+
+## 17. Known gaps, tech debt, and watch-outs
+
+- **Effect Style shadow colors are not yet variable-bound** (hardcoded RGBA inside the styles); dark-mode binding pending. Bind code to `wb/shadow/ui/color` regardless (section 12.3).
+- **`shadow/canvas/focus-node/error`** Effect Style name retains the legacy `error` term — naming mismatch with the `critical` vocabulary, pending closure.
+- **`wb/ui/brand/identity` scope** is flagged for expansion (tech debt) — currently equals `brand/fill`; treat as a separate semantic slot in code so a future split is cheap.
+- **Nav Button `bg-primary-pressed` / `bg-primary-focus`** currently share the hover value — possible future differentiation.
+- **Legacy-remote bindings** may exist in components beyond Nav Button — audit each component before wiring it to code (section 10).
+- **Disabled-state contrast** is an intentional WCAG exception (disabled controls are exempt from contrast minima) — document it explicitly rather than "fixing" it.
+- **Status palettes (critical/success/warning) for alerts/snackbars are intentionally non-vivid** in their surface usage — do not "harmonize" them with the vivid button ramp.
+
+---
+
+## Related artifacts (project files)
+
+- `wb-ds-rename-mapping-29-05.md` — full old→new map by ID (2026-05-29 taxonomy; audit trail)
+- `wb-ds-rename-mapping-10-06.md` — component domain restructure map (103 renames, 2026-06-10; audit trail)
+- `ds-test-ii-audyt-usprawnien.md` (v3) — canonical design-side audit / session-restore document
+- ~~`wb-ds-changelog-dev-migration.md`~~ and ~~`wb-ds-changelog-dev-2026-06-10.md`~~ — Polish-language changelogs, **superseded by this document** and scheduled for deletion. Do not reference them.
+
+_Export-by-name reminder: if the build uses variable names as keys (Style Dictionary / Tokens Studio), every rename in this document is a downstream key change — update wherever names are hardcoded._
+
+---
+
+## Appendix — Verification log (2026-06-12)
+
+All of the following was re-read live from both Figma files via the Plugin API on 2026-06-12:
+
+| Check                   | Old file (`Dv3nOrLqTgGEU7QB2SRDSL`)                                                     | New file (`hfT6zrYS948n8LrEK9y3Wh`)                                                                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Primitives              | 154 vars, mode `Mode 1`                                                                 | 264 vars, mode `Mode 1`                                                                                                                 |
+| Tokens                  | 207 vars, modes `Light`/`Dark`                                                          | 200 vars, modes `Light`/`Dark`; domains `wb/ui/*` 55 · `wb/components/*` 105 · `wb/canvas/*` 40; names outside the three domains: **0** |
+| Numerals                | 316 vars, mode `Mode 1`                                                                 | —                                                                                                                                       |
+| Canvas                  | —                                                                                       | 56 vars (all FLOAT), mode `value`                                                                                                       |
+| Effects                 | —                                                                                       | 29 vars, modes `light`/`dark`                                                                                                           |
+| Text Styles             | 38                                                                                      | 39                                                                                                                                      |
+| Effect Styles           | 10                                                                                      | 10 — names verified, including the `shadow/canvas/focus-node/error` mismatch                                                            |
+| `acc1-500`              | —                                                                                       | `#3969FF` confirmed (RGB 57/105/255)                                                                                                    |
+| `wb/colors/transparent` | —                                                                                       | present, `VariableID:10665:20`                                                                                                          |
+| `destuctive` typo       | **still present** as `wb/txt-destuctive-default` (`1592:58782`) — manual rename pending | zero occurrences of either spelling                                                                                                     |

--- a/packages/tokens/migration/2026-06-15-ds2-migration-map.md
+++ b/packages/tokens/migration/2026-06-15-ds2-migration-map.md
@@ -2,14 +2,14 @@
 
 ## Old DS → New DS (WB 2.0)
 
-|                                     |                                                                                                                                                                                                                                                                      |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Old system (production, source)** | `Dv3nOrLqTgGEU7QB2SRDSL` — _WB · UI · Design System_ — [Figma link](https://www.figma.com/design/Dv3nOrLqTgGEU7QB2SRDSL/WB---UI---Design-System)                                                                                                                     |
-| **New system (target)**             | `hfT6zrYS948n8LrEK9y3Wh` — _WB 2.0 · UI · Design System_ — [Figma link](https://www.figma.com/design/hfT6zrYS948n8LrEK9y3Wh/WB-2.0---UI---Design-System--in-progress-)                                                                                               |
-| **Baseline comparison**             | 2026-05-29 (variable-by-variable diff, matched by internal ID)                                                                                                                                                                                                       |
-| **Revisions folded in**             | 2026-06-10 (component domain restructure, `acc1` refresh, Nav Button rebind) · 2026-06-12 (drifted `wb/canvas/*` leaf names re-aligned: `-default` suffixes restored on 10 tokens by ID — names in this document were and remain correct)                            |
-| **Compiled & live-verified**        | 2026-06-12 — collection counts, mode names, collection IDs, Tokens domain breakdown, and key values re-read directly from both Figma files via the Plugin API (see Appendix — Verification log)                                                                      |
-| **Status**                          | **SINGLE SOURCE OF TRUTH.** This document supersedes all prior Polish-language changelogs (`wb-ds-changelog-dev-migration.md`, `wb-ds-changelog-dev-2026-06-10.md`). In case of any discrepancy with earlier documents or mapping files, **this document prevails.** |
+| | |
+|---|---|
+| **Old system (production, source)** | `Dv3nOrLqTgGEU7QB2SRDSL` — *WB · UI · Design System* — [Figma link](https://www.figma.com/design/Dv3nOrLqTgGEU7QB2SRDSL/WB---UI---Design-System) |
+| **New system (target)** | `hfT6zrYS948n8LrEK9y3Wh` — *WB 2.0 · UI · Design System* — [Figma link](https://www.figma.com/design/hfT6zrYS948n8LrEK9y3Wh/WB-2.0---UI---Design-System--in-progress-) |
+| **Baseline comparison** | 2026-05-29 (variable-by-variable diff, matched by internal ID) |
+| **Revisions folded in** | 2026-06-10 (component domain restructure, `acc1` refresh, Nav Button rebind) · 2026-06-12 (drifted `wb/canvas/*` leaf names re-aligned: `-default` suffixes restored on 10 tokens by ID — names in this document were and remain correct) |
+| **Compiled & live-verified** | 2026-06-12 — collection counts, mode names, collection IDs, Tokens domain breakdown, and key values re-read directly from both Figma files via the Plugin API (see Appendix — Verification log) |
+| **Status** | **SINGLE SOURCE OF TRUTH.** This document supersedes all prior Polish-language changelogs (`wb-ds-changelog-dev-migration.md`, `wb-ds-changelog-dev-2026-06-10.md`). In case of any discrepancy with earlier documents or mapping files, **this document prevails.** |
 
 **Purpose.** This is the single reference for re-pointing the entire codebase (CSS variables, Style Dictionary / Tokens Studio export, component props, enums, class names) from the old design system to the new one. All mappings were verified directly in the live Figma files, variable by variable, by internal ID.
 
@@ -34,15 +34,15 @@
 
 ## 2. The numbers
 
-| Collection / asset   | Old               | New (verified 2026-06-12)                                     | Delta                      |
-| -------------------- | ----------------- | ------------------------------------------------------------- | -------------------------- |
-| Primitives           | 154 (colors only) | 264 (colors + dimensions + `transparent`)                     | +110                       |
-| Tokens (Light/Dark)  | 207               | 200 — `wb/ui/*` 55 · `wb/components/*` 105 · `wb/canvas/*` 40 | −7                         |
-| Numerals             | 316               | — (dissolved)                                                 | −316                       |
-| Canvas (dimensions)  | —                 | 56                                                            | +56                        |
-| Effects (Light/Dark) | —                 | 29                                                            | +29                        |
-| Text Styles          | 38                | 39                                                            | +1 (full name replacement) |
-| Effect Styles        | 10                | 10                                                            | 0 (renamed)                |
+| Collection / asset | Old | New (verified 2026-06-12) | Delta |
+|---|---|---|---|
+| Primitives | 154 (colors only) | 264 (colors + dimensions + `transparent`) | +110 |
+| Tokens (Light/Dark) | 207 | 200 — `wb/ui/*` 55 · `wb/components/*` 105 · `wb/canvas/*` 40 | −7 |
+| Numerals | 316 | — (dissolved) | −316 |
+| Canvas (dimensions) | — | 56 | +56 |
+| Effects (Light/Dark) | — | 29 | +29 |
+| Text Styles | 38 | 39 | +1 (full name replacement) |
+| Effect Styles | 10 | 10 | 0 (renamed) |
 
 **Change volume in Tokens:** 146 renames (2026-05-29 taxonomy) + 103 restructured paths (2026-06-10) · 61 removed by ID (+3 more on 2026-06-10) · 52 added by ID (+5 Nav Button backgrounds on 2026-06-10).
 
@@ -74,13 +74,13 @@ Effects    (29, light/dark)     → shadow geometry components (x/y/blur/spread)
 
 **Collection IDs (verified 2026-06-12):**
 
-| Collection | Old file                         | New file                                                        |
-| ---------- | -------------------------------- | --------------------------------------------------------------- |
-| Primitives | `VariableCollectionId:17:332`    | `VariableCollectionId:17:332` _(same — the new file is a fork)_ |
-| Tokens     | `VariableCollectionId:17:391`    | `VariableCollectionId:17:391` _(same)_                          |
-| Numerals   | `VariableCollectionId:2666:3363` | — (dissolved)                                                   |
-| Canvas     | —                                | `VariableCollectionId:7266:20`                                  |
-| Effects    | —                                | `VariableCollectionId:9126:20`                                  |
+| Collection | Old file | New file |
+|---|---|---|
+| Primitives | `VariableCollectionId:17:332` | `VariableCollectionId:17:332` *(same — the new file is a fork)* |
+| Tokens | `VariableCollectionId:17:391` | `VariableCollectionId:17:391` *(same)* |
+| Numerals | `VariableCollectionId:2666:3363` | — (dissolved) |
+| Canvas | — | `VariableCollectionId:7266:20` |
+| Effects | — | `VariableCollectionId:9126:20` |
 
 **Implication for code:** if your build exports variables per collection (Style Dictionary / Tokens Studio / custom export), add two new sources (`Canvas`, `Effects`) and remove `Numerals`. The `Primitives` and `Tokens` collection IDs are identical in both files (see table above), which helps diffing — but every variable name changed regardless.
 
@@ -90,25 +90,25 @@ Effects    (29, light/dark)     → shadow geometry components (x/y/blur/spread)
 
 ## 4. Naming conventions and terminology (find-replace rules)
 
-| Rule                | Old                                     | New                                                                                                                          |
-| ------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Domain              | none                                    | `wb/ui/*` (UI), `wb/components/*` (components), or `wb/canvas/*` (canvas)                                                    |
-| Hierarchy separator | flat dash                               | slash namespace                                                                                                              |
-| Component tokens    | `wb/{component}-*`                      | `wb/components/{component}/*`                                                                                                |
-| Text                | `txt`                                   | `text`                                                                                                                       |
-| Icon                | `ico`, `icon-txt`                       | `icon`                                                                                                                       |
-| Error status        | `error`                                 | `critical`                                                                                                                   |
-| Destructive action  | `destructive`                           | `critical`                                                                                                                   |
-| Info status         | `information`                           | `info`                                                                                                                       |
-| Text hierarchy      | `primary/secondary/tertiary/quaternary` | roles: `default/subtle/muted/ghost`                                                                                          |
-| Backgrounds         | `ui-bg-primary/secondary/tertiary`      | `ui/bg/base/elevated/inset`                                                                                                  |
-| Input               | `input-*`                               | `text-field-*`                                                                                                               |
-| Pin tooltip / tour  | `pt-*`                                  | `tour/*`                                                                                                                     |
-| Button leaf         | `{variant}-{color}-bg-{state}`          | nested path `{variant}/{color}/{state}` (fill is the default role; non-fill roles named explicitly, e.g. `…/stroke-default`) |
+| Rule | Old | New |
+|---|---|---|
+| Domain | none | `wb/ui/*` (UI), `wb/components/*` (components), or `wb/canvas/*` (canvas) |
+| Hierarchy separator | flat dash | slash namespace |
+| Component tokens | `wb/{component}-*` | `wb/components/{component}/*` |
+| Text | `txt` | `text` |
+| Icon | `ico`, `icon-txt` | `icon` |
+| Error status | `error` | `critical` |
+| Destructive action | `destructive` | `critical` |
+| Info status | `information` | `info` |
+| Text hierarchy | `primary/secondary/tertiary/quaternary` | roles: `default/subtle/muted/ghost` |
+| Backgrounds | `ui-bg-primary/secondary/tertiary` | `ui/bg/base/elevated/inset` |
+| Input | `input-*` | `text-field-*` |
+| Pin tooltip / tour | `pt-*` | `tour/*` |
+| Button leaf | `{variant}-{color}-bg-{state}` | nested path `{variant}/{color}/{state}` (fill is the default role; non-fill roles named explicitly, e.g. `…/stroke-default`) |
 
 Additional rules:
 
-- **`-default` suffixes are kept system-wide** (deliberate decision for searchability). `no suffix = default state` is _not_ the convention here — `default` is always explicit on default-state tokens within stateful families (single-state role tokens like `canvas/node/icon-primary`, `canvas/node/text`, `canvas/node/decor-primary` carry no state suffix by design). _Note: a temporary drift was detected on 2026-06-12 — ten `wb/canvas/_`default-state tokens had lost their`-default` suffix in the file; restored by ID the same day. If any token export was generated from the drifted state, regenerate it.\*
+- **`-default` suffixes are kept system-wide** (deliberate decision for searchability). `no suffix = default state` is *not* the convention here — `default` is always explicit on default-state tokens within stateful families (single-state role tokens like `canvas/node/icon-primary`, `canvas/node/text`, `canvas/node/decor-primary` carry no state suffix by design). *Note: a temporary drift was detected on 2026-06-12 — ten `wb/canvas/*` default-state tokens had lost their `-default` suffix in the file; restored by ID the same day. If any token export was generated from the drifted state, regenerate it.*
 - Leaf names are flat and dash-joined (`ui/icon/action-default`, not `ui/icon/action/default`).
 - **Typo cleanup:** the old system contains a misspelled token `wb/txt-destuctive-default` (missing "r") — `VariableID:1592:58782`, Tokens collection, old file. Verified **still present under the misspelled name on 2026-06-12**; a manual in-place rename to `wb/txt-destructive-default` is scheduled (rename preserves the ID, so both spellings are the same token). Whichever spelling your legacy export carries, it was a **duplicate of `wb/txt-error-default`** and has **no counterpart in the new system** — it merged into `wb/ui/text/critical-default`. Remove the key from code either way. The new file contains zero occurrences of either spelling (verified).
 - For the 2026-06-10 restructure specifically, two global transforms cover almost everything: `wb/ui/components/` → `wb/components/` (all component tokens) and the button leaf transformation above. If you had already started consuming the interim `wb.ui.components.*` paths, re-point them.
@@ -123,17 +123,17 @@ This is the most important section for visual regression: changing a hex in Prim
 
 The old palettes were narrow (100–400) with muted hexes. The new ones are full 50–950 scales in the Tailwind/M3 style, with more vivid bases.
 
-| Primitive    | Old hex           | New hex               |
-| ------------ | ----------------- | --------------------- |
-| `red-400`    | `#962929` (brick) | `#e02020` (vivid red) |
-| `red-500`    | `#7d0000`         | `#c41a1a`             |
-| `red-100`    | `#f7e9e9`         | `#fee2e2`             |
-| `green-400`  | `#007c29`         | `#16a34a`             |
-| `green-300`  | `#29974e`         | `#4ade80`             |
-| `green-100`  | `#e9f7ee`         | `#dcfce7`             |
-| `orange-400` | `#e59800`         | `#f59e0b`             |
-| `orange-300` | `#ffaf10`         | `#fcd34d`             |
-| `orange-100` | `#f7f2e9`         | `#fef3c7`             |
+| Primitive | Old hex | New hex |
+|---|---|---|
+| `red-400` | `#962929` (brick) | `#e02020` (vivid red) |
+| `red-500` | `#7d0000` | `#c41a1a` |
+| `red-100` | `#f7e9e9` | `#fee2e2` |
+| `green-400` | `#007c29` | `#16a34a` |
+| `green-300` | `#29974e` | `#4ade80` |
+| `green-100` | `#e9f7ee` | `#dcfce7` |
+| `orange-400` | `#e59800` | `#f59e0b` |
+| `orange-300` | `#ffaf10` | `#fcd34d` |
+| `orange-100` | `#f7f2e9` | `#fef3c7` |
 
 - `red`, `green`, `orange` extended to the full scale **50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950** (previously only 100–400 for green/orange, 100–600 for red).
 - `blue` extended to **50–950** (was 100–600 + 350).
@@ -142,19 +142,19 @@ The old palettes were narrow (100–400) with muted hexes. The new ones are full
 
 **Motivation:** the old `acc1-500` (`#1096E7`) gave a white-text contrast of **3.21 — below WCAG AA** for normal text, so the default state of the primary button was inaccessible. The new palette is anchored at `acc1-500` = **`#3969FF`** (white text 4.53 ✓ AA). The primary button now passes full AA on default/hover/active **without shifting the ramp** (`brand/fill*` still aliases 500/600/700).
 
-| Primitive  | Old hex   | New hex   | White-text contrast (new) |
-| ---------- | --------- | --------- | ------------------------- |
-| `acc1-50`  | `#F0F8FF` | `#EDF2FF` | — (tints)                 |
-| `acc1-100` | `#E0F0FE` | `#CCD9FF` | —                         |
-| `acc1-200` | `#BBE2FC` | `#99B3FF` | —                         |
-| `acc1-300` | `#5FBEFA` | `#6B90FF` | 2.98                      |
-| `acc1-400` | `#3AB0F6` | `#527DFF` | 3.66 (AA-large)           |
-| `acc1-500` | `#1096E7` | `#3969FF` | **4.53 ✓ AA**             |
-| `acc1-600` | `#0477C5` | `#144CF5` | **6.21 ✓ AA**             |
-| `acc1-700` | `#045FA0` | `#0F3FCC` | **8.07 ✓ AA**             |
-| `acc1-800` | `#085184` | `#11349C` | 10.53 (AAA)               |
-| `acc1-900` | `#0D446D` | `#132C76` | 12.73 (AAA)               |
-| `acc1-950` | `#092B48` | `#111F4B` | 15.89 (AAA)               |
+| Primitive | Old hex | New hex | White-text contrast (new) |
+|---|---|---|---|
+| `acc1-50` | `#F0F8FF` | `#EDF2FF` | — (tints) |
+| `acc1-100` | `#E0F0FE` | `#CCD9FF` | — |
+| `acc1-200` | `#BBE2FC` | `#99B3FF` | — |
+| `acc1-300` | `#5FBEFA` | `#6B90FF` | 2.98 |
+| `acc1-400` | `#3AB0F6` | `#527DFF` | 3.66 (AA-large) |
+| `acc1-500` | `#1096E7` | `#3969FF` | **4.53 ✓ AA** |
+| `acc1-600` | `#0477C5` | `#144CF5` | **6.21 ✓ AA** |
+| `acc1-700` | `#045FA0` | `#0F3FCC` | **8.07 ✓ AA** |
+| `acc1-800` | `#085184` | `#11349C` | 10.53 (AAA) |
+| `acc1-900` | `#0D446D` | `#132C76` | 12.73 (AAA) |
+| `acc1-950` | `#092B48` | `#111F4B` | 15.89 (AAA) |
 
 Alpha variants follow the base (alpha preserved): `acc1-500-{10,20,30,40,50}` → `#3969FF` at the respective opacity; `acc1-950-{10..50}` → `#111F4B`. **21 value changes in total.** Names and IDs are unchanged — this is a pure value change.
 
@@ -183,20 +183,20 @@ Alpha variants follow the base (alpha preserved): `acc1-500-{10,20,30,40,50}` �
 
 The most important semantic change. In the old system the same status had two sources in Primitives (e.g. critical = `red-*` in some tokens, `acc2-*` in others — different hexes). In the new system, `critical/success/warning` alias **exclusively** to `red/green/orange`.
 
-| Token (new name)                            | Old alias           | New alias        |
-| ------------------------------------------- | ------------------- | ---------------- |
-| `wb/canvas/badge-notify/critical-icon`      | `acc2-50`           | `red-50`         |
-| `wb/canvas/badge-notify/success-bg-default` | `acc3-500`          | `green-500`      |
-| `wb/canvas/badge-notify/success-icon`       | `acc3-50`           | `green-50`       |
-| `wb/canvas/badge-notify/warning-bg-default` | `acc5-500`          | `orange-500`     |
-| `wb/canvas/badge-notify/warning-icon`       | `acc5-50`           | `orange-50`      |
-| `wb/canvas/edge/stroke-success`             | `acc3-500/400`      | `green-500/400`  |
-| `wb/canvas/edge/stroke-warning`             | `acc5-500/400`      | `orange-500/400` |
-| `wb/canvas/node/focus-critical`             | `acc2-500-40`       | `red-400-40`     |
-| `wb/canvas/node/focus-success`              | `acc3-500-40`       | `green-400-40`   |
-| `wb/canvas/node/focus-warning`              | `acc5-500-40`       | `orange-400-40`  |
-| `wb/ui/icon/success-default`                | `acc3-600/500`      | `green-400/100`  |
-| `wb/ui/icon/warning-default`                | `acc5-500/acc5-400` | `orange-400/100` |
+| Token (new name) | Old alias | New alias |
+|---|---|---|
+| `wb/canvas/badge-notify/critical-icon` | `acc2-50` | `red-50` |
+| `wb/canvas/badge-notify/success-bg-default` | `acc3-500` | `green-500` |
+| `wb/canvas/badge-notify/success-icon` | `acc3-50` | `green-50` |
+| `wb/canvas/badge-notify/warning-bg-default` | `acc5-500` | `orange-500` |
+| `wb/canvas/badge-notify/warning-icon` | `acc5-50` | `orange-50` |
+| `wb/canvas/edge/stroke-success` | `acc3-500/400` | `green-500/400` |
+| `wb/canvas/edge/stroke-warning` | `acc5-500/400` | `orange-500/400` |
+| `wb/canvas/node/focus-critical` | `acc2-500-40` | `red-400-40` |
+| `wb/canvas/node/focus-success` | `acc3-500-40` | `green-400-40` |
+| `wb/canvas/node/focus-warning` | `acc5-500-40` | `orange-400-40` |
+| `wb/ui/icon/success-default` | `acc3-600/500` | `green-400/100` |
+| `wb/ui/icon/warning-default` | `acc5-500/acc5-400` | `orange-400/100` |
 
 ---
 
@@ -206,145 +206,145 @@ The most important semantic change. In the old system the same status had two so
 
 ### 7.1 Foundations — Text (`txt-*` → `ui/text/*`)
 
-| Old                             | New                                                                   |
-| ------------------------------- | --------------------------------------------------------------------- |
-| `wb/txt-primary-default`        | `wb/ui/text/default`                                                  |
-| `wb/txt-primary-inverse`        | `wb/ui/text/inverse-default`                                          |
-| `wb/txt-primary-disabled`       | `wb/ui/text/disabled` ⚠ _(Light: `gray-100-75` → `gray-900-30`, fix)_ |
-| `wb/txt-primary-white`          | `wb/ui/text/onaccent-default`                                         |
-| `wb/txt-secondary-default`      | `wb/ui/text/subtle-default`                                           |
-| `wb/txt-secondary-inverse`      | `wb/ui/text/inverse-subtle-default`                                   |
-| `wb/txt-tertiary-default`       | `wb/ui/text/muted-default`                                            |
-| `wb/txt-quaternary-default`     | `wb/ui/text/ghost-default`                                            |
-| `wb/txt-tooltip-bw`             | `wb/ui/text/tooltip-default`                                          |
-| `wb/txt-tooltip-blue`           | `wb/ui/text/tooltip-accent-default`                                   |
-| `wb/txt-ghost-primary-default`  | `wb/ui/text/action-default` ⚠ _(brand `#3969FF`)_                     |
-| `wb/txt-ghost-primary-disabled` | `wb/ui/text/action-disabled`                                          |
-| `wb/txt-error-default`          | `wb/ui/text/critical-default` ⚠ _(red refreshed)_                     |
-| `wb/txt-destructive-disabled`   | `wb/ui/text/critical-disabled`                                        |
-| `wb/txt-success-default`        | `wb/ui/text/success-default` ⚠ _(green refreshed)_                    |
-| `wb/txt-ghost-success-disabled` | `wb/ui/text/success-disabled`                                         |
-| `wb/txt-info-default`           | `wb/ui/text/info-default` ⚠ _(acc1 refreshed)_                        |
-| `wb/txt-warning-default`        | `wb/ui/text/warning-default` ⚠ _(orange refreshed)_                   |
-| `wb/txt-ghost-warning-disabled` | `wb/ui/text/warning-disabled`                                         |
+| Old | New |
+|---|---|
+| `wb/txt-primary-default` | `wb/ui/text/default` |
+| `wb/txt-primary-inverse` | `wb/ui/text/inverse-default` |
+| `wb/txt-primary-disabled` | `wb/ui/text/disabled` ⚠ *(Light: `gray-100-75` → `gray-900-30`, fix)* |
+| `wb/txt-primary-white` | `wb/ui/text/onaccent-default` |
+| `wb/txt-secondary-default` | `wb/ui/text/subtle-default` |
+| `wb/txt-secondary-inverse` | `wb/ui/text/inverse-subtle-default` |
+| `wb/txt-tertiary-default` | `wb/ui/text/muted-default` |
+| `wb/txt-quaternary-default` | `wb/ui/text/ghost-default` |
+| `wb/txt-tooltip-bw` | `wb/ui/text/tooltip-default` |
+| `wb/txt-tooltip-blue` | `wb/ui/text/tooltip-accent-default` |
+| `wb/txt-ghost-primary-default` | `wb/ui/text/action-default` ⚠ *(brand `#3969FF`)* |
+| `wb/txt-ghost-primary-disabled` | `wb/ui/text/action-disabled` |
+| `wb/txt-error-default` | `wb/ui/text/critical-default` ⚠ *(red refreshed)* |
+| `wb/txt-destructive-disabled` | `wb/ui/text/critical-disabled` |
+| `wb/txt-success-default` | `wb/ui/text/success-default` ⚠ *(green refreshed)* |
+| `wb/txt-ghost-success-disabled` | `wb/ui/text/success-disabled` |
+| `wb/txt-info-default` | `wb/ui/text/info-default` ⚠ *(acc1 refreshed)* |
+| `wb/txt-warning-default` | `wb/ui/text/warning-default` ⚠ *(orange refreshed)* |
+| `wb/txt-ghost-warning-disabled` | `wb/ui/text/warning-disabled` |
 
 ### 7.2 Foundations — Icon (`icon-*` → `ui/icon/*`)
 
-| Old                       | New                                                                                                                                         |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wb/icon-primary-default` | `wb/ui/icon/action-default`                                                                                                                 |
-| `wb/icon-txt-default`     | `wb/ui/icon/default` _(via interim `onsurface-default`, merged 2026-06-10; codeSyntax `--wb-icon-txt-default` now lives on `icon/default`)_ |
-| `wb/icon-txt-inverse`     | `wb/ui/icon/inverse-default`                                                                                                                |
-| `wb/icon-disabled`        | `wb/ui/icon/disabled`                                                                                                                       |
-| `wb/icon-error-default`   | `wb/ui/icon/critical-default` ⚠ _(acc2 → red)_                                                                                              |
-| `wb/icon-success-default` | `wb/ui/icon/success-default` ⚠ _(acc3 → green)_                                                                                             |
-| `wb/icon-warning-default` | `wb/ui/icon/warning-default` ⚠ _(acc5 → orange)_                                                                                            |
+| Old | New |
+|---|---|
+| `wb/icon-primary-default` | `wb/ui/icon/action-default` |
+| `wb/icon-txt-default` | `wb/ui/icon/default` *(via interim `onsurface-default`, merged 2026-06-10; codeSyntax `--wb-icon-txt-default` now lives on `icon/default`)* |
+| `wb/icon-txt-inverse` | `wb/ui/icon/inverse-default` |
+| `wb/icon-disabled` | `wb/ui/icon/disabled` |
+| `wb/icon-error-default` | `wb/ui/icon/critical-default` ⚠ *(acc2 → red)* |
+| `wb/icon-success-default` | `wb/ui/icon/success-default` ⚠ *(acc3 → green)* |
+| `wb/icon-warning-default` | `wb/ui/icon/warning-default` ⚠ *(acc5 → orange)* |
 
 ### 7.3 Foundations — Stroke / Background / Focus
 
-| Old                               | New                                                                            |
-| --------------------------------- | ------------------------------------------------------------------------------ |
-| `wb/ui-stroke-primary-default`    | `wb/ui/stroke/default`                                                         |
-| `wb/ui-stroke-secondary-default`  | `wb/ui/stroke/subtle`                                                          |
-| `wb/ui-stroke-primary-focus`      | `wb/ui/stroke/focus` ⚠ _(acc1 refreshed)_                                      |
-| `wb/ui-stroke-primary-highlight`  | `wb/ui/stroke/highlight`                                                       |
-| `wb/ui-separator-primary-default` | `wb/ui/stroke/divider`                                                         |
-| `wb/ui-bg-primary-default`        | `wb/ui/bg/base`                                                                |
-| `wb/ui-bg-secondary-default`      | `wb/ui/bg/elevated`                                                            |
-| `wb/ui-bg-tertiary-default`       | `wb/ui/bg/inset`                                                               |
-| `wb/ui-canvas-dots-default`       | `wb/ui/bg/canvas-dots`                                                         |
-| `wb/ui-bg-tertiary-selected`      | `wb/components/selector/fill-checked`                                          |
-| `wb/focus-ring-element`           | `wb/ui/focus-ring` _(flattened single token, 2026-06-10)_ ⚠ _(acc1 refreshed)_ |
+| Old | New |
+|---|---|
+| `wb/ui-stroke-primary-default` | `wb/ui/stroke/default` |
+| `wb/ui-stroke-secondary-default` | `wb/ui/stroke/subtle` |
+| `wb/ui-stroke-primary-focus` | `wb/ui/stroke/focus` ⚠ *(acc1 refreshed)* |
+| `wb/ui-stroke-primary-highlight` | `wb/ui/stroke/highlight` |
+| `wb/ui-separator-primary-default` | `wb/ui/stroke/divider` |
+| `wb/ui-bg-primary-default` | `wb/ui/bg/base` |
+| `wb/ui-bg-secondary-default` | `wb/ui/bg/elevated` |
+| `wb/ui-bg-tertiary-default` | `wb/ui/bg/inset` |
+| `wb/ui-canvas-dots-default` | `wb/ui/bg/canvas-dots` |
+| `wb/ui-bg-tertiary-selected` | `wb/components/selector/fill-checked` |
+| `wb/focus-ring-element` | `wb/ui/focus-ring` *(flattened single token, 2026-06-10)* ⚠ *(acc1 refreshed)* |
 
 ### 7.4 Button — solid (`button-{primary,gray,red,green,orange}-*`)
 
 > Color → status mapping: `red → critical`, `green → success`, `orange → warning`. **Disabled state consolidated**: four separate disabled tokens (`primary/gray/red/green`) → one shared `solid/disabled`. The shared disabled sits at the variant level, not the color level — intentional.
 
-| Old                                                         | New                                                                                            |
-| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `wb/button-primary-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/primary/{default,hover,active,focus,loading}` ⚠ _(acc1 `#3969FF`)_ |
-| `wb/button-primary-bg-disabled`                             | `wb/components/button/solid/disabled`                                                          |
-| `wb/button-gray-bg-{default,hover,active,focus,loading}`    | `wb/components/button/solid/gray/{…}`                                                          |
-| `wb/button-gray-bg-disabled`                                | `wb/components/button/solid/disabled` _(consolidated)_                                         |
-| `wb/button-red-bg-{default,hover,active,focus,loading}`     | `wb/components/button/solid/critical/{…}` ⚠                                                    |
-| `wb/button-red-bg-disabled`                                 | `wb/components/button/solid/disabled` _(consolidated)_                                         |
-| `wb/button-green-bg-{default,hover,active,focus,loading}`   | `wb/components/button/solid/success/{…}` ⚠                                                     |
-| `wb/button-green-bg-disabled`                               | `wb/components/button/solid/disabled` _(consolidated)_                                         |
-| `wb/button-orange-bg-{default,hover,active,focus,loading}`  | `wb/components/button/solid/warning/{…}` ⚠                                                     |
+| Old | New |
+|---|---|
+| `wb/button-primary-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/primary/{default,hover,active,focus,loading}` ⚠ *(acc1 `#3969FF`)* |
+| `wb/button-primary-bg-disabled` | `wb/components/button/solid/disabled` |
+| `wb/button-gray-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/gray/{…}` |
+| `wb/button-gray-bg-disabled` | `wb/components/button/solid/disabled` *(consolidated)* |
+| `wb/button-red-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/critical/{…}` ⚠ |
+| `wb/button-red-bg-disabled` | `wb/components/button/solid/disabled` *(consolidated)* |
+| `wb/button-green-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/success/{…}` ⚠ |
+| `wb/button-green-bg-disabled` | `wb/components/button/solid/disabled` *(consolidated)* |
+| `wb/button-orange-bg-{default,hover,active,focus,loading}` | `wb/components/button/solid/warning/{…}` ⚠ |
 
 ⚠ **Solid critical/success/warning color logic changed.** Old `button-green-bg-default` = `green-300`, hover = `green-400`. New `solid/success/default` = `green-500`, hover = `green-600`, active = `green-700` — full saturation plus correct darkening across states. Critical (`red-500/600/700`) and warning (`orange-500/600/700`) follow the same pattern. Button appearance changes noticeably.
 
 ### 7.5 Button — ghost (`button-ghost-{primary,success,warning,destructive}-*`)
 
-| Old                                                                        | New                                                                                                                                           |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wb/button-ghost-primary-bg-{default,hover,active,focus,loading,disabled}` | `wb/components/button/ghost/primary/{default,hover,active,focus,loading,disabled}` ⚠ _(primary now flows through `brand/_`, acc1 refreshed)\* |
-| `wb/button-ghost-primary-stroke-default`                                   | `wb/components/button/ghost/primary/stroke-default` ⚠                                                                                         |
-| `wb/button-ghost-success-bg-{…}`                                           | `wb/components/button/ghost/success/{…}`                                                                                                      |
-| `wb/button-ghost-success-stroke-default`                                   | `wb/components/button/ghost/success/stroke-default`                                                                                           |
-| `wb/button-ghost-warning-bg-{…}`                                           | `wb/components/button/ghost/warning/{…}`                                                                                                      |
-| `wb/button-ghost-warning-stroke-default`                                   | `wb/components/button/ghost/warning/stroke-default`                                                                                           |
-| `wb/button-ghost-destructive-bg-{…}`                                       | `wb/components/button/ghost/critical/{…}`                                                                                                     |
-| `wb/button-ghost-destructive-stroke-default`                               | `wb/components/button/ghost/critical/stroke-default`                                                                                          |
+| Old | New |
+|---|---|
+| `wb/button-ghost-primary-bg-{default,hover,active,focus,loading,disabled}` | `wb/components/button/ghost/primary/{default,hover,active,focus,loading,disabled}` ⚠ *(primary now flows through `brand/*`, acc1 refreshed)* |
+| `wb/button-ghost-primary-stroke-default` | `wb/components/button/ghost/primary/stroke-default` ⚠ |
+| `wb/button-ghost-success-bg-{…}` | `wb/components/button/ghost/success/{…}` |
+| `wb/button-ghost-success-stroke-default` | `wb/components/button/ghost/success/stroke-default` |
+| `wb/button-ghost-warning-bg-{…}` | `wb/components/button/ghost/warning/{…}` |
+| `wb/button-ghost-warning-stroke-default` | `wb/components/button/ghost/warning/stroke-default` |
+| `wb/button-ghost-destructive-bg-{…}` | `wb/components/button/ghost/critical/{…}` |
+| `wb/button-ghost-destructive-stroke-default` | `wb/components/button/ghost/critical/stroke-default` |
 
 In Style Dictionary terms, the button moved from a flat string to a nested structure: `wb.button-primary-bg-loading` → `wb.components.button.solid.primary.loading`.
 
 ### 7.6 Input → Text Field
 
-| Old                               | New                                                          |
-| --------------------------------- | ------------------------------------------------------------ |
-| `wb/input-stroke-primary-default` | `wb/components/text-field/stroke-default`                    |
-| `wb/input-stroke-primary-focus`   | `wb/components/text-field/stroke-focus` ⚠ _(acc1 refreshed)_ |
-| `wb/input-stroke-primary-error`   | `wb/components/text-field/stroke-critical` ⚠                 |
-| `wb/input-stroke-primary-success` | `wb/components/text-field/stroke-success` ⚠                  |
-| `wb/input-bg-primary-error`       | `wb/components/text-field/bg-primary-critical` ⚠             |
-| `wb/input-bg-primary-success`     | `wb/components/text-field/bg-primary-success` ⚠              |
+| Old | New |
+|---|---|
+| `wb/input-stroke-primary-default` | `wb/components/text-field/stroke-default` |
+| `wb/input-stroke-primary-focus` | `wb/components/text-field/stroke-focus` ⚠ *(acc1 refreshed)* |
+| `wb/input-stroke-primary-error` | `wb/components/text-field/stroke-critical` ⚠ |
+| `wb/input-stroke-primary-success` | `wb/components/text-field/stroke-success` ⚠ |
+| `wb/input-bg-primary-error` | `wb/components/text-field/bg-primary-critical` ⚠ |
+| `wb/input-bg-primary-success` | `wb/components/text-field/bg-primary-success` ⚠ |
 
 ### 7.7 Other UI components
 
-| Old                                                                  | New                                                                                                                   |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `wb/nav-button-bg-primary-hover`                                     | `wb/components/nav-button/bg-primary-hover` _(see section 10 — this one old token split into three new state tokens)_ |
-| `wb/nav-button-icon-primary-{default,hover,active,pressed,disabled}` | `wb/components/nav-button/icon-primary-{…}` ⚠ _(pressed: brand `#3969FF`)_                                            |
-| `wb/snackbar-bg-information`                                         | `wb/components/snackbar/bg-info`                                                                                      |
-| `wb/snackbar-bg-warning`                                             | `wb/components/snackbar/bg-warning`                                                                                   |
-| `wb/snackbar-bg-success`                                             | `wb/components/snackbar/bg-success`                                                                                   |
-| `wb/snackbar-bg-error`                                               | `wb/components/snackbar/bg-critical`                                                                                  |
-| `wb/dropzone-bg-{default,hover,dragging}`                            | `wb/components/dropzone/bg-{default,hover,dragging}`                                                                  |
-| `wb/dropzone-bg-error`                                               | `wb/components/dropzone/bg-critical`                                                                                  |
-| `wb/dropzone-stroke-{default,hover,dragging}`                        | `wb/components/dropzone/stroke-{…}`                                                                                   |
-| `wb/dropzone-stroke-error`                                           | `wb/components/dropzone/stroke-critical`                                                                              |
-| `wb/dropdown-bg-primary-default`                                     | **removed** → use `wb/ui/bg/base` _(dropdown panels)_                                                                 |
-| `wb/dropdown-bg-secondary-default`                                   | **removed** → use `wb/ui/bg/inset` _(embedded options)_                                                               |
-| `wb/tooltip-bg-default`                                              | `wb/components/tooltip/bg-default`                                                                                    |
-| `wb/tooltip-bg-blue`                                                 | `wb/components/tooltip/bg-info` _(no more literal color in the name)_ ⚠ _(acc1 refreshed)_                            |
-| `wb/pt-bg-primary-default`                                           | `wb/components/tour/bg-primary-default`                                                                               |
-| `wb/pt-stroke-primary-default`                                       | `wb/components/tour/stroke-default`                                                                                   |
-| `wb/tab-stroke-{default,hover,active}`                               | `wb/components/tab/stroke-{…}`                                                                                        |
-| `wb/avatar-fill-default`                                             | `wb/components/avatar/fill-default`                                                                                   |
-| `wb/avatar-stroke-default`                                           | `wb/components/avatar/stroke-default`                                                                                 |
-| `wb/datepicker-bg-primary`                                           | `wb/components/datepicker/bg-primary` ⚠ _(acc1-600 → acc1-500, plus acc1 refreshed)_                                  |
-| `wb/datepicker-bg-secondary`                                         | `wb/components/datepicker/bg-secondary`                                                                               |
-| `wb/scrollbar-bg-default`                                            | `wb/components/scrollbar/bg-default`                                                                                  |
-| `wb/chips-neutral-txt`                                               | `wb/components/chips/solid-text`                                                                                      |
+| Old | New |
+|---|---|
+| `wb/nav-button-bg-primary-hover` | `wb/components/nav-button/bg-primary-hover` *(see section 10 — this one old token split into three new state tokens)* |
+| `wb/nav-button-icon-primary-{default,hover,active,pressed,disabled}` | `wb/components/nav-button/icon-primary-{…}` ⚠ *(pressed: brand `#3969FF`)* |
+| `wb/snackbar-bg-information` | `wb/components/snackbar/bg-info` |
+| `wb/snackbar-bg-warning` | `wb/components/snackbar/bg-warning` |
+| `wb/snackbar-bg-success` | `wb/components/snackbar/bg-success` |
+| `wb/snackbar-bg-error` | `wb/components/snackbar/bg-critical` |
+| `wb/dropzone-bg-{default,hover,dragging}` | `wb/components/dropzone/bg-{default,hover,dragging}` |
+| `wb/dropzone-bg-error` | `wb/components/dropzone/bg-critical` |
+| `wb/dropzone-stroke-{default,hover,dragging}` | `wb/components/dropzone/stroke-{…}` |
+| `wb/dropzone-stroke-error` | `wb/components/dropzone/stroke-critical` |
+| `wb/dropdown-bg-primary-default` | **removed** → use `wb/ui/bg/base` *(dropdown panels)* |
+| `wb/dropdown-bg-secondary-default` | **removed** → use `wb/ui/bg/inset` *(embedded options)* |
+| `wb/tooltip-bg-default` | `wb/components/tooltip/bg-default` |
+| `wb/tooltip-bg-blue` | `wb/components/tooltip/bg-info` *(no more literal color in the name)* ⚠ *(acc1 refreshed)* |
+| `wb/pt-bg-primary-default` | `wb/components/tour/bg-primary-default` |
+| `wb/pt-stroke-primary-default` | `wb/components/tour/stroke-default` |
+| `wb/tab-stroke-{default,hover,active}` | `wb/components/tab/stroke-{…}` |
+| `wb/avatar-fill-default` | `wb/components/avatar/fill-default` |
+| `wb/avatar-stroke-default` | `wb/components/avatar/stroke-default` |
+| `wb/datepicker-bg-primary` | `wb/components/datepicker/bg-primary` ⚠ *(acc1-600 → acc1-500, plus acc1 refreshed)* |
+| `wb/datepicker-bg-secondary` | `wb/components/datepicker/bg-secondary` |
+| `wb/scrollbar-bg-default` | `wb/components/scrollbar/bg-default` |
+| `wb/chips-neutral-txt` | `wb/components/chips/solid-text` |
 
 ### 7.8 Canvas — badge-notify, widget-swatches, node focus
 
 > These three groups were **moved into the `canvas/*` domain** (IDs preserved, so it's a rename, not a rebuild). Terminology: `error → critical`, `ico → icon`.
 
-| Old                                   | New                                                |
-| ------------------------------------- | -------------------------------------------------- |
-| `wb/badge-notify-error-bg-default`    | `wb/canvas/badge-notify/critical-bg-default`       |
-| `wb/badge-notify-error-ico-default`   | `wb/canvas/badge-notify/critical-icon` ⚠           |
-| `wb/badge-notify-success-bg-default`  | `wb/canvas/badge-notify/success-bg-default` ⚠      |
-| `wb/badge-notify-success-ico-default` | `wb/canvas/badge-notify/success-icon` ⚠            |
-| `wb/badge-notify-warning-bg-default`  | `wb/canvas/badge-notify/warning-bg-default` ⚠      |
-| `wb/badge-notify-warning-ico-default` | `wb/canvas/badge-notify/warning-icon` ⚠            |
-| `wb/widget-swatches-acc1..6`          | `wb/canvas/widget-swatches/acc1..6`                |
-| `wb/focus-ring-node-active`           | `wb/canvas/node/focus-active` ⚠ _(acc1 refreshed)_ |
-| `wb/focus-ring-node-error`            | `wb/canvas/node/focus-critical` ⚠                  |
-| `wb/focus-ring-node-success`          | `wb/canvas/node/focus-success` ⚠                   |
-| `wb/focus-ring-node-warning`          | `wb/canvas/node/focus-warning` ⚠                   |
+| Old | New |
+|---|---|
+| `wb/badge-notify-error-bg-default` | `wb/canvas/badge-notify/critical-bg-default` |
+| `wb/badge-notify-error-ico-default` | `wb/canvas/badge-notify/critical-icon` ⚠ |
+| `wb/badge-notify-success-bg-default` | `wb/canvas/badge-notify/success-bg-default` ⚠ |
+| `wb/badge-notify-success-ico-default` | `wb/canvas/badge-notify/success-icon` ⚠ |
+| `wb/badge-notify-warning-bg-default` | `wb/canvas/badge-notify/warning-bg-default` ⚠ |
+| `wb/badge-notify-warning-ico-default` | `wb/canvas/badge-notify/warning-icon` ⚠ |
+| `wb/widget-swatches-acc1..6` | `wb/canvas/widget-swatches/acc1..6` |
+| `wb/focus-ring-node-active` | `wb/canvas/node/focus-active` ⚠ *(acc1 refreshed)* |
+| `wb/focus-ring-node-error` | `wb/canvas/node/focus-critical` ⚠ |
+| `wb/focus-ring-node-success` | `wb/canvas/node/focus-success` ⚠ |
+| `wb/focus-ring-node-warning` | `wb/canvas/node/focus-warning` ⚠ |
 
 ---
 
@@ -354,23 +354,23 @@ In Style Dictionary terms, the button moved from a flat string to a nested struc
 
 ### 8.1 Canvas: node / port / edge — rebuilt as `canvas/*` (Removed → re-created)
 
-| Old token (removed)                                  | New equivalent (created)                    |
-| ---------------------------------------------------- | ------------------------------------------- |
-| `wb/node-bg-primary-{default,hover,active,disabled}` | `wb/canvas/node/bg-primary-{…}`             |
-| `wb/node-bg-secondary-default`                       | `wb/canvas/node/bg-secondary-default`       |
-| `wb/node-stroke-primary-{default,hover}`             | `wb/canvas/node/stroke-{default,hover}`     |
-| `wb/node-icon-primary-default`                       | `wb/canvas/node/icon-primary`               |
-| `wb/node-icon-primary-disabled`                      | _(none — handled by `wb/ui/icon/disabled`)_ |
-| `wb/node-txt-disabled`                               | `wb/canvas/node/text-disabled`              |
-| `wb/node-port-fill-{default,active}`                 | `wb/canvas/port/fill-{default,active}`      |
-| `wb/node-port-stroke-{default,active}`               | `wb/canvas/port/stroke-{default,active}`    |
-| `wb/edge-primary-default`                            | `wb/canvas/edge/stroke-default`             |
-| `wb/edge-primary-hover`                              | `wb/canvas/edge/stroke-hover`               |
-| `wb/edge-primary-active`                             | `wb/canvas/edge/stroke-active`              |
-| `wb/edge-primary-disabled`                           | `wb/canvas/edge/stroke-disabled`            |
-| `wb/edge-primary-error`                              | `wb/canvas/edge/stroke-critical` ⚠          |
-| `wb/edge-primary-success`                            | `wb/canvas/edge/stroke-success` ⚠           |
-| `wb/edge-primary-warning`                            | `wb/canvas/edge/stroke-warning` ⚠           |
+| Old token (removed) | New equivalent (created) |
+|---|---|
+| `wb/node-bg-primary-{default,hover,active,disabled}` | `wb/canvas/node/bg-primary-{…}` |
+| `wb/node-bg-secondary-default` | `wb/canvas/node/bg-secondary-default` |
+| `wb/node-stroke-primary-{default,hover}` | `wb/canvas/node/stroke-{default,hover}` |
+| `wb/node-icon-primary-default` | `wb/canvas/node/icon-primary` |
+| `wb/node-icon-primary-disabled` | *(none — handled by `wb/ui/icon/disabled`)* |
+| `wb/node-txt-disabled` | `wb/canvas/node/text-disabled` |
+| `wb/node-port-fill-{default,active}` | `wb/canvas/port/fill-{default,active}` |
+| `wb/node-port-stroke-{default,active}` | `wb/canvas/port/stroke-{default,active}` |
+| `wb/edge-primary-default` | `wb/canvas/edge/stroke-default` |
+| `wb/edge-primary-hover` | `wb/canvas/edge/stroke-hover` |
+| `wb/edge-primary-active` | `wb/canvas/edge/stroke-active` |
+| `wb/edge-primary-disabled` | `wb/canvas/edge/stroke-disabled` |
+| `wb/edge-primary-error` | `wb/canvas/edge/stroke-critical` ⚠ |
+| `wb/edge-primary-success` | `wb/canvas/edge/stroke-success` ⚠ |
+| `wb/edge-primary-warning` | `wb/canvas/edge/stroke-warning` ⚠ |
 
 New additions in `canvas/node/*` on top of the rebuild: `bg-content-default`, `text` (default), `text-subtle`, `decor-primary` (see section 9).
 
@@ -380,18 +380,18 @@ The entire old per-accent matrix is gone: `chips-neutral-{bg,icon,x}` + `chips-a
 
 ### 8.3 Other removals
 
-| Removed token                                                                                                                             | Reason / replacement                                                                                                                                                           |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `wb/shadow`                                                                                                                               | moved to the **Effects** collection → `wb/shadow/ui/color`                                                                                                                     |
-| `wb/snackbar-bg-default`                                                                                                                  | neutral snackbar now uses a foundation background; separate `snackbar/stroke-*` tokens were added                                                                              |
-| `wb/tab-stroke-line`                                                                                                                      | removed (tab line via `wb/ui/stroke/*`)                                                                                                                                        |
-| `wb/icon-black`, `wb/icon-white`                                                                                                          | removed (literal colors; use `wb/ui/icon/default` / `onaccent`)                                                                                                                |
-| `wb/dropdown-bg-destructive-default`, `…-hover`                                                                                           | removed (destructive dropdown variant retired)                                                                                                                                 |
-| `wb/dropdown-bg-secondary-active`                                                                                                         | removed                                                                                                                                                                        |
-| `wb/button-gray-bg-disabled`, `wb/button-green-bg-disabled`, `wb/button-red-bg-disabled`                                                  | consolidated into `wb/components/button/solid/disabled`                                                                                                                        |
-| `wb/txt-destuctive-default` _(ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling)_ | typo-duplicate of `txt-error-default`, merged into `wb/ui/text/critical-default`                                                                                               |
-| `wb/dropdown-bg-primary-default`, `wb/dropdown-bg-secondary-default` _(2026-06-10)_                                                       | pass-through tokens deleted after re-pointing all consumers — panels → `wb/ui/bg/base`, embedded options → `wb/ui/bg/inset`. **Do not introduce `dropdown/*` keys into code.** |
-| `wb/ui/icon/onsurface-default` _(2026-06-10)_                                                                                             | redundant duplicate of `wb/ui/icon/default` (same value and role) — merged; legacy `icon-txt-default` maps to `wb/ui/icon/default`                                             |
+| Removed token | Reason / replacement |
+|---|---|
+| `wb/shadow` | moved to the **Effects** collection → `wb/shadow/ui/color` |
+| `wb/snackbar-bg-default` | neutral snackbar now uses a foundation background; separate `snackbar/stroke-*` tokens were added |
+| `wb/tab-stroke-line` | removed (tab line via `wb/ui/stroke/*`) |
+| `wb/icon-black`, `wb/icon-white` | removed (literal colors; use `wb/ui/icon/default` / `onaccent`) |
+| `wb/dropdown-bg-destructive-default`, `…-hover` | removed (destructive dropdown variant retired) |
+| `wb/dropdown-bg-secondary-active` | removed |
+| `wb/button-gray-bg-disabled`, `wb/button-green-bg-disabled`, `wb/button-red-bg-disabled` | consolidated into `wb/components/button/solid/disabled` |
+| `wb/txt-destuctive-default` *(ID `1592:58782`; manual rename to `wb/txt-destructive-default` pending — same token under either spelling)* | typo-duplicate of `txt-error-default`, merged into `wb/ui/text/critical-default` |
+| `wb/dropdown-bg-primary-default`, `wb/dropdown-bg-secondary-default` *(2026-06-10)* | pass-through tokens deleted after re-pointing all consumers — panels → `wb/ui/bg/base`, embedded options → `wb/ui/bg/inset`. **Do not introduce `dropdown/*` keys into code.** |
+| `wb/ui/icon/onsurface-default` *(2026-06-10)* | redundant duplicate of `wb/ui/icon/default` (same value and role) — merged; legacy `icon-txt-default` maps to `wb/ui/icon/default` |
 
 ---
 
@@ -401,17 +401,17 @@ The entire old per-accent matrix is gone: `chips-neutral-{bg,icon,x}` + `chips-a
 
 The missing link for the lead color. Primary components now alias `brand/*`, not `acc1` directly. This is a thin, role-named abstraction — if the brand color ever changes again, only the `brand/*` aliases move.
 
-| Token                            | Alias         | Role                                                                                                        |
-| -------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------- |
-| `wb/ui/brand/fill`               | `acc1-500`    | primary surface (default)                                                                                   |
-| `wb/ui/brand/fill-hover`         | `acc1-600`    | primary hover                                                                                               |
-| `wb/ui/brand/fill-active`        | `acc1-700`    | primary pressed                                                                                             |
-| `wb/ui/brand/fill-subtle`        | `acc1-500-10` | ghost-primary background                                                                                    |
-| `wb/ui/brand/fill-subtle-hover`  | `acc1-500-20` | ghost hover                                                                                                 |
-| `wb/ui/brand/fill-subtle-active` | `acc1-500-30` | ghost pressed                                                                                               |
-| `wb/ui/brand/border`             | `acc1-500`    | primary outline/accent                                                                                      |
-| `wb/ui/brand/text-on`            | `gray-100`    | text on brand surface (mode-independent; verified AA on all primary button states after the `acc1` refresh) |
-| `wb/ui/brand/identity`           | `acc1-500`    | logo / brand identity                                                                                       |
+| Token | Alias | Role |
+|---|---|---|
+| `wb/ui/brand/fill` | `acc1-500` | primary surface (default) |
+| `wb/ui/brand/fill-hover` | `acc1-600` | primary hover |
+| `wb/ui/brand/fill-active` | `acc1-700` | primary pressed |
+| `wb/ui/brand/fill-subtle` | `acc1-500-10` | ghost-primary background |
+| `wb/ui/brand/fill-subtle-hover` | `acc1-500-20` | ghost hover |
+| `wb/ui/brand/fill-subtle-active` | `acc1-500-30` | ghost pressed |
+| `wb/ui/brand/border` | `acc1-500` | primary outline/accent |
+| `wb/ui/brand/text-on` | `gray-100` | text on brand surface (mode-independent; verified AA on all primary button states after the `acc1` refresh) |
+| `wb/ui/brand/identity` | `acc1-500` | logo / brand identity |
 
 ### 9.2 UI foundations (NEW)
 
@@ -440,12 +440,12 @@ The missing link for the lead color. Primary components now alias `brand/*`, not
 
 ### 9.6 Nav Button state set (NEW, 2026-06-10)
 
-| Token                                          | Light →                | Dark →                 | Scopes                   |
-| ---------------------------------------------- | ---------------------- | ---------------------- | ------------------------ |
-| `wb/components/nav-button/bg-primary-default`  | `→ colors/transparent` | `→ colors/transparent` | `FRAME_FILL, SHAPE_FILL` |
-| `wb/components/nav-button/bg-primary-pressed`  | `→ gray-900-5`         | `→ gray-100-5`         | `FRAME_FILL, SHAPE_FILL` |
-| `wb/components/nav-button/bg-primary-active`   | `→ ui/brand/fill`      | `→ ui/brand/fill`      | `FRAME_FILL, SHAPE_FILL` |
-| `wb/components/nav-button/bg-primary-focus`    | `→ gray-900-5`         | `→ gray-100-5`         | `FRAME_FILL, SHAPE_FILL` |
+| Token | Light → | Dark → | Scopes |
+|---|---|---|---|
+| `wb/components/nav-button/bg-primary-default` | `→ colors/transparent` | `→ colors/transparent` | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-pressed` | `→ gray-900-5` | `→ gray-100-5` | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-active` | `→ ui/brand/fill` | `→ ui/brand/fill` | `FRAME_FILL, SHAPE_FILL` |
+| `wb/components/nav-button/bg-primary-focus` | `→ gray-900-5` | `→ gray-100-5` | `FRAME_FILL, SHAPE_FILL` |
 | `wb/components/nav-button/bg-primary-disabled` | `→ colors/transparent` | `→ colors/transparent` | `FRAME_FILL, SHAPE_FILL` |
 
 The pre-existing `bg-primary-hover` completes the set — all 6 background states are now tokenized: default · hover · pressed · active · focus · disabled, alongside the 5 icon states (`icon-primary-{default,hover,active,pressed,disabled}`; Focus reuses `icon-primary-default` deliberately). Note: `bg-primary-pressed` and `bg-primary-focus` currently share the hover value (`gray-900-5`) — a candidate for differentiation, pending design decision.
@@ -456,19 +456,19 @@ The pre-existing `bg-primary-hover` completes the set — all 6 background state
 
 The Nav Button component in the new file was discovered still hanging on **remote variables from the old, legacy DS library** (flat names). All 402 bindings are now local (0 remote). For code that consumed the old flat names, the mapping is **state-dependent**, because one old variable served three states:
 
-| Legacy (old DS, remote)                                              | → New local token                                                     |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `wb/nav-button-icon-primary-default`                                 | `wb/components/nav-button/icon-primary-default`                       |
-| `wb/nav-button-icon-primary-hover`                                   | `wb/components/nav-button/icon-primary-hover`                         |
-| `wb/nav-button-icon-primary-active`                                  | `wb/components/nav-button/icon-primary-active`                        |
-| `wb/nav-button-icon-primary-pressed`                                 | `wb/components/nav-button/icon-primary-pressed` ⚠ _(brand `#3969FF`)_ |
-| `wb/nav-button-icon-primary-disabled`                                | `wb/components/nav-button/icon-primary-disabled`                      |
-| `wb/nav-button-bg-primary-hover` _(Hover state)_                     | `wb/components/nav-button/bg-primary-hover`                           |
-| `wb/nav-button-bg-primary-hover` _(Pressed state)_                   | `wb/components/nav-button/bg-primary-pressed`                         |
-| `wb/nav-button-bg-primary-hover` _(Focus state)_                     | `wb/components/nav-button/bg-primary-focus`                           |
-| `wb/button-primary-bg-default` _(Active background)_                 | `wb/components/nav-button/bg-primary-active` ⚠ _(brand `#3969FF`)_    |
-| `wb/ui-bg-primary-default` _(white focus inner ring)_                | `wb/ui/bg/base`                                                       |
-| `wb/pt-stroke-primary-default` _(focus ring, "No background" style)_ | `wb/ui/stroke/focus`                                                  |
+| Legacy (old DS, remote) | → New local token |
+|---|---|
+| `wb/nav-button-icon-primary-default` | `wb/components/nav-button/icon-primary-default` |
+| `wb/nav-button-icon-primary-hover` | `wb/components/nav-button/icon-primary-hover` |
+| `wb/nav-button-icon-primary-active` | `wb/components/nav-button/icon-primary-active` |
+| `wb/nav-button-icon-primary-pressed` | `wb/components/nav-button/icon-primary-pressed` ⚠ *(brand `#3969FF`)* |
+| `wb/nav-button-icon-primary-disabled` | `wb/components/nav-button/icon-primary-disabled` |
+| `wb/nav-button-bg-primary-hover` *(Hover state)* | `wb/components/nav-button/bg-primary-hover` |
+| `wb/nav-button-bg-primary-hover` *(Pressed state)* | `wb/components/nav-button/bg-primary-pressed` |
+| `wb/nav-button-bg-primary-hover` *(Focus state)* | `wb/components/nav-button/bg-primary-focus` |
+| `wb/button-primary-bg-default` *(Active background)* | `wb/components/nav-button/bg-primary-active` ⚠ *(brand `#3969FF`)* |
+| `wb/ui-bg-primary-default` *(white focus inner ring)* | `wb/ui/bg/base` |
+| `wb/pt-stroke-primary-default` *(focus ring, "No background" style)* | `wb/ui/stroke/focus` |
 
 **Visual changes (intended):** Active background and Pressed icon now use the new brand `#3969FF` instead of the stale legacy `#1096E7`. All other states changed source only (remote → local) with identical results. Placeholder icon fills (`#ffffff`) inside the swap slot remain unbound on purpose — a real icon brings its own color; do not treat them as Nav Button tokens.
 
@@ -514,17 +514,17 @@ Dimension tokens for `node/port/edge/widget`, aliasing `space/*`, `radius/*`, `s
 
 ### 12.1 Effect Styles — renamed into a slash hierarchy (10 → 10)
 
-| Old                  | New                                |
-| -------------------- | ---------------------------------- |
-| `shadow-xs`          | `shadow/ui/xs`                     |
-| `shadow-s`           | `shadow/ui/s`                      |
-| `shadow-m`           | `shadow/ui/m`                      |
-| `shadow-l`           | `shadow/ui/l`                      |
-| `shadow-xl`          | `shadow/ui/xl`                     |
-| `focus-ring-element` | `shadow/ui/focus-element`          |
-| `focus-ring-active`  | `shadow/canvas/focus-node/active`  |
+| Old | New |
+|---|---|
+| `shadow-xs` | `shadow/ui/xs` |
+| `shadow-s` | `shadow/ui/s` |
+| `shadow-m` | `shadow/ui/m` |
+| `shadow-l` | `shadow/ui/l` |
+| `shadow-xl` | `shadow/ui/xl` |
+| `focus-ring-element` | `shadow/ui/focus-element` |
+| `focus-ring-active` | `shadow/canvas/focus-node/active` |
 | `focus-ring-warning` | `shadow/canvas/focus-node/warning` |
-| `focus-ring-error`   | `shadow/canvas/focus-node/error`   |
+| `focus-ring-error` | `shadow/canvas/focus-node/error` |
 | `focus-ring-success` | `shadow/canvas/focus-node/success` |
 
 > Note: the Effect Style `focus-node/error` keeps the old `error` term (color tokens already use `critical`) — a known naming mismatch, pending closure (verified still named `error` on 2026-06-12). If you build a code-side enum, prefer `critical` and map the style name.
@@ -550,16 +550,16 @@ The Effect Styles' own color properties are **not yet bound to variables** (hard
 
 The old and new name sets are **disjoint** — this is not a rename, it's a new ramp. Every typography class in code requires manual mapping.
 
-| Old system (38)                                                 | New system (39)                                        |
-| --------------------------------------------------------------- | ------------------------------------------------------ |
-| `Heading/H1` … `Heading/H12`                                    | `Display/{S,M,L}`, `Headline/{S,M,L}`, `Title/{S,M,L}` |
-| `Paragraph/P1` … `Paragraph/P12`                                | `Body/{S,M,L}`                                         |
-| `Button/Button {Large,Medium,Small,XtraSmall}` + `Txt` variants | (covered by `Label/*`)                                 |
-| `Label/{Medium,Small,XtraSmall}`                                | `Label/{S,M,L,XL}`                                     |
-| `KeyShortcut/Txt {Large,Medium,Small}`                          | (map onto `Label/*` or `UI/Code`)                      |
-| —                                                               | `Node/{S,M,L}` _(new family for the canvas)_           |
-| —                                                               | every family has an `… Emphasized` variant             |
-| —                                                               | `UI/Code`                                              |
+| Old system (38) | New system (39) |
+|---|---|
+| `Heading/H1` … `Heading/H12` | `Display/{S,M,L}`, `Headline/{S,M,L}`, `Title/{S,M,L}` |
+| `Paragraph/P1` … `Paragraph/P12` | `Body/{S,M,L}` |
+| `Button/Button {Large,Medium,Small,XtraSmall}` + `Txt` variants | (covered by `Label/*`) |
+| `Label/{Medium,Small,XtraSmall}` | `Label/{S,M,L,XL}` |
+| `KeyShortcut/Txt {Large,Medium,Small}` | (map onto `Label/*` or `UI/Code`) |
+| — | `Node/{S,M,L}` *(new family for the canvas)* |
+| — | every family has an `… Emphasized` variant |
+| — | `UI/Code` |
 
 **Implication:** typography is the most manual part of the migration — there is no ID or name continuity. Recommended: build a mapping table from old H/P numbers to new roles (e.g. `Heading/H1` → `Display/L`, `Paragraph/P3` → `Body/M`) based on the real font sizes in both files before re-pointing.
 
@@ -651,7 +651,7 @@ Rebuilt as a 252-variant set with the full tokenized state model from section 9.
 - `ds-test-ii-audyt-usprawnien.md` (v3) — canonical design-side audit / session-restore document
 - ~~`wb-ds-changelog-dev-migration.md`~~ and ~~`wb-ds-changelog-dev-2026-06-10.md`~~ — Polish-language changelogs, **superseded by this document** and scheduled for deletion. Do not reference them.
 
-_Export-by-name reminder: if the build uses variable names as keys (Style Dictionary / Tokens Studio), every rename in this document is a downstream key change — update wherever names are hardcoded._
+*Export-by-name reminder: if the build uses variable names as keys (Style Dictionary / Tokens Studio), every rename in this document is a downstream key change — update wherever names are hardcoded.*
 
 ---
 
@@ -659,15 +659,15 @@ _Export-by-name reminder: if the build uses variable names as keys (Style Dictio
 
 All of the following was re-read live from both Figma files via the Plugin API on 2026-06-12:
 
-| Check                   | Old file (`Dv3nOrLqTgGEU7QB2SRDSL`)                                                     | New file (`hfT6zrYS948n8LrEK9y3Wh`)                                                                                                     |
-| ----------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Primitives              | 154 vars, mode `Mode 1`                                                                 | 264 vars, mode `Mode 1`                                                                                                                 |
-| Tokens                  | 207 vars, modes `Light`/`Dark`                                                          | 200 vars, modes `Light`/`Dark`; domains `wb/ui/*` 55 · `wb/components/*` 105 · `wb/canvas/*` 40; names outside the three domains: **0** |
-| Numerals                | 316 vars, mode `Mode 1`                                                                 | —                                                                                                                                       |
-| Canvas                  | —                                                                                       | 56 vars (all FLOAT), mode `value`                                                                                                       |
-| Effects                 | —                                                                                       | 29 vars, modes `light`/`dark`                                                                                                           |
-| Text Styles             | 38                                                                                      | 39                                                                                                                                      |
-| Effect Styles           | 10                                                                                      | 10 — names verified, including the `shadow/canvas/focus-node/error` mismatch                                                            |
-| `acc1-500`              | —                                                                                       | `#3969FF` confirmed (RGB 57/105/255)                                                                                                    |
-| `wb/colors/transparent` | —                                                                                       | present, `VariableID:10665:20`                                                                                                          |
-| `destuctive` typo       | **still present** as `wb/txt-destuctive-default` (`1592:58782`) — manual rename pending | zero occurrences of either spelling                                                                                                     |
+| Check | Old file (`Dv3nOrLqTgGEU7QB2SRDSL`) | New file (`hfT6zrYS948n8LrEK9y3Wh`) |
+|---|---|---|
+| Primitives | 154 vars, mode `Mode 1` | 264 vars, mode `Mode 1` |
+| Tokens | 207 vars, modes `Light`/`Dark` | 200 vars, modes `Light`/`Dark`; domains `wb/ui/*` 55 · `wb/components/*` 105 · `wb/canvas/*` 40; names outside the three domains: **0** |
+| Numerals | 316 vars, mode `Mode 1` | — |
+| Canvas | — | 56 vars (all FLOAT), mode `value` |
+| Effects | — | 29 vars, modes `light`/`dark` |
+| Text Styles | 38 | 39 |
+| Effect Styles | 10 | 10 — names verified, including the `shadow/canvas/focus-node/error` mismatch |
+| `acc1-500` | — | `#3969FF` confirmed (RGB 57/105/255) |
+| `wb/colors/transparent` | — | present, `VariableID:10665:20` |
+| `destuctive` typo | **still present** as `wb/txt-destuctive-default` (`1592:58782`) — manual rename pending | zero occurrences of either spelling |

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -11,10 +11,13 @@
     "prepare": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "codemod:map": "node scripts/build-codemod-map.mjs",
+    "codemod:apply": "node scripts/codemod-usages.mjs"
   },
   "devDependencies": {
     "@tokens-studio/sd-transforms": "^1.2.12",
+    "change-case": "^5.4.4",
     "remeda": "^2.21.2",
     "style-dictionary": "^4.3.3",
     "tsx": "^4.19.3",

--- a/packages/tokens/scripts/build-codemod-map.mjs
+++ b/packages/tokens/scripts/build-codemod-map.mjs
@@ -2,7 +2,7 @@
  * Generates codemod-map.json from the designer migration changelog
  * (migration/2026-06-15-ds2-migration-map.md).
  *
- * Parses the rename tables (section 7), the removed/rebuilt tables
+ * Parses the rename tables (section 7) and the removed/rebuilt tables
  * (sections 8.1 and 8.3) and emits, for every pair, both the Figma names and
  * the CSS custom-property names the codemod operates on:
  *   old  `wb/txt-primary-default`  -> oldCss  `--ax-txt-primary-default`
@@ -10,8 +10,11 @@
  * (The legacy export prefixed variables with `ax/`; the map's OLD column
  * writes them under `wb/`. Only the segment after the prefix matters.)
  *
- * Anything the parser cannot resolve into an unambiguous 1:1 pair lands in
- * `unparsed` — loudly, so a map update never silently drops rows.
+ * The parser never guesses: only code spans shaped like a concrete token
+ * path (`wb/…`, no globs) count as names. A row whose replacement cell stays
+ * ambiguous after that filter lands in `unparsed` — unless a human resolved
+ * it in RESOLVED_BY_HAND below, which is the explicit, reviewable place for
+ * judgment calls the changelog prose requires.
  *
  * Usage: node scripts/build-codemod-map.mjs [path-to-map.md]
  */
@@ -26,7 +29,31 @@ const OUT_PATH = path.join(TOKENS_DIRECTORY, 'codemod-map.json');
 
 const markdown = readFileSync(MAP_PATH, 'utf8');
 
+/**
+ * Rows whose replacement cell mixes prose with more than one candidate —
+ * resolved by a human against the changelog text instead of a heuristic.
+ * Keyed by the OLD Figma name; `valueChanged` mirrors the row's ⚠ where set.
+ */
+const RESOLVED_BY_HAND = {
+  // §8.3: typo-duplicate of txt-error-default, "merged into wb/ui/text/critical-default";
+  // the row names both spellings ("same token under either spelling").
+  'wb/txt-destuctive-default': { replacement: 'wb/ui/text/critical-default' },
+  'wb/txt-destructive-default': { replacement: 'wb/ui/text/critical-default' },
+  // §8.3: interim 2.0 name, never present in the legacy export — merged into icon/default.
+  'wb/ui/icon/onsurface-default': { replacement: 'wb/ui/icon/default' },
+  // §8.3: "literal colors; use wb/ui/icon/default / onaccent".
+  'wb/icon-black': { replacement: 'wb/ui/icon/default' },
+  'wb/icon-white': {
+    replacement: 'wb/ui/icon/onaccent-default',
+    note: 'onaccent icon token — verify the exact name against the 2.0 export',
+  },
+};
+
 const ELLIPSIS = /\{(?:…|\.\.\.)\}/;
+
+/** A concrete token path: `wb/…`, no glob stars. Filters out Figma IDs,
+ * suffix shorthands, and `--wb-…` codeSyntax mentions inside notes. */
+const isTokenPath = (span) => /^wb\/[^*]+$/.test(span);
 
 /**
  * Expands `{a,b,c}` alternatives and `accN..M` ranges into concrete names.
@@ -55,9 +82,10 @@ function expandName(name, inheritedList) {
 }
 
 /**
- * Expands every code span of an OLD cell. A span that starts with an
- * ellipsis (`…-hover`) inherits its stem from the previous span in the same
- * cell ('wb/dropdown-bg-destructive-default', '…-hover' → …-destructive-hover).
+ * Expands the OLD cell's code spans. A span that starts with an ellipsis
+ * (`…-hover`) inherits its stem from the previous span in the same cell;
+ * anything that is neither a token path nor an ellipsis (e.g. a Figma ID
+ * mentioned in a note) is dropped.
  */
 function expandOldCell(spans, inheritedList) {
   const names = [];
@@ -68,6 +96,7 @@ function expandOldCell(spans, inheritedList) {
       names.push(previous.replace(/-[a-z0-9]+$/, '') + tail);
       continue;
     }
+    if (!isTokenPath(span)) continue;
     names.push(...expandName(span, inheritedList));
   }
   return names;
@@ -96,16 +125,48 @@ function cells(row) {
 
 const codeSpans = (text) => [...text.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
 
-/** `{…}` / `..6` in the NEW column inherits the same expansion list as OLD. */
-function resolveNewNames(newSpans, braceList) {
-  const target = newSpans[0];
-  if (target === undefined) return [];
-  return expandName(target, braceList);
-}
+/** Italic notes, whichever emphasis marker the document carries. */
 const noteOf = (text) => {
-  const italics = [...text.matchAll(/\*\(([^)]+)\)\*/g)].map((match) => match[1]);
+  const italics = [...text.matchAll(/[*_]\(([^)]+)\)[*_]/g)].map((match) => match[1]);
   return italics.length > 0 ? italics.join('; ') : undefined;
 };
+
+/**
+ * A row-level ⚠ with a note naming specific states (e.g. "pressed: brand
+ * #3969FF") applies only to those expanded names; without such a note it
+ * applies to every name from the row.
+ */
+function valueChangedFor(name, rowFlag, note, braceList) {
+  if (!rowFlag) return false;
+  if (!note || !braceList) return true;
+  const mentioned = braceList.filter((state) => new RegExp(`\\b${state}\\b`).test(note));
+  if (mentioned.length === 0) return true;
+  return mentioned.some((state) => name.endsWith(`-${state}`) || name.endsWith(`/${state}`));
+}
+
+function renameEntry(oldName, target, { rowFlag, note, braceList }) {
+  return {
+    old: oldName,
+    new: target,
+    oldCss: oldCss(oldName),
+    newCss: newCss(target),
+    ...(valueChangedFor(oldName, rowFlag, note, braceList) && { valueChanged: true }),
+    ...(note && { note }),
+  };
+}
+
+function removedEntry(oldName, replacement, { rowFlag, note, braceList, rebuilt, extra = {} }) {
+  return {
+    old: oldName,
+    replacement,
+    oldCss: oldCss(oldName),
+    replacementCss: replacement === null ? null : newCss(replacement),
+    ...(rebuilt && { rebuilt }),
+    ...(valueChangedFor(oldName, rowFlag, note, braceList) && { valueChanged: true }),
+    ...(note && { note }),
+    ...extra,
+  };
+}
 
 const lines = markdown.split('\n');
 const renames = [];
@@ -140,8 +201,7 @@ for (const line of lines) {
   const braceList = lastBraceList;
 
   const oldNames = expandOldCell(codeSpans(oldCell), braceList);
-  const newSpans = codeSpans(newCell);
-  const valueChanged = line.includes('⚠');
+  const rowFlag = line.includes('⚠');
   const note = noteOf(line) ?? noteOf(oldCell);
 
   if (oldNames.length === 0) {
@@ -149,31 +209,21 @@ for (const line of lines) {
     continue;
   }
 
+  const newSpansAll = codeSpans(newCell);
+  const candidates = newSpansAll.filter((span) => isTokenPath(span)).flatMap((span) => expandName(span, braceList));
+
   const isRemovedRow = /\*\*removed\*\*/i.test(newCell) || /\(none/i.test(newCell) || inRemoved === true;
 
   if (inRenames && !isRemovedRow) {
-    const newNames = resolveNewNames(newSpans, braceList);
-    if (newNames.length === oldNames.length) {
+    if (candidates.length === oldNames.length) {
       for (const [position, oldName] of oldNames.entries()) {
-        renames.push({
-          old: oldName,
-          new: newNames[position],
-          oldCss: oldCss(oldName),
-          newCss: newCss(newNames[position]),
-          ...(valueChanged && { valueChanged }),
-          ...(note && { note }),
-        });
+        renames.push(renameEntry(oldName, candidates[position], { rowFlag, note, braceList }));
       }
-    } else if (newNames.length === 1) {
+    } else if (candidates.length > 0 && newSpansAll.filter((span) => isTokenPath(span)).length === 1) {
+      // One token expression in the cell (extra spans were note mentions);
+      // a single unexpanded target maps every OLD name onto it.
       for (const oldName of oldNames) {
-        renames.push({
-          old: oldName,
-          new: newNames[0],
-          oldCss: oldCss(oldName),
-          newCss: newCss(newNames[0]),
-          ...(valueChanged && { valueChanged }),
-          ...(note && { note }),
-        });
+        renames.push(renameEntry(oldName, candidates[0], { rowFlag, note, braceList }));
       }
     } else {
       unparsed.push({ section, row: line.trim() });
@@ -182,43 +232,37 @@ for (const line of lines) {
   }
 
   // Removed rows (8.1 rebuilt, 8.3 removals, and `**removed**` rows in 7.7).
-  const replacementNames = resolveNewNames(newSpans, braceList);
   const rebuilt = section === '8.1';
-  if (replacementNames.length === oldNames.length && replacementNames.length > 0) {
+  const context = { rowFlag, note, braceList, rebuilt };
+
+  const handResolved = oldNames.every((name) => RESOLVED_BY_HAND[name]);
+  if (handResolved) {
+    for (const oldName of oldNames) {
+      const resolution = RESOLVED_BY_HAND[oldName];
+      removed.push(
+        removedEntry(oldName, resolution.replacement, {
+          ...context,
+          extra: { resolvedByHand: true, ...(resolution.note && { note: resolution.note }) },
+        }),
+      );
+    }
+  } else if (candidates.length === oldNames.length && candidates.length > 0) {
     for (const [position, oldName] of oldNames.entries()) {
-      removed.push({
-        old: oldName,
-        replacement: replacementNames[position],
-        oldCss: oldCss(oldName),
-        replacementCss: newCss(replacementNames[position]),
-        ...(rebuilt && { rebuilt }),
-        ...(valueChanged && { valueChanged }),
-        ...(note && { note }),
-      });
+      removed.push(removedEntry(oldName, candidates[position], context));
     }
-  } else if (replacementNames.length === 1) {
+  } else if (candidates.length === 1 && newSpansAll.length === 1) {
+    // A clean consolidation: many OLD names, exactly one token span and
+    // nothing else in the cell (e.g. button-*-disabled → solid/disabled).
     for (const oldName of oldNames) {
-      removed.push({
-        old: oldName,
-        replacement: replacementNames[0],
-        oldCss: oldCss(oldName),
-        replacementCss: newCss(replacementNames[0]),
-        ...(rebuilt && { rebuilt }),
-        ...(valueChanged && { valueChanged }),
-        ...(note && { note }),
-      });
+      removed.push(removedEntry(oldName, candidates[0], context));
     }
-  } else if (replacementNames.length === 0) {
+  } else if (candidates.length === 0) {
     for (const oldName of oldNames) {
-      removed.push({
-        old: oldName,
-        replacement: null,
-        oldCss: oldCss(oldName),
-        replacementCss: null,
-        ...(note && { note }),
-      });
+      removed.push(removedEntry(oldName, null, context));
     }
   } else {
+    // More candidates than a positional or clean-consolidation match allows
+    // — prose-mixed cell; do not guess.
     unparsed.push({ section, row: line.trim() });
   }
 }
@@ -243,13 +287,7 @@ const map = {
   manual: [
     {
       pattern: '--ax-chips-*',
-      reason:
-        'Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task.',
-    },
-    {
-      pattern: '--ax-nav-button-bg-primary-hover',
-      reason:
-        'One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task.',
+      reason: 'Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task.',
     },
   ],
   renames: dedupedRenames,
@@ -263,9 +301,13 @@ const map = {
 
 writeFileSync(OUT_PATH, `${JSON.stringify(map, null, 2)}\n`);
 console.log(
-  `codemod-map.json: ${dedupedRenames.length} renames, ${dedupedRemoved.length} removed, ${unparsed.length} unparsed rows.`,
+  `codemod-map.json: ${dedupedRenames.length} renames, ${dedupedRemoved.length} removed ` +
+    `(${dedupedRemoved.filter((entry) => entry.replacement === null).length} without a replacement, ` +
+    `${dedupedRemoved.filter((entry) => entry.resolvedByHand).length} resolved by hand), ` +
+    `${unparsed.length} unparsed rows.`,
 );
 if (unparsed.length > 0) {
-  console.log('unparsed rows (resolve manually or fix the parser):');
+  console.log('unparsed rows (resolve in RESOLVED_BY_HAND or fix the parser):');
   for (const entry of unparsed) console.log(`  [${entry.section}] ${entry.row}`);
+  process.exitCode = 1;
 }

--- a/packages/tokens/scripts/build-codemod-map.mjs
+++ b/packages/tokens/scripts/build-codemod-map.mjs
@@ -244,12 +244,12 @@ const map = {
     {
       pattern: '--ax-chips-*',
       reason:
-        'Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task (WB-489).',
+        'Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task.',
     },
     {
       pattern: '--ax-nav-button-bg-primary-hover',
       reason:
-        'One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task (WB-490).',
+        'One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task.',
     },
   ],
   renames: dedupedRenames,

--- a/packages/tokens/scripts/build-codemod-map.mjs
+++ b/packages/tokens/scripts/build-codemod-map.mjs
@@ -1,0 +1,271 @@
+/**
+ * Generates codemod-map.json from the designer migration changelog
+ * (migration/2026-06-15-ds2-migration-map.md).
+ *
+ * Parses the rename tables (section 7), the removed/rebuilt tables
+ * (sections 8.1 and 8.3) and emits, for every pair, both the Figma names and
+ * the CSS custom-property names the codemod operates on:
+ *   old  `wb/txt-primary-default`  -> oldCss  `--ax-txt-primary-default`
+ *   new  `wb/ui/text/default`      -> newCss  `--wb-ui-text-default`
+ * (The legacy export prefixed variables with `ax/`; the map's OLD column
+ * writes them under `wb/`. Only the segment after the prefix matters.)
+ *
+ * Anything the parser cannot resolve into an unambiguous 1:1 pair lands in
+ * `unparsed` — loudly, so a map update never silently drops rows.
+ *
+ * Usage: node scripts/build-codemod-map.mjs [path-to-map.md]
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const TOKENS_DIRECTORY = path.resolve(fileURLToPath(import.meta.url), '../..');
+const MAP_PATH = process.argv[2] ?? path.join(TOKENS_DIRECTORY, 'migration/2026-06-15-ds2-migration-map.md');
+const OUT_PATH = path.join(TOKENS_DIRECTORY, 'codemod-map.json');
+
+const markdown = readFileSync(MAP_PATH, 'utf8');
+
+const ELLIPSIS = /\{(?:…|\.\.\.)\}/;
+
+/**
+ * Expands `{a,b,c}` alternatives and `accN..M` ranges into concrete names.
+ * `{…}` inherits `inheritedList` — the last fully-written brace list in the
+ * current table (the map's convention: the first row spells the states out,
+ * later rows abbreviate).
+ */
+function expandName(name, inheritedList) {
+  const resolved = ELLIPSIS.test(name) && inheritedList ? name.replace(ELLIPSIS, `{${inheritedList.join(',')}}`) : name;
+  const braceMatch = resolved.match(/^(.*)\{([^}]+)\}(.*)$/);
+  if (braceMatch) {
+    return braceMatch[2]
+      .split(',')
+      .flatMap((part) => expandName(`${braceMatch[1]}${part.trim()}${braceMatch[3]}`, inheritedList));
+  }
+  const rangeMatch = resolved.match(/^(.*?)(\d+)\.\.(\d+)(.*)$/);
+  if (rangeMatch) {
+    const [, head, from, to, tail] = rangeMatch;
+    const names = [];
+    for (let index = Number(from); index <= Number(to); index += 1) {
+      names.push(`${head}${index}${tail}`);
+    }
+    return names;
+  }
+  return [resolved];
+}
+
+/**
+ * Expands every code span of an OLD cell. A span that starts with an
+ * ellipsis (`…-hover`) inherits its stem from the previous span in the same
+ * cell ('wb/dropdown-bg-destructive-default', '…-hover' → …-destructive-hover).
+ */
+function expandOldCell(spans, inheritedList) {
+  const names = [];
+  for (const [index, span] of spans.entries()) {
+    if (/^(…|\.\.\.)/.test(span) && index > 0) {
+      const tail = span.replace(/^(…|\.\.\.)/, '');
+      const previous = spans[index - 1];
+      names.push(previous.replace(/-[a-z0-9]+$/, '') + tail);
+      continue;
+    }
+    names.push(...expandName(span, inheritedList));
+  }
+  return names;
+}
+
+function toCss(figmaName, prefix) {
+  const withoutNamespace = figmaName.replace(/^wb\//, '');
+  const kebab = withoutNamespace
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '');
+  return `${prefix}${kebab}`;
+}
+
+const oldCss = (name) => toCss(name, '--ax-');
+const newCss = (name) => toCss(name, '--wb-');
+
+/** Splits a markdown table row into trimmed cells. */
+function cells(row) {
+  return row
+    .replace(/^\|/, '')
+    .replace(/\|\s*$/, '')
+    .split('|')
+    .map((cell) => cell.trim());
+}
+
+const codeSpans = (text) => [...text.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+
+/** `{…}` / `..6` in the NEW column inherits the same expansion list as OLD. */
+function resolveNewNames(newSpans, braceList) {
+  const target = newSpans[0];
+  if (target === undefined) return [];
+  return expandName(target, braceList);
+}
+const noteOf = (text) => {
+  const italics = [...text.matchAll(/\*\(([^)]+)\)\*/g)].map((match) => match[1]);
+  return italics.length > 0 ? italics.join('; ') : undefined;
+};
+
+const lines = markdown.split('\n');
+const renames = [];
+const removed = [];
+const unparsed = [];
+
+let section = '';
+let lastBraceList;
+for (const line of lines) {
+  const heading = line.match(/^#{2,3}\s+(\d+(?:\.\d+)?)/);
+  if (heading) {
+    section = heading[1];
+    lastBraceList = undefined;
+  }
+
+  const inRenames = section.startsWith('7.');
+  const inRemoved = section === '8.1' || section === '8.3';
+  if (!inRenames && !inRemoved) continue;
+  if (!line.startsWith('|') || /^\|\s*-+/.test(line) || /^\|\s*Old/i.test(line) || /^\|\s*Removed/i.test(line)) {
+    continue;
+  }
+
+  const [oldCell, newCell] = cells(line);
+  if (oldCell === undefined || newCell === undefined) continue;
+
+  // A fully-written brace list becomes the inheritance context for `{…}`
+  // rows below it in the same table.
+  const fullBrace = oldCell.match(/\{([^}…]+)\}/);
+  if (fullBrace && fullBrace[1].includes(',')) {
+    lastBraceList = fullBrace[1].split(',').map((part) => part.trim());
+  }
+  const braceList = lastBraceList;
+
+  const oldNames = expandOldCell(codeSpans(oldCell), braceList);
+  const newSpans = codeSpans(newCell);
+  const valueChanged = line.includes('⚠');
+  const note = noteOf(line) ?? noteOf(oldCell);
+
+  if (oldNames.length === 0) {
+    unparsed.push({ section, row: line.trim() });
+    continue;
+  }
+
+  const isRemovedRow = /\*\*removed\*\*/i.test(newCell) || /\(none/i.test(newCell) || inRemoved === true;
+
+  if (inRenames && !isRemovedRow) {
+    const newNames = resolveNewNames(newSpans, braceList);
+    if (newNames.length === oldNames.length) {
+      for (const [position, oldName] of oldNames.entries()) {
+        renames.push({
+          old: oldName,
+          new: newNames[position],
+          oldCss: oldCss(oldName),
+          newCss: newCss(newNames[position]),
+          ...(valueChanged && { valueChanged }),
+          ...(note && { note }),
+        });
+      }
+    } else if (newNames.length === 1) {
+      for (const oldName of oldNames) {
+        renames.push({
+          old: oldName,
+          new: newNames[0],
+          oldCss: oldCss(oldName),
+          newCss: newCss(newNames[0]),
+          ...(valueChanged && { valueChanged }),
+          ...(note && { note }),
+        });
+      }
+    } else {
+      unparsed.push({ section, row: line.trim() });
+    }
+    continue;
+  }
+
+  // Removed rows (8.1 rebuilt, 8.3 removals, and `**removed**` rows in 7.7).
+  const replacementNames = resolveNewNames(newSpans, braceList);
+  const rebuilt = section === '8.1';
+  if (replacementNames.length === oldNames.length && replacementNames.length > 0) {
+    for (const [position, oldName] of oldNames.entries()) {
+      removed.push({
+        old: oldName,
+        replacement: replacementNames[position],
+        oldCss: oldCss(oldName),
+        replacementCss: newCss(replacementNames[position]),
+        ...(rebuilt && { rebuilt }),
+        ...(valueChanged && { valueChanged }),
+        ...(note && { note }),
+      });
+    }
+  } else if (replacementNames.length === 1) {
+    for (const oldName of oldNames) {
+      removed.push({
+        old: oldName,
+        replacement: replacementNames[0],
+        oldCss: oldCss(oldName),
+        replacementCss: newCss(replacementNames[0]),
+        ...(rebuilt && { rebuilt }),
+        ...(valueChanged && { valueChanged }),
+        ...(note && { note }),
+      });
+    }
+  } else if (replacementNames.length === 0) {
+    for (const oldName of oldNames) {
+      removed.push({
+        old: oldName,
+        replacement: null,
+        oldCss: oldCss(oldName),
+        replacementCss: null,
+        ...(note && { note }),
+      });
+    }
+  } else {
+    unparsed.push({ section, row: line.trim() });
+  }
+}
+
+// Some tokens appear both in a section-7 rename row (all states expanded) and
+// in a section-8.3 removal row (state-specific consolidation) — the specific
+// removal wins. Within `removed`, 7.7's inline `**removed**` rows repeat 8.3.
+const removedByCss = new Map();
+for (const entry of removed) {
+  if (!removedByCss.has(entry.oldCss)) removedByCss.set(entry.oldCss, entry);
+}
+const dedupedRemoved = [...removedByCss.values()];
+const dedupedRenames = renames.filter((entry) => !removedByCss.has(entry.oldCss));
+
+const map = {
+  $source: path.relative(TOKENS_DIRECTORY, MAP_PATH),
+  $generatedBy: 'scripts/build-codemod-map.mjs',
+  // Primitives keep their names 1:1 under the new namespace; validated
+  // against the real 2.0 export by the manifest when it lands.
+  prefixRules: [{ oldCssPrefix: '--ax-colors-', newCssPrefix: '--wb-colors-' }],
+  // Not expressible as 1:1 renames — handled inside their component tasks:
+  manual: [
+    {
+      pattern: '--ax-chips-*',
+      reason:
+        'Chips rebuilt as a 4-token factory (map §8.2/§9.3) — chip coloring is rebuilt in the Chips task (WB-489).',
+    },
+    {
+      pattern: '--ax-nav-button-bg-primary-hover',
+      reason:
+        'One legacy token served hover/pressed/focus states (map §10) — split per state in the Buttons task (WB-490).',
+    },
+  ],
+  renames: dedupedRenames,
+  removed: dedupedRemoved,
+  // Numerals (spacing/radius/stroke) have no rename rows in the designer map —
+  // spacing migrated in Figma via bindings. Pairs are generated value→token
+  // against the real 2.0 export in the pipeline-switch PR and appended here.
+  dimensions: [],
+  unparsed,
+};
+
+writeFileSync(OUT_PATH, `${JSON.stringify(map, null, 2)}\n`);
+console.log(
+  `codemod-map.json: ${dedupedRenames.length} renames, ${dedupedRemoved.length} removed, ${unparsed.length} unparsed rows.`,
+);
+if (unparsed.length > 0) {
+  console.log('unparsed rows (resolve manually or fix the parser):');
+  for (const entry of unparsed) console.log(`  [${entry.section}] ${entry.row}`);
+}

--- a/packages/tokens/scripts/build-codemod-map.mjs
+++ b/packages/tokens/scripts/build-codemod-map.mjs
@@ -114,7 +114,6 @@ function toCss(figmaName, prefix) {
 const oldCss = (name) => toCss(name, '--ax-');
 const newCss = (name) => toCss(name, '--wb-');
 
-/** Splits a markdown table row into trimmed cells. */
 function cells(row) {
   return row
     .replace(/^\|/, '')
@@ -192,8 +191,6 @@ for (const line of lines) {
   const [oldCell, newCell] = cells(line);
   if (oldCell === undefined || newCell === undefined) continue;
 
-  // A fully-written brace list becomes the inheritance context for `{…}`
-  // rows below it in the same table.
   const fullBrace = oldCell.match(/\{([^}…]+)\}/);
   if (fullBrace && fullBrace[1].includes(',')) {
     lastBraceList = fullBrace[1].split(',').map((part) => part.trim());
@@ -261,8 +258,6 @@ for (const line of lines) {
       removed.push(removedEntry(oldName, null, context));
     }
   } else {
-    // More candidates than a positional or clean-consolidation match allows
-    // — prose-mixed cell; do not guess.
     unparsed.push({ section, row: line.trim() });
   }
 }
@@ -283,7 +278,6 @@ const map = {
   // Primitives keep their names 1:1 under the new namespace; validated
   // against the real 2.0 export by the manifest when it lands.
   prefixRules: [{ oldCssPrefix: '--ax-colors-', newCssPrefix: '--wb-colors-' }],
-  // Not expressible as 1:1 renames — handled inside their component tasks:
   manual: [
     {
       pattern: '--ax-chips-*',

--- a/packages/tokens/scripts/codemod-usages.mjs
+++ b/packages/tokens/scripts/codemod-usages.mjs
@@ -1,0 +1,106 @@
+/**
+ * Rewrites `var(--ax-…)` usages in app/package sources to their DS 2.0
+ * `var(--wb-…)` targets, following codemod-map.json (decision: fix usages at
+ * the source instead of shipping a compatibility bridge).
+ *
+ * Replacement order per usage:
+ *   1. exact pair from `renames` / `removed` (with a replacement) / `dimensions`
+ *   2. `prefixRules` (primitives keep their names under the new namespace)
+ *   3. `manual` patterns and replacement-less removals are never rewritten —
+ *      they are reported for the accompanying hand-edit.
+ *
+ * Dry-run by default; pass --write to modify files.
+ *
+ * Usage: node scripts/codemod-usages.mjs [--write]
+ */
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const TOKENS_DIRECTORY = path.resolve(fileURLToPath(import.meta.url), '../..');
+const REPO_ROOT = path.resolve(TOKENS_DIRECTORY, '../..');
+const WRITE = process.argv.includes('--write');
+
+const map = JSON.parse(readFileSync(path.join(TOKENS_DIRECTORY, 'codemod-map.json'), 'utf8'));
+
+const exactPairs = new Map();
+for (const entry of map.renames) exactPairs.set(entry.oldCss, entry.newCss);
+for (const entry of map.dimensions ?? []) exactPairs.set(entry.oldCss, entry.newCss);
+const removedWithoutReplacement = new Set();
+for (const entry of map.removed) {
+  if (entry.replacementCss) exactPairs.set(entry.oldCss, entry.replacementCss);
+  else removedWithoutReplacement.add(entry.oldCss);
+}
+const manualPrefixes = (map.manual ?? []).map((entry) => entry.pattern.replace(/\*$/, ''));
+
+const SOURCE_EXTENSIONS = new Set(['.css', '.scss', '.ts', '.tsx']);
+const scanRoots = ['packages', 'apps']
+  .flatMap((group) => {
+    const groupDirectory = path.join(REPO_ROOT, group);
+    return readdirSync(groupDirectory).map((name) => path.join(groupDirectory, name, 'src'));
+  })
+  .filter((directory) => !directory.includes(`apps${path.sep}docs`));
+
+function walk(directory, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(directory);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(directory, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (SOURCE_EXTENSIONS.has(path.extname(full))) out.push(full);
+  }
+  return out;
+}
+
+const USE_RE = /var\(\s*(--ax-[A-Za-z0-9_-]+)/g;
+
+const rewriteCounts = new Map();
+const needsHand = new Map();
+let changedFiles = 0;
+
+for (const file of scanRoots.flatMap((directory) => walk(directory))) {
+  const text = readFileSync(file, 'utf8');
+  let fileChanged = false;
+
+  const rewritten = text.replaceAll(USE_RE, (match, name) => {
+    const manual = manualPrefixes.some((prefix) => name.startsWith(prefix));
+    if (manual || removedWithoutReplacement.has(name)) {
+      const reason = manual ? 'manual' : 'removed without replacement';
+      const key = `${name} (${reason})`;
+      needsHand.set(key, [...(needsHand.get(key) ?? []), path.relative(REPO_ROOT, file)]);
+      return match;
+    }
+
+    let target = exactPairs.get(name);
+    if (!target) {
+      const rule = map.prefixRules.find((candidate) => name.startsWith(candidate.oldCssPrefix));
+      if (rule) target = name.replace(rule.oldCssPrefix, rule.newCssPrefix);
+    }
+    if (!target) return match;
+
+    rewriteCounts.set(target, (rewriteCounts.get(target) ?? 0) + 1);
+    fileChanged = true;
+    return match.replace(name, target);
+  });
+
+  if (fileChanged) {
+    changedFiles += 1;
+    if (WRITE) writeFileSync(file, rewritten);
+  }
+}
+
+const totalRewrites = [...rewriteCounts.values()].reduce((sum, count) => sum + count, 0);
+console.log(
+  `codemod-usages (${WRITE ? 'write' : 'dry-run'}): ${totalRewrites} usages across ${changedFiles} files ` +
+    `(${rewriteCounts.size} distinct targets).`,
+);
+if (needsHand.size > 0) {
+  console.log(`needs a hand-edit (${needsHand.size} names):`);
+  for (const [name, files] of needsHand) console.log(`  ${name} — ${[...new Set(files)].join(', ')}`);
+}
+if (!WRITE) console.log('No files modified. Re-run with --write to apply.');

--- a/packages/tokens/scripts/codemod-usages.mjs
+++ b/packages/tokens/scripts/codemod-usages.mjs
@@ -12,9 +12,8 @@
  * names that exist in today's token dist (a real gap that will dangle after
  * the pipeline switch) and component-local names that need no rewrite.
  *
- * Dry-run by default; pass --write to modify files. apps/docs is excluded
- * (not part of the shipped packages; its one usage is handled in the docs
- * workflow separately).
+ * Dry-run by default; pass --write to modify files. apps/docs is excluded —
+ * it is not part of the shipped packages.
  *
  * Usage: node scripts/codemod-usages.mjs [--write]
  */

--- a/packages/tokens/scripts/codemod-usages.mjs
+++ b/packages/tokens/scripts/codemod-usages.mjs
@@ -5,15 +5,20 @@
  *
  * Replacement order per usage:
  *   1. exact pair from `renames` / `removed` (with a replacement) / `dimensions`
- *   2. `prefixRules` (primitives keep their names under the new namespace)
- *   3. `manual` patterns and replacement-less removals are never rewritten —
- *      they are reported for the accompanying hand-edit.
+ *   2. `manual` patterns and replacement-less removals — never rewritten,
+ *      reported for the accompanying hand-edit
+ *   3. `prefixRules` (primitives keep their names under the new namespace)
+ * Anything that matches none of the above is reported as unmapped, split into
+ * names that exist in today's token dist (a real gap that will dangle after
+ * the pipeline switch) and component-local names that need no rewrite.
  *
- * Dry-run by default; pass --write to modify files.
+ * Dry-run by default; pass --write to modify files. apps/docs is excluded
+ * (not part of the shipped packages; its one usage is handled in the docs
+ * workflow separately).
  *
  * Usage: node scripts/codemod-usages.mjs [--write]
  */
-import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -45,22 +50,31 @@ const scanRoots = ['packages', 'apps']
 function walk(directory, out = []) {
   let entries;
   try {
-    entries = readdirSync(directory);
+    entries = readdirSync(directory, { withFileTypes: true });
   } catch {
     return out;
   }
   for (const entry of entries) {
-    const full = path.join(directory, entry);
-    if (statSync(full).isDirectory()) walk(full, out);
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) walk(full, out);
     else if (SOURCE_EXTENSIONS.has(path.extname(full))) out.push(full);
   }
   return out;
+}
+
+const distributionDefinitions = new Set();
+for (const file of walk(path.join(TOKENS_DIRECTORY, 'dist'))) {
+  if (!file.endsWith('.css')) continue;
+  for (const match of readFileSync(file, 'utf8').matchAll(/(--ax-[A-Za-z0-9_-]+)\s*:/g)) {
+    distributionDefinitions.add(match[1]);
+  }
 }
 
 const USE_RE = /var\(\s*(--ax-[A-Za-z0-9_-]+)/g;
 
 const rewriteCounts = new Map();
 const needsHand = new Map();
+const unmapped = new Map();
 let changedFiles = 0;
 
 for (const file of scanRoots.flatMap((directory) => walk(directory))) {
@@ -68,20 +82,26 @@ for (const file of scanRoots.flatMap((directory) => walk(directory))) {
   let fileChanged = false;
 
   const rewritten = text.replaceAll(USE_RE, (match, name) => {
-    const manual = manualPrefixes.some((prefix) => name.startsWith(prefix));
-    if (manual || removedWithoutReplacement.has(name)) {
-      const reason = manual ? 'manual' : 'removed without replacement';
-      const key = `${name} (${reason})`;
-      needsHand.set(key, [...(needsHand.get(key) ?? []), path.relative(REPO_ROOT, file)]);
-      return match;
-    }
-
+    // Exact pairs win over the manual globs: chips-neutral-txt has a clean
+    // rename while --ax-chips-* as a family is rebuilt by hand.
     let target = exactPairs.get(name);
+
     if (!target) {
+      const manual = manualPrefixes.some((prefix) => name.startsWith(prefix));
+      if (manual || removedWithoutReplacement.has(name)) {
+        const reason = manual ? 'manual' : 'removed without replacement';
+        const key = `${name} (${reason})`;
+        needsHand.set(key, [...(needsHand.get(key) ?? []), path.relative(REPO_ROOT, file)]);
+        return match;
+      }
       const rule = map.prefixRules.find((candidate) => name.startsWith(candidate.oldCssPrefix));
       if (rule) target = name.replace(rule.oldCssPrefix, rule.newCssPrefix);
     }
-    if (!target) return match;
+
+    if (!target) {
+      unmapped.set(name, (unmapped.get(name) ?? 0) + 1);
+      return match;
+    }
 
     rewriteCounts.set(target, (rewriteCounts.get(target) ?? 0) + 1);
     fileChanged = true;
@@ -100,7 +120,32 @@ console.log(
     `(${rewriteCounts.size} distinct targets).`,
 );
 if (needsHand.size > 0) {
-  console.log(`needs a hand-edit (${needsHand.size} names):`);
+  console.log(`\nneeds a hand-edit (${needsHand.size} names):`);
   for (const [name, files] of needsHand) console.log(`  ${name} — ${[...new Set(files)].join(', ')}`);
 }
-if (!WRITE) console.log('No files modified. Re-run with --write to apply.');
+
+const gaps = [...unmapped.entries()].filter(([name]) => distributionDefinitions.has(name));
+const componentLocal = [...unmapped.entries()].filter(([name]) => !distributionDefinitions.has(name));
+const sum = (entries) => entries.reduce((total, [, count]) => total + count, 0);
+const byPrefix = (entries) => {
+  const groups = new Map();
+  for (const [name, count] of entries) {
+    const prefix = name.split('-').slice(0, 4).join('-');
+    groups.set(prefix, (groups.get(prefix) ?? 0) + count);
+  }
+  return [...groups.entries()].sort((a, b) => b[1] - a[1]);
+};
+if (gaps.length > 0) {
+  console.log(
+    `\nunmapped but defined in today's dist — will dangle after the pipeline switch ` +
+      `(${gaps.length} names / ${sum(gaps)} usages; dimensions land with the 2.0 export):`,
+  );
+  for (const [prefix, count] of byPrefix(gaps)) console.log(`  ${prefix}* — ${count}`);
+}
+if (componentLocal.length > 0) {
+  console.log(
+    `\nunmapped component-local names (defined in package sources, no rewrite needed): ` +
+      `${componentLocal.length} names / ${sum(componentLocal)} usages.`,
+  );
+}
+if (!WRITE) console.log('\nNo files modified. Re-run with --write to apply.');

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -2,16 +2,23 @@ import fs from 'node:fs';
 
 import { tokensToCss } from './tokens-to-css';
 
+import tokens from '../tokens.json';
 import { OUTPUT_DIR } from './constants';
 import { ejectTokens } from './eject-tokens';
 import { generateCSSBundle } from './generate-css-bundle';
 import { buildManifest } from './manifest';
+import { assertNoValueCollisions } from './validate-collisions';
 
 // Stale outputs must not survive a rebuild: a renamed set leaves its old file
 // behind, and an incremental UI build would ship it as if it were current.
 fs.rmSync(OUTPUT_DIR, { recursive: true, force: true });
 
 const manifest = buildManifest();
+
+assertNoValueCollisions(
+  tokens,
+  [...manifest.primitives, ...manifest.themes].map((entry) => entry.key),
+);
 
 ejectTokens(manifest);
 await tokensToCss(manifest);

--- a/packages/tokens/src/validate-collisions.spec.ts
+++ b/packages/tokens/src/validate-collisions.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { assertNoValueCollisions, findCssNameCollisions } from './validate-collisions';
+
+describe('findCssNameCollisions', () => {
+  it('finds names that kebab to the same CSS custom property', () => {
+    const collisions = findCssNameCollisions({
+      ax: {
+        colors: {
+          'acc7- 100': { value: '#cfd0d6', type: 'color' },
+          'acc7-100': { value: '#cfd0d6', type: 'color' },
+          'acc7-200': { value: '#a0a1ad', type: 'color' },
+        },
+      },
+    });
+
+    expect(collisions).toEqual([
+      {
+        cssName: '--ax-colors-acc7-100',
+        entries: [
+          { path: 'ax/colors/acc7- 100', value: '#cfd0d6' },
+          { path: 'ax/colors/acc7-100', value: '#cfd0d6' },
+        ],
+        sameValue: true,
+      },
+    ]);
+  });
+
+  it('returns nothing for distinct names', () => {
+    expect(
+      findCssNameCollisions({
+        ax: { colors: { 'gray-100': { value: '#eee', type: 'color' } } },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('assertNoValueCollisions', () => {
+  it('only warns when the colliding values are identical', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const tokens = {
+      'Primitives/Mode 1': {
+        ax: {
+          colors: {
+            'acc7- 100': { value: '#cfd0d6', type: 'color' },
+            'acc7-100': { value: '#cfd0d6', type: 'color' },
+          },
+        },
+      },
+    };
+
+    expect(() => assertNoValueCollisions(tokens, ['Primitives/Mode 1'])).not.toThrow();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('throws when one CSS name would carry different values', () => {
+    const tokens = {
+      'Primitives/Mode 1': {
+        ax: {
+          colors: {
+            'acc7- 100': { value: '#ffffff', type: 'color' },
+            'acc7-100': { value: '#cfd0d6', type: 'color' },
+          },
+        },
+      },
+    };
+
+    expect(() => assertNoValueCollisions(tokens, ['Primitives/Mode 1'])).toThrow(/--ax-colors-acc7-100/);
+  });
+});

--- a/packages/tokens/src/validate-collisions.ts
+++ b/packages/tokens/src/validate-collisions.ts
@@ -1,0 +1,97 @@
+/**
+ * Detects token names that become the same CSS custom property after the
+ * Style Dictionary kebab transform — e.g. the Figma-side duplicate
+ * 'ax/colors/acc7- 100' (stray space) vs 'ax/colors/acc7-100', which both
+ * emit `--ax-colors-acc7-100` and silently overwrite each other in the
+ * built CSS.
+ *
+ * Same-value collisions warn (today's export carries ten of them, all
+ * benign); different-value collisions throw, because the emitted value
+ * would then depend on object iteration order.
+ */
+type TokenLeaf = { value: unknown; type: string };
+type TokenNode = TokenLeaf | { [key: string]: TokenNode };
+
+export type CssNameCollision = {
+  cssName: string;
+  entries: { path: string; value: unknown }[];
+  sameValue: boolean;
+};
+
+function isLeaf(node: TokenNode): node is TokenLeaf {
+  return typeof node === 'object' && node !== null && 'value' in node && 'type' in node;
+}
+
+function collectLeaves(node: TokenNode, path: string[], out: { path: string; value: unknown }[]) {
+  if (isLeaf(node)) {
+    out.push({ path: path.join('/'), value: node.value });
+    return;
+  }
+  for (const [key, child] of Object.entries(node)) {
+    collectLeaves(child as TokenNode, [...path, key], out);
+  }
+}
+
+/** Mirrors the sd-transforms kebab output (which keeps letter–digit runs like
+ * 'acc7' together — remeda's toKebabCase would split them to 'acc-7'). */
+function toCssName(tokenPath: string): string {
+  const kebab = tokenPath
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '');
+  return `--${kebab}`;
+}
+
+export function findCssNameCollisions(tokenSet: Record<string, TokenNode>): CssNameCollision[] {
+  const leaves: { path: string; value: unknown }[] = [];
+  for (const [key, node] of Object.entries(tokenSet)) {
+    collectLeaves(node, [key], leaves);
+  }
+
+  const byCssName = new Map<string, { path: string; value: unknown }[]>();
+  for (const leaf of leaves) {
+    const cssName = toCssName(leaf.path);
+    byCssName.set(cssName, [...(byCssName.get(cssName) ?? []), leaf]);
+  }
+
+  return [...byCssName.entries()]
+    .filter(([, entries]) => entries.length > 1)
+    .map(([cssName, entries]) => ({
+      cssName,
+      entries,
+      sameValue: new Set(entries.map((entry) => JSON.stringify(entry.value))).size === 1,
+    }));
+}
+
+/**
+ * Validates every configured set in the raw tokens.json export. Different
+ * values behind one CSS name fail the build; identical values only warn so
+ * the known Figma-side duplicates don't block builds until design removes
+ * them at the source (WB-421).
+ */
+export function assertNoValueCollisions(tokens: Record<string, unknown>, setKeys: string[]): void {
+  for (const setKey of setKeys) {
+    const collisions = findCssNameCollisions(tokens[setKey] as Record<string, TokenNode>);
+    const conflicting = collisions.filter((collision) => !collision.sameValue);
+
+    for (const collision of collisions.filter((c) => c.sameValue)) {
+      console.warn(
+        `tokens: '${setKey}' exports duplicate names for ${collision.cssName} ` +
+          `(${collision.entries.map((entry) => `'${entry.path}'`).join(', ')}) — same value, ` +
+          'the built CSS keeps one copy; remove the duplicate in Figma (WB-421).',
+      );
+    }
+
+    if (conflicting.length > 0) {
+      throw new Error(
+        conflicting
+          .map(
+            (collision) =>
+              `'${setKey}': ${collision.entries.map((entry) => `'${entry.path}' (${JSON.stringify(entry.value)})`).join(' and ')} ` +
+              `all emit ${collision.cssName} with different values — the winner would depend on iteration order`,
+          )
+          .join('\n'),
+      );
+    }
+  }
+}

--- a/packages/tokens/src/validate-collisions.ts
+++ b/packages/tokens/src/validate-collisions.ts
@@ -12,7 +12,7 @@
 type TokenLeaf = { value: unknown; type: string };
 type TokenNode = TokenLeaf | { [key: string]: TokenNode };
 
-export type CssNameCollision = {
+type CssNameCollision = {
   cssName: string;
   entries: { path: string; value: unknown }[];
   sameValue: boolean;

--- a/packages/tokens/src/validate-collisions.ts
+++ b/packages/tokens/src/validate-collisions.ts
@@ -34,9 +34,8 @@ function collectLeaves(node: TokenNode, path: string[], out: { path: string; val
   }
 }
 
-/** The emitted CSS name: Style Dictionary's `name/kebab` transform runs
- * change-case's kebabCase over the space-joined token path — use the same
- * function so the two can never drift. */
+/** Must match Style Dictionary's `name/kebab` output — same function
+ * (change-case), same input shape, so the two cannot drift. */
 function toCssName(tokenPath: string): string {
   return `--${kebabCase(tokenPath.split('/').join(' '))}`;
 }

--- a/packages/tokens/src/validate-collisions.ts
+++ b/packages/tokens/src/validate-collisions.ts
@@ -67,7 +67,7 @@ export function findCssNameCollisions(tokenSet: Record<string, TokenNode>): CssN
  * Validates every configured set in the raw tokens.json export. Different
  * values behind one CSS name fail the build; identical values only warn so
  * the known Figma-side duplicates don't block builds until design removes
- * them at the source (WB-421).
+ * them at the source.
  */
 export function assertNoValueCollisions(tokens: Record<string, unknown>, setKeys: string[]): void {
   for (const setKey of setKeys) {
@@ -78,7 +78,7 @@ export function assertNoValueCollisions(tokens: Record<string, unknown>, setKeys
       console.warn(
         `tokens: '${setKey}' exports duplicate names for ${collision.cssName} ` +
           `(${collision.entries.map((entry) => `'${entry.path}'`).join(', ')}) — same value, ` +
-          'the built CSS keeps one copy; remove the duplicate in Figma (WB-421).',
+          'the built CSS keeps one copy; remove the duplicate in Figma.',
       );
     }
 

--- a/packages/tokens/src/validate-collisions.ts
+++ b/packages/tokens/src/validate-collisions.ts
@@ -9,6 +9,8 @@
  * benign); different-value collisions throw, because the emitted value
  * would then depend on object iteration order.
  */
+import { kebabCase } from 'change-case';
+
 type TokenLeaf = { value: unknown; type: string };
 type TokenNode = TokenLeaf | { [key: string]: TokenNode };
 
@@ -32,14 +34,11 @@ function collectLeaves(node: TokenNode, path: string[], out: { path: string; val
   }
 }
 
-/** Mirrors the sd-transforms kebab output (which keeps letter–digit runs like
- * 'acc7' together — remeda's toKebabCase would split them to 'acc-7'). */
+/** The emitted CSS name: Style Dictionary's `name/kebab` transform runs
+ * change-case's kebabCase over the space-joined token path — use the same
+ * function so the two can never drift. */
 function toCssName(tokenPath: string): string {
-  const kebab = tokenPath
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, '-')
-    .replaceAll(/^-+|-+$/g, '');
-  return `--${kebab}`;
+  return `--${kebabCase(tokenPath.split('/').join(' '))}`;
 }
 
 export function findCssNameCollisions(tokenSet: Record<string, TokenNode>): CssNameCollision[] {
@@ -71,7 +70,11 @@ export function findCssNameCollisions(tokenSet: Record<string, TokenNode>): CssN
  */
 export function assertNoValueCollisions(tokens: Record<string, unknown>, setKeys: string[]): void {
   for (const setKey of setKeys) {
-    const collisions = findCssNameCollisions(tokens[setKey] as Record<string, TokenNode>);
+    const tokenSet = tokens[setKey];
+    if (!tokenSet) {
+      throw new Error(`tokens.json does not export a '${setKey}' set`);
+    }
+    const collisions = findCssNameCollisions(tokenSet as Record<string, TokenNode>);
     const conflicting = collisions.filter((collision) => !collision.sameValue);
 
     for (const collision of collisions.filter((c) => c.sameValue)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,7 +527,7 @@ importers:
         version: 4.1.0
       i18next:
         specifier: ^24.0.0
-        version: 24.2.3(typescript@5.6.3)
+        version: 24.2.3(typescript@5.9.3)
       i18next-browser-languagedetector:
         specifier: ^8.0.0
         version: 8.0.5
@@ -548,7 +548,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       react-i18next:
         specifier: ^15.0.0
-        version: 15.4.1(i18next@24.2.3(typescript@5.6.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.4.1(i18next@24.2.3(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-mentions-ts:
         specifier: ^5.4.7
         version: 5.4.7(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwind-merge@3.5.0)
@@ -588,10 +588,10 @@ importers:
         version: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.12.0)(rollup@4.57.1)(typescript@5.6.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.5.4(@types/node@22.12.0)(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.57.1)(typescript@5.6.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.3.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       vitest:
         specifier: ^3.0.4
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.12.0)(jiti@2.6.1)(jsdom@26.0.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
@@ -600,14 +600,13 @@ importers:
         version: 5.0.3(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
 
   packages/tokens:
-    dependencies:
-      change-case:
-        specifier: ^5.4.4
-        version: 5.4.4
     devDependencies:
       '@tokens-studio/sd-transforms':
         specifier: ^1.2.12
         version: 1.3.0(style-dictionary@4.4.0(tslib@2.8.1))
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       remeda:
         specifier: ^2.21.2
         version: 2.39.0
@@ -10176,17 +10175,6 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.26.7)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.26.7)
 
-  '@svgr/core@8.1.0(typescript@5.6.3)':
-    dependencies:
-      '@babel/core': 7.26.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.7)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.6.3)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.26.7
@@ -10202,16 +10190,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
       entities: 4.5.0
-
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.6.3))':
-    dependencies:
-      '@babel/core': 7.26.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.7)
-      '@svgr/core': 8.1.0(typescript@5.6.3)
-      '@svgr/hast-util-to-babel-ast': 8.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
@@ -10918,6 +10896,19 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.6.3
+
+  '@vue/language-core@2.2.0(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.33
+      alien-signals: 0.4.14
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@vue/shared@3.5.33': {}
 
@@ -11773,15 +11764,6 @@ snapshots:
       '@types/node': 22.12.0
       cosmiconfig: 9.0.1(typescript@5.6.3)
       jiti: 2.6.1
-      typescript: 5.6.3
-
-  cosmiconfig@8.3.6(typescript@5.6.3):
-    dependencies:
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-    optionalDependencies:
       typescript: 5.6.3
 
   cosmiconfig@8.3.6(typescript@5.9.3):
@@ -13352,12 +13334,6 @@ snapshots:
   i18next@23.16.8:
     dependencies:
       '@babel/runtime': 7.29.7
-
-  i18next@24.2.3(typescript@5.6.3):
-    dependencies:
-      '@babel/runtime': 7.27.0
-    optionalDependencies:
-      typescript: 5.6.3
 
   i18next@24.2.3(typescript@5.9.3):
     dependencies:
@@ -15072,15 +15048,6 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-i18next@15.4.1(i18next@24.2.3(typescript@5.6.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.27.0
-      html-parse-stringify: 3.0.1
-      i18next: 24.2.3(typescript@5.6.3)
-      react: 19.1.0
-    optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
-
   react-i18next@15.4.1(i18next@24.2.3(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.0
@@ -16400,6 +16367,25 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-plugin-dts@4.5.4(@types/node@22.12.0)(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+    dependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@22.12.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
   vite-plugin-lib-inject-css@2.2.2(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@ast-grep/napi': 0.36.3
@@ -16415,17 +16401,6 @@ snapshots:
       p-map: 7.0.4
       picocolors: 1.1.1
       vite: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
-
-  vite-plugin-svgr@4.3.0(rollup@4.57.1)(typescript@5.6.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@svgr/core': 8.1.0(typescript@5.6.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
-      vite: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - typescript
 
   vite-plugin-svgr@4.3.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,7 +527,7 @@ importers:
         version: 4.1.0
       i18next:
         specifier: ^24.0.0
-        version: 24.2.3(typescript@5.9.3)
+        version: 24.2.3(typescript@5.6.3)
       i18next-browser-languagedetector:
         specifier: ^8.0.0
         version: 8.0.5
@@ -548,7 +548,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       react-i18next:
         specifier: ^15.0.0
-        version: 15.4.1(i18next@24.2.3(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.4.1(i18next@24.2.3(typescript@5.6.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-mentions-ts:
         specifier: ^5.4.7
         version: 5.4.7(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwind-merge@3.5.0)
@@ -588,10 +588,10 @@ importers:
         version: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.12.0)(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.5.4(@types/node@22.12.0)(rollup@4.57.1)(typescript@5.6.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.3.0(rollup@4.57.1)(typescript@5.6.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       vitest:
         specifier: ^3.0.4
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.12.0)(jiti@2.6.1)(jsdom@26.0.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
@@ -600,6 +600,10 @@ importers:
         version: 5.0.3(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
 
   packages/tokens:
+    dependencies:
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
     devDependencies:
       '@tokens-studio/sd-transforms':
         specifier: ^1.2.12
@@ -1287,11 +1291,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -4968,6 +4972,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -7365,6 +7370,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -10170,6 +10176,17 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.26.7)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.26.7)
 
+  '@svgr/core@8.1.0(typescript@5.6.3)':
+    dependencies:
+      '@babel/core': 7.26.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.7)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@5.6.3)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.26.7
@@ -10185,6 +10202,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
       entities: 4.5.0
+
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.6.3))':
+    dependencies:
+      '@babel/core': 7.26.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.7)
+      '@svgr/core': 8.1.0(typescript@5.6.3)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
@@ -10891,19 +10918,6 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.6.3
-
-  '@vue/language-core@2.2.0(typescript@5.9.3)':
-    dependencies:
-      '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.33
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.33
-      alien-signals: 0.4.14
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@vue/shared@3.5.33': {}
 
@@ -11759,6 +11773,15 @@ snapshots:
       '@types/node': 22.12.0
       cosmiconfig: 9.0.1(typescript@5.6.3)
       jiti: 2.6.1
+      typescript: 5.6.3
+
+  cosmiconfig@8.3.6(typescript@5.6.3):
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.6.3
 
   cosmiconfig@8.3.6(typescript@5.9.3):
@@ -13329,6 +13352,12 @@ snapshots:
   i18next@23.16.8:
     dependencies:
       '@babel/runtime': 7.29.7
+
+  i18next@24.2.3(typescript@5.6.3):
+    dependencies:
+      '@babel/runtime': 7.27.0
+    optionalDependencies:
+      typescript: 5.6.3
 
   i18next@24.2.3(typescript@5.9.3):
     dependencies:
@@ -15043,6 +15072,15 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-i18next@15.4.1(i18next@24.2.3(typescript@5.6.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      html-parse-stringify: 3.0.1
+      i18next: 24.2.3(typescript@5.6.3)
+      react: 19.1.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
   react-i18next@15.4.1(i18next@24.2.3(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.0
@@ -16362,25 +16400,6 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-dts@4.5.4(@types/node@22.12.0)(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
-    dependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@22.12.0)
-      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@volar/typescript': 2.4.28
-      '@vue/language-core': 2.2.0(typescript@5.9.3)
-      compare-versions: 6.1.1
-      debug: 4.4.3
-      kolorist: 1.8.0
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      typescript: 5.9.3
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
-    transitivePeerDependencies:
-      - '@types/node'
-      - rollup
-      - supports-color
-
   vite-plugin-lib-inject-css@2.2.2(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@ast-grep/napi': 0.36.3
@@ -16396,6 +16415,17 @@ snapshots:
       p-map: 7.0.4
       picocolors: 1.1.1
       vite: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+
+  vite-plugin-svgr@4.3.0(rollup@4.57.1)(typescript@5.6.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
+      '@svgr/core': 8.1.0(typescript@5.6.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
+      vite: 6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
 
   vite-plugin-svgr@4.3.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.12.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:


### PR DESCRIPTION
Token-pipeline prep (1/2), targeting `ds-2.0`. Everything that does **not** need the Figma 2.0 variables export; 2/2 (the pipeline switch) lands once the export exists.

## Changes

- **Collision guard in the tokens build** (`src/validate-collisions.ts`) — names that kebab to the same CSS custom property (`acc7- 100` vs `acc7-100`) silently overwrite each other in the built CSS. Different values → build fails; identical values → warning (today's export has ten benign ones, awaiting cleanup in Figma). Kebab comes from `change-case` — the same function Style Dictionary uses — so the two cannot drift.
- **Codemod map** — the designer changelog checked in verbatim (`migration/`, shielded via `.prettierignore`; reformatting corrupted token paths) + `scripts/build-codemod-map.mjs` → `codemod-map.json`: **144 renames, 37 removals** (32 with a replacement), primitive prefix rules, a `manual` list (chips factory). The parser never guesses: ambiguous rows fail the build unless resolved in the generator's `RESOLVED_BY_HAND` table (5 entries). CI regenerates the artifact and fails on any diff.
- **Usage codemod** (`scripts/codemod-usages.mjs`, dry-run by default) — rewrites `var(--ax-…)` → `var(--wb-…)` per the map; fixes usages at the source instead of shipping a bridge. Current plan: **344 rewrites / 64 files / 6 hand-edits**; the dry-run also reports the deferred gap (136 Numerals names defined in today's dist → the `dimensions` table, generated against the real export in 2/2) and component-local names needing no rewrite.
- `pnpm --filter @workflowbuilder/ui-tokens codemod:map` / `codemod:apply`.

## Deliberately not here (2/2, needs the export)

`config.ts` entries for Canvas/Effects (the manifest validates set names against `tokens.json` verbatim), the `dimensions` value→token pairs, and running the codemod itself. Precondition for 2/2: the `--wb-*` targets must exist (export or provisional definitions) before `--write`, or the token-usage lint from #78 rejects the result.

Note: CI on this PR needs #81 merged, `main` synced into `ds-2.0`, and a head-branch push.
