### PR TITLE
feat(execution-core): add execution_incomplete terminal state

### DIFF
--- a/apps/ai-studio/src/adapters/execution-stream-adapter.ts
+++ b/apps/ai-studio/src/adapters/execution-stream-adapter.ts
@@ -3,8 +3,13 @@ import type { ExecutionEvent, ExecutionSnapshot } from '@workflow-builder/types/
 import { BACKEND_URL } from '../config';
 import { applyConnectionLost, applyEvent, applySnapshot } from '../stores/use-execution-store';
 
-const TERMINAL_TYPES = new Set(['execution_completed', 'execution_failed', 'execution_cancelled']);
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+const TERMINAL_TYPES = new Set([
+  'execution_completed',
+  'execution_incomplete',
+  'execution_failed',
+  'execution_cancelled',
+]);
+const TERMINAL_STATUSES = new Set(['completed', 'incomplete', 'failed', 'cancelled']);
 const MAX_RETRIES = 5;
 
 export function connectExecutionStream(executionId: string, streamUrl: string): () => void {

--- a/apps/ai-studio/src/adapters/execution-stream-adapter.ts
+++ b/apps/ai-studio/src/adapters/execution-stream-adapter.ts
@@ -1,15 +1,17 @@
-import type { ExecutionEvent, ExecutionSnapshot } from '@workflow-builder/types/workflow-execution/execution-events';
+import {
+  type ExecutionEvent,
+  type ExecutionEventType,
+  type ExecutionSnapshot,
+  type ExecutionStatus,
+  TERMINAL_EXECUTION_EVENT_TYPES,
+  TERMINAL_EXECUTION_STATUSES,
+} from '@workflow-builder/types/workflow-execution/execution-events';
 
 import { BACKEND_URL } from '../config';
 import { applyConnectionLost, applyEvent, applySnapshot } from '../stores/use-execution-store';
 
-const TERMINAL_TYPES = new Set([
-  'execution_completed',
-  'execution_incomplete',
-  'execution_failed',
-  'execution_cancelled',
-]);
-const TERMINAL_STATUSES = new Set(['completed', 'incomplete', 'failed', 'cancelled']);
+const TERMINAL_TYPES: ReadonlySet<ExecutionEventType> = new Set(TERMINAL_EXECUTION_EVENT_TYPES);
+const TERMINAL_STATUSES: ReadonlySet<ExecutionStatus> = new Set(TERMINAL_EXECUTION_STATUSES);
 const MAX_RETRIES = 5;
 
 export function connectExecutionStream(executionId: string, streamUrl: string): () => void {

--- a/apps/ai-studio/src/components/controls/ai-studio-controls.tsx
+++ b/apps/ai-studio/src/components/controls/ai-studio-controls.tsx
@@ -28,7 +28,7 @@ export function AiStudioControls() {
   }, [executeFromCanvas]);
 
   const isRunning = status === 'pending' || status === 'running';
-  const isDone = status === 'completed' || status === 'failed' || status === 'cancelled';
+  const isDone = status === 'completed' || status === 'incomplete' || status === 'failed' || status === 'cancelled';
 
   return (
     <div

--- a/apps/ai-studio/src/components/execution/highlighting.css
+++ b/apps/ai-studio/src/components/execution/highlighting.css
@@ -1,16 +1,19 @@
 html[data-theme='light'] {
   --ai-studio-edge-color--active: var(--ax-colors-green-400);
   --ai-studio-status-color--completed: var(--ax-colors-green-400);
+  --ai-studio-status-color--incomplete: var(--ax-colors-orange-400);
 }
 
 html[data-theme='dark'] {
   --ai-studio-edge-color--active: var(--ax-colors-green-200);
   --ai-studio-status-color--completed: var(--ax-colors-green-200);
+  --ai-studio-status-color--incomplete: var(--ax-colors-orange-300);
 }
 
 :root {
   --ai-studio-status-color--failed: var(--ax-txt-error-default);
   --ai-studio-status-bg--completed: color-mix(in srgb, var(--ai-studio-status-color--completed), transparent 85%);
+  --ai-studio-status-bg--incomplete: color-mix(in srgb, var(--ai-studio-status-color--incomplete), transparent 85%);
   --ai-studio-status-bg--failed: color-mix(in srgb, var(--ai-studio-status-color--failed), transparent 85%);
 
   --ai-studio-node-shadow-color--active: var(--ai-studio-edge-color--active);

--- a/apps/ai-studio/src/components/execution/highlighting.css
+++ b/apps/ai-studio/src/components/execution/highlighting.css
@@ -1,16 +1,16 @@
 html[data-theme='light'] {
   --ai-studio-edge-color--active: var(--ax-colors-green-400);
-  --ai-studio-status-color--completed: var(--ax-colors-green-400);
-  --ai-studio-status-color--incomplete: var(--ax-colors-orange-400);
+  --ai-studio-status-color--incomplete: var(--ax-txt-warning-default);
 }
 
 html[data-theme='dark'] {
   --ai-studio-edge-color--active: var(--ax-colors-green-200);
-  --ai-studio-status-color--completed: var(--ax-colors-green-200);
+  /* No dark warning-accent token exists (--ax-txt-warning-default is orange-100 body-text cream). */
   --ai-studio-status-color--incomplete: var(--ax-colors-orange-300);
 }
 
 :root {
+  --ai-studio-status-color--completed: var(--ax-txt-success-default);
   --ai-studio-status-color--failed: var(--ax-txt-error-default);
   --ai-studio-status-bg--completed: color-mix(in srgb, var(--ai-studio-status-color--completed), transparent 85%);
   --ai-studio-status-bg--incomplete: color-mix(in srgb, var(--ai-studio-status-color--incomplete), transparent 85%);

--- a/apps/ai-studio/src/components/execution/log-panel.module.css
+++ b/apps/ai-studio/src/components/execution/log-panel.module.css
@@ -94,6 +94,10 @@
   color: var(--ax-txt-secondary-default, #888);
 }
 
+.badge--execution_incomplete {
+  color: var(--ai-studio-status-color--incomplete);
+}
+
 .badge--node_failed,
 .badge--execution_failed {
   color: var(--ai-studio-status-color--failed);
@@ -157,6 +161,11 @@
 .status--completed {
   color: var(--ai-studio-status-color--completed);
   background: var(--ai-studio-status-bg--completed);
+}
+
+.status--incomplete {
+  color: var(--ai-studio-status-color--incomplete);
+  background: var(--ai-studio-status-bg--incomplete);
 }
 
 .status--failed {

--- a/apps/ai-studio/src/components/execution/log-panel.tsx
+++ b/apps/ai-studio/src/components/execution/log-panel.tsx
@@ -50,6 +50,13 @@ function EventRow({ event, selectedNodeId }: { event: ExecutionEvent; selectedNo
 
       break;
     }
+    case 'execution_incomplete': {
+      detail = event.payload.deadEnds
+        .map(({ nodeId, port }) => `${nodeId} routed to "${port}" — nothing connected to that handle`)
+        .join('\n');
+
+      break;
+    }
     // No default
   }
 

--- a/apps/ai-studio/src/stores/use-execution-store.ts
+++ b/apps/ai-studio/src/stores/use-execution-store.ts
@@ -130,6 +130,9 @@ function eventToExecutionStatus(event: ExecutionEvent): ExecutionStatus | undefi
     case 'execution_completed': {
       return 'completed';
     }
+    case 'execution_incomplete': {
+      return 'incomplete';
+    }
     case 'execution_failed': {
       return 'failed';
     }

--- a/apps/backend/src/events/drain-events.test.ts
+++ b/apps/backend/src/events/drain-events.test.ts
@@ -78,6 +78,15 @@ describe('drainEventsSince', () => {
     expect(result.lastSequence).toBe(2);
   });
 
+  it('flags terminal when the last fetched event is execution_incomplete', async () => {
+    const fetch = fixedFetcher([makeEvent('exec-1', 1), makeEvent('exec-1', 2, 'execution_incomplete')]);
+
+    const result = await drainEventsSince('exec-1', 0, fetch, async () => {});
+
+    expect(result.reachedTerminal).toBe(true);
+    expect(result.lastSequence).toBe(2);
+  });
+
   it('write failure stops the drain and pins the cursor at the last successful write', async () => {
     const fetch = fixedFetcher([makeEvent('exec-1', 1), makeEvent('exec-1', 2), makeEvent('exec-1', 3)]);
     let calls = 0;

--- a/apps/backend/src/events/drain-events.ts
+++ b/apps/backend/src/events/drain-events.ts
@@ -3,7 +3,12 @@ import type { ExecutionEventRow } from './fetch-events-after';
 export type EventFetcher = (executionId: string, afterSequence: number) => Promise<ExecutionEventRow[]>;
 type EventWriter = (event: ExecutionEventRow) => Promise<void>;
 
-const TERMINAL_EVENT_TYPES = new Set(['execution_completed', 'execution_failed', 'execution_cancelled']);
+const TERMINAL_EVENT_TYPES = new Set([
+  'execution_completed',
+  'execution_incomplete',
+  'execution_failed',
+  'execution_cancelled',
+]);
 
 export type DrainResult = {
   lastSequence: number;

--- a/apps/backend/src/events/drain-events.ts
+++ b/apps/backend/src/events/drain-events.ts
@@ -1,14 +1,12 @@
+import { TERMINAL_EXECUTION_EVENT_TYPES } from '@workflow-builder/types/workflow-execution/execution-events';
+
 import type { ExecutionEventRow } from './fetch-events-after';
 
 export type EventFetcher = (executionId: string, afterSequence: number) => Promise<ExecutionEventRow[]>;
 type EventWriter = (event: ExecutionEventRow) => Promise<void>;
 
-const TERMINAL_EVENT_TYPES = new Set([
-  'execution_completed',
-  'execution_incomplete',
-  'execution_failed',
-  'execution_cancelled',
-]);
+// Set<string> because ExecutionEventRow.type is a plain string from $inferSelect.
+const TERMINAL_EVENT_TYPES = new Set<string>(TERMINAL_EXECUTION_EVENT_TYPES);
 
 export type DrainResult = {
   lastSequence: number;

--- a/apps/backend/src/routes/executions.test.ts
+++ b/apps/backend/src/routes/executions.test.ts
@@ -144,7 +144,7 @@ describe('createExecutionsRoutes - authorize is called with the right shape per 
     const app = buildApp(port);
 
     databaseMock.select.mockReturnValue(chainResolving([execution]));
-    databaseMock.update.mockReturnValue(chainResolving([]));
+    databaseMock.update.mockReturnValue(chainResolving([{ id: 'e-1' }]));
 
     await app.request(path, { method });
 
@@ -259,5 +259,136 @@ describe('createExecutionsRoutes - stream tenant cross-check', () => {
     const response = await app.request('/api/executions/e-1/stream');
 
     expect(response.status).toBe(200);
+  });
+});
+
+// ---- snapshot-window race ----------------------------------------------------
+//
+// The worker commits the terminal event and the terminal status as two separate
+// activities, so the route's executions-row read can lag its events read. The
+// stream must trust the last event, not the stale row: otherwise the snapshot
+// says "running", the drainer is seeded past the terminal row, no NOTIFY is
+// coming (updateStatus does not notify), and the connection heartbeats forever.
+
+function makeEventRow(sequence: number, type: string) {
+  return {
+    id: `ev-${sequence}`,
+    executionId: 'e-1',
+    sequence,
+    timestamp: new Date(0),
+    type,
+    nodeId: null,
+    pathId: null,
+    payloadJson: null,
+    tenantId: null,
+    createdAt: new Date(0),
+  };
+}
+
+function snapshotFrom(body: string): { status: string; lastSequence: number } {
+  const dataLine = body.split('\n').find((line) => line.startsWith('data:'));
+  return JSON.parse(dataLine!.slice('data:'.length)) as { status: string; lastSequence: number };
+}
+
+describe('createExecutionsRoutes - stream snapshot-window race', () => {
+  it('stale pending row with a committed terminal event - snapshot carries the derived status and the stream closes', async () => {
+    const app = buildApp(allowStream());
+    // Row read returns the stale pre-terminal status; the events read already
+    // contains the terminal event the worker committed in between.
+    databaseMock.select.mockReturnValueOnce(chainResolving([pendingExecution]));
+    databaseMock.select.mockReturnValue(
+      chainResolving([makeEventRow(1, 'execution_started'), makeEventRow(2, 'execution_completed')]),
+    );
+
+    const response = await app.request('/api/executions/e-1/stream');
+    // Pre-fix this text() never resolves: the handler holds the stream open on
+    // heartbeats forever, so a test timeout here is the regression signal.
+    const body = await response.text();
+
+    const snapshot = snapshotFrom(body);
+    expect(snapshot.status).toBe('completed');
+    expect(snapshot.lastSequence).toBe(2);
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { type: 'execution_completed', status: 'completed' },
+    { type: 'execution_incomplete', status: 'incomplete' },
+    { type: 'execution_failed', status: 'failed' },
+    { type: 'execution_cancelled', status: 'cancelled' },
+  ])('a trailing $type derives snapshot status $status', async ({ type, status }) => {
+    const app = buildApp(allowStream());
+    databaseMock.select.mockReturnValueOnce(chainResolving([pendingExecution]));
+    databaseMock.select.mockReturnValue(chainResolving([makeEventRow(1, type)]));
+
+    const response = await app.request('/api/executions/e-1/stream');
+    const body = await response.text();
+
+    expect(snapshotFrom(body).status).toBe(status);
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it('a non-terminal last event does not flip the status - the live path still drains to terminal', async () => {
+    const app = buildApp(allowStream());
+    subscribeMock.mockResolvedValue(() => {});
+    // Call order: executions row, snapshot events fetch, catch-up drain fetch.
+    databaseMock.select.mockReturnValueOnce(chainResolving([pendingExecution]));
+    databaseMock.select.mockReturnValueOnce(chainResolving([makeEventRow(1, 'execution_started')]));
+    databaseMock.select.mockReturnValue(chainResolving([makeEventRow(2, 'execution_completed')]));
+
+    const response = await app.request('/api/executions/e-1/stream');
+    const body = await response.text();
+
+    // Negative half: 'execution_started' must not read as terminal.
+    expect(snapshotFrom(body).status).toBe('pending');
+    // The catch-up drain still delivered the post-snapshot terminal event and
+    // ended the stream (drainer.done resolves the hold-open promise).
+    expect(body).toContain('execution_completed');
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---- cancel race -------------------------------------------------------------
+//
+// The pre-check 409 reads the row, but the enforcement is the UPDATE's WHERE:
+// a worker committing a terminal status between the two must not be overwritten
+// to 'cancelling' - nothing ever writes a run out of that status again.
+
+describe('createExecutionsRoutes - cancel enforcement in the UPDATE', () => {
+  it('DELETE races a terminal write - guarded UPDATE matches 0 rows, 409, engine untouched', async () => {
+    const app = buildApp(allowStream());
+    databaseMock.select.mockReturnValue(chainResolving([pendingExecution]));
+    databaseMock.update.mockReturnValue(chainResolving([]));
+
+    const response = await app.request('/api/executions/e-1', { method: 'DELETE' });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      code: 'execution_not_cancellable',
+      message: 'Execution already finished',
+    });
+    expect(engineMock.cancel).not.toHaveBeenCalled();
+  });
+
+  it('DELETE wins the race - 200 cancelling and engine.cancel fires', async () => {
+    const app = buildApp(allowStream());
+    databaseMock.select.mockReturnValue(chainResolving([pendingExecution]));
+    databaseMock.update.mockReturnValue(chainResolving([{ id: 'e-1' }]));
+
+    const response = await app.request('/api/executions/e-1', { method: 'DELETE' });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: 'e-1', status: 'cancelling' });
+    expect(engineMock.cancel).toHaveBeenCalledWith('e-1');
+  });
+
+  it('DELETE on a terminal row - 409 from the pre-check, no UPDATE issued', async () => {
+    const app = buildApp(allowStream());
+    databaseMock.select.mockReturnValue(chainResolving([terminalExecution]));
+
+    const response = await app.request('/api/executions/e-1', { method: 'DELETE' });
+
+    expect(response.status).toBe(409);
+    expect(databaseMock.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/routes/executions.ts
+++ b/apps/backend/src/routes/executions.ts
@@ -1,8 +1,12 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, notInArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 
-import { TERMINAL_EXECUTION_STATUSES } from '@workflow-builder/types/workflow-execution/execution-events';
+import {
+  TERMINAL_EVENT_TO_STATUS,
+  TERMINAL_EXECUTION_STATUSES,
+  type TerminalExecutionEventType,
+} from '@workflow-builder/types/workflow-execution/execution-events';
 
 import type { AssertAuthorized, AuthVariables } from '../auth';
 import { database } from '../db/client';
@@ -100,17 +104,29 @@ export function createExecutionsRoutes(
       const existingEvents = await fetchEventsAfter(executionId, 0);
       const lastSequence = existingEvents.length > 0 ? Number(existingEvents.at(-1)!.sequence) : 0;
 
+      // The worker commits the terminal event and the terminal status in two separate
+      // activities, so the row read before this stream opened can lag the events read
+      // here. Trusting the stale row would send a live-looking snapshot (the client
+      // closes only on a terminal snapshot status, so it would reconnect forever) and
+      // seed the drainer past the terminal row: the catch-up drain returns empty,
+      // `updateStatus` fires no NOTIFY, and the stream heartbeats until the client
+      // gives up. The last event is the authority on "over" — derive the status from it.
+      const lastEventType = existingEvents.at(-1)?.type;
+      const effectiveStatus = isTerminalEventType(lastEventType)
+        ? TERMINAL_EVENT_TO_STATUS[lastEventType]
+        : execution.status;
+
       await stream.writeSSE({
         data: JSON.stringify({
           type: 'execution_snapshot',
           executionId,
-          status: execution.status,
+          status: effectiveStatus,
           lastSequence,
           events: existingEvents.map(formatEvent),
         }),
       });
 
-      if (TERMINAL_STATUSES.has(execution.status)) {
+      if (TERMINAL_STATUSES.has(effectiveStatus)) {
         return;
       }
 
@@ -189,10 +205,21 @@ export function createExecutionsRoutes(
       return c.json({ code: 'execution_not_cancellable', message: 'Execution already finished' }, 409);
     }
 
-    await database
+    // The check above is a courtesy read; this WHERE is the enforcement. The worker
+    // can commit a terminal status between the two, and an unguarded UPDATE would
+    // resurrect the finished run as 'cancelling' — a status nothing ever writes it
+    // out of. 'cancelling' itself stays cancellable on purpose: a repeat cancel is
+    // an idempotent no-op write and a second engine cancel is harmless, which is
+    // friendlier to a retrying client than a 409.
+    const [updated] = await database
       .update(executions)
       .set({ status: 'cancelling', updatedAt: new Date() })
-      .where(eq(executions.id, executionId));
+      .where(and(eq(executions.id, executionId), notInArray(executions.status, [...TERMINAL_EXECUTION_STATUSES])))
+      .returning({ id: executions.id });
+
+    if (!updated) {
+      return c.json({ code: 'execution_not_cancellable', message: 'Execution already finished' }, 409);
+    }
 
     logger.info('cancel requested', { executionId: execution.id, workflowId: execution.workflowId });
     await getWorkflowEngine().cancel(execution.id);
@@ -201,6 +228,10 @@ export function createExecutionsRoutes(
   });
 
   return routes;
+}
+
+function isTerminalEventType(type: string | undefined): type is TerminalExecutionEventType {
+  return type !== undefined && type in TERMINAL_EVENT_TO_STATUS;
 }
 
 function formatEvent(event: ExecutionEventRow) {

--- a/apps/backend/src/routes/executions.ts
+++ b/apps/backend/src/routes/executions.ts
@@ -15,7 +15,7 @@ import type { TenantVariables } from '../tenant';
 
 const logger = backendLogger.child({ component: 'executions-route' });
 
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+const TERMINAL_STATUSES = new Set(['completed', 'incomplete', 'failed', 'cancelled']);
 
 export function createExecutionsRoutes(
   assertAuthorized: AssertAuthorized,

--- a/apps/backend/src/routes/executions.ts
+++ b/apps/backend/src/routes/executions.ts
@@ -2,6 +2,8 @@ import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 
+import { TERMINAL_EXECUTION_STATUSES } from '@workflow-builder/types/workflow-execution/execution-events';
+
 import type { AssertAuthorized, AuthVariables } from '../auth';
 import { database } from '../db/client';
 import { executions } from '../db/schema';
@@ -15,7 +17,7 @@ import type { TenantVariables } from '../tenant';
 
 const logger = backendLogger.child({ component: 'executions-route' });
 
-const TERMINAL_STATUSES = new Set(['completed', 'incomplete', 'failed', 'cancelled']);
+const TERMINAL_STATUSES = new Set<string>(TERMINAL_EXECUTION_STATUSES);
 
 export function createExecutionsRoutes(
   assertAuthorized: AssertAuthorized,

--- a/apps/execution-worker/package.json
+++ b/apps/execution-worker/package.json
@@ -18,6 +18,7 @@
     "@temporalio/worker": "^1.11.0",
     "@temporalio/workflow": "^1.11.0",
     "@workflow-builder/execution-core": "workspace:*",
+    "@workflow-builder/types": "workspace:*",
     "ai": "^6.0.0",
     "dotenv": "^17.4.2",
     "postgres": "^3.4.5",

--- a/apps/execution-worker/src/database.ts
+++ b/apps/execution-worker/src/database.ts
@@ -1,9 +1,15 @@
 // Worker DB access — raw SQL to avoid coupling worker to backend's Drizzle schema.
 import postgres from 'postgres';
 
+import { TERMINAL_EXECUTION_STATUSES } from '@workflow-builder/types/workflow-execution/execution-events';
+
 import { env } from './env';
 
 const sql = postgres(env.DATABASE_URL);
+
+// Widened alias: `status` arrives as a plain string, and `.includes` on a
+// literal-union tuple rejects it.
+const TERMINAL_STATUSES: readonly string[] = TERMINAL_EXECUTION_STATUSES;
 
 export const database = {
   async emitExecutionEvent(executionId: string, sequence: number, type: string, payload?: unknown, nodeId?: string) {
@@ -29,7 +35,7 @@ export const database = {
   },
 
   async updateExecutionStatus(executionId: string, status: string, errorMessage?: string) {
-    const isTerminal = ['completed', 'incomplete', 'failed', 'cancelled'].includes(status);
+    const isTerminal = TERMINAL_STATUSES.includes(status);
 
     await sql`
       UPDATE executions SET

--- a/apps/execution-worker/src/database.ts
+++ b/apps/execution-worker/src/database.ts
@@ -29,7 +29,7 @@ export const database = {
   },
 
   async updateExecutionStatus(executionId: string, status: string, errorMessage?: string) {
-    const isTerminal = ['completed', 'failed', 'cancelled'].includes(status);
+    const isTerminal = ['completed', 'incomplete', 'failed', 'cancelled'].includes(status);
 
     await sql`
       UPDATE executions SET

--- a/apps/execution-worker/src/database.ts
+++ b/apps/execution-worker/src/database.ts
@@ -37,6 +37,9 @@ export const database = {
   async updateExecutionStatus(executionId: string, status: string, errorMessage?: string) {
     const isTerminal = TERMINAL_STATUSES.includes(status);
 
+    // Terminal statuses are immutable: a cancel cleanup landing after the run already
+    // wrote `failed` must not flip it to `cancelled`. Matching 0 rows is a silent
+    // no-op, which also makes a retried terminal write idempotent.
     await sql`
       UPDATE executions SET
         status = ${status},
@@ -45,6 +48,7 @@ export const database = {
         error_message = ${errorMessage ?? null},
         updated_at = now()
       WHERE id = ${executionId}
+        AND status NOT IN ${sql([...TERMINAL_EXECUTION_STATUSES])}
     `;
   },
 };

--- a/apps/execution-worker/src/engines/temporal/workflows/cancellation-handling.decision-log.md
+++ b/apps/execution-worker/src/engines/temporal/workflows/cancellation-handling.decision-log.md
@@ -31,7 +31,7 @@ Wrap the `runGraph(...)` call in `runWorkflow` with a `try/catch` that:
 
 - **Catch inside `runGraph` itself** — rejected. Would leak Temporal coupling (`isCancellation`, `CancellationScope`) into the engine-agnostic execution core. Other engines (e.g., a future in-process runner) would have to invent their own cancellation primitives that match Temporal's, or carry around a no-op shim.
 - **Cooperative cancellation via periodic `cancelRequested` polling inside the graph runner** — rejected. More code, racier semantics (cancellation only checked between iterations), and it doesn't free in-flight activities any sooner than Temporal's own propagation does.
-- **Add a "terminal-state guard" to `updateExecutionStatus`** so the rare `failed`-then-cancel race can't overwrite a terminal status — deferred. Belongs to a separate hardening pass on the worker DB layer; out of scope for this single-bug PR.
+- **Add a "terminal-state guard" to `updateExecutionStatus`** so the rare `failed`-then-cancel race can't overwrite a terminal status — deferred. Belongs to a separate hardening pass on the worker DB layer; out of scope for this single-bug PR. (Landed since: `updateExecutionStatus` now guards `status NOT IN (<terminal>)` — see `apps/execution-worker/src/database.ts`.)
 
 ## Consequences
 
@@ -41,7 +41,7 @@ Wrap the `runGraph(...)` call in `runWorkflow` with a `try/catch` that:
   - Engine-agnostic core (`execution-core`) stays free of Temporal imports.
 
 - **Cons**
-  - Narrow race window: if `runGraph` has already emitted `execution_failed` and is mid-`updateStatus('failed')` activity when the cancel arrives, the workflow's await throws `CancelledFailure`, our cleanup runs, and `updateExecutionStatus` overwrites `'failed'` → `'cancelled'`. Acceptable trade-off; mitigation deferred to a future PR that adds a terminal-state guard at the DB layer.
+  - Narrow race window: if `runGraph` has already emitted `execution_failed` and is mid-`updateStatus('failed')` activity when the cancel arrives, the workflow's await throws `CancelledFailure`, our cleanup runs, and `updateExecutionStatus` overwrites `'failed'` → `'cancelled'`. Acceptable trade-off; mitigation deferred to a future PR that adds a terminal-state guard at the DB layer. (Closed since by the terminal-state guard in `database.ts`; the overwrite is now a no-op.)
   - No automated regression test in this PR — `apps/execution-worker` has no test infrastructure today, and standing one up (`@temporalio/testing` + vitest) is a separate scope decision. Verified via the manual smoke test documented in the PR description.
 
 ## Status

--- a/apps/execution-worker/src/engines/temporal/workflows/run-workflow.ts
+++ b/apps/execution-worker/src/engines/temporal/workflows/run-workflow.ts
@@ -52,6 +52,11 @@ export async function runWorkflow(input: WorkflowExecutionInput<AiStudioNode>): 
   // tells Temporal to close the run as Failed rather than Completed. It has to be a
   // TemporalFailure (anything else fails the workflow *task* and retries forever), and
   // non-retryable since replaying a deterministic graph failure would re-run LLM activities.
+  //
+  // Only 'failed' throws. An 'incomplete' outcome — a branch that routed to a port with
+  // nothing wired to it — falls through on purpose: nothing errored, so the Workflow
+  // Execution closes as Completed and the run's own 'incomplete' status carries the
+  // detail. Do not add it to this check.
   if (outcome.status === 'failed') {
     throw ApplicationFailure.nonRetryable(outcome.error.message, outcome.error.code ?? 'WorkflowExecutionFailed');
   }

--- a/packages/execution-core/README.md
+++ b/packages/execution-core/README.md
@@ -92,6 +92,8 @@ Concrete executors and node configs live in the worker package that consumes the
    }
    ```
 
+   An executor that returns `nextPort` promises a live route — see [Incomplete runs](#incomplete-runs) for what happens when nothing is wired to it.
+
 3. Register it in your worker's `NodeExecutorRegistry<MyNode>`:
 
    ```ts
@@ -107,15 +109,15 @@ The registry's mapped type — `{ [K in TNode['type']]: NodeExecutor<Extract<TNo
 
 Each node can declare an `errorPolicy` on its `BaseNode` (sibling to `config`). The runner consults it after catching a node error and decides whether to propagate, absorb, or route the failure.
 
-| Policy         | When the node throws                                                                                                                                                                                       | Use case                                                |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `'fail'`       | (default) Emit `node_failed`, then abort the workflow with `execution_failed` and end the run as `{ status: 'failed' }`, which the engine adapter surfaces as a failed run (Temporal closes it as Failed). | Unrecoverable infra / programming bugs.                 |
-| `'continue'`   | Emit `node_failed`, set `nodeOutputs[id] = { error: { message, code? } }`, schedule downstream nodes through every outgoing edge **except** those tagged with the reserved `'errorRoute'` handle.          | Best-effort steps; downstream inspects the error.       |
-| `'errorRoute'` | Emit `node_failed`, set the same `{ error }` output, but only follow outgoing edges whose `sourceHandle === 'errorRoute'`. The success branch is pruned by the standard skip-propagation path.             | Retry-with-fallback, send-to-DLQ, compensating actions. |
+| Policy         | When the node throws                                                                                                                                                                                                                                                                                    | Use case                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `'fail'`       | (default) Emit `node_failed`, then abort the workflow with `execution_failed` and end the run as `{ status: 'failed' }`, which the engine adapter surfaces as a failed run (Temporal closes it as Failed).                                                                                              | Unrecoverable infra / programming bugs.                 |
+| `'continue'`   | Emit `node_failed`, set `nodeOutputs[id] = { error: { message, code? } }`, schedule downstream nodes through every outgoing edge **except** those tagged with the reserved `'errorRoute'` handle.                                                                                                       | Best-effort steps; downstream inspects the error.       |
+| `'errorRoute'` | Emit `node_failed`, set the same `{ error }` output, but only follow outgoing edges whose `sourceHandle === 'errorRoute'`. The success branch is pruned by the standard skip-propagation path. If no `'errorRoute'` edge exists, the run ends **incomplete** (see [Incomplete runs](#incomplete-runs)). | Retry-with-fallback, send-to-DLQ, compensating actions. |
 
 `'errorRoute'` piggybacks on the same `nextPort` mechanism decision nodes use — non-`'errorRoute'` edges are pruned through the standard skip-propagation path, so deep dead branches stay dormant.
 
-Only `'fail'` ends the run as failed. A node that fails under `'continue'` or `'errorRoute'` is absorbed by the graph: `node_failed` is still emitted, so the failure stays visible to anyone tailing events, but the run itself completes — `runGraph` returns `{ status: 'completed' }` and the engine reports a successful run.
+Only `'fail'` ends the run as failed. A node that fails under `'continue'` is absorbed by the graph: `node_failed` is still emitted, so the failure stays visible to anyone tailing events, but the run itself completes — `runGraph` returns `{ status: 'completed' }` and the engine reports a successful run. `'errorRoute'` absorbs the failure the same way only when the error port is actually routed; the same failure with no live `'errorRoute'` edge ends the run as `{ status: 'incomplete' }` — see [Incomplete runs](#incomplete-runs).
 
 ### `'errorRoute'` is a reserved `sourceHandle`
 

--- a/packages/execution-core/README.md
+++ b/packages/execution-core/README.md
@@ -158,7 +158,7 @@ A `node_skipped` emit that exhausts its retries is swallowed and the run carries
 
 ## Incomplete runs
 
-A run is **incomplete** when a node returned an explicit `nextPort` and no outgoing edge went live. Each occurrence is a _dead end_, recorded as `{ nodeId, port }`; the run finishes everything else it can reach, then emits a single terminal `execution_incomplete` event naming every one of them, sets the execution status to `'incomplete'`, and returns `{ status: 'incomplete', deadEnds }`.
+A run is **incomplete** when a node returned a non-empty `nextPort` and no outgoing edge went live. A falsy `nextPort` — `''`, or a `null` that unvalidated config lets through — counts as no port, mirroring the router, which treats a falsy `nextPort` as unrestricted routing. Each occurrence is a _dead end_, recorded as `{ nodeId, port }`; the run finishes everything else it can reach, then emits a single terminal `execution_incomplete` event naming every one of them, sets the execution status to `'incomplete'`, and returns `{ status: 'incomplete', deadEnds }`.
 
 It is deliberately **not** a failure. Nothing threw, so the engine closes the run normally — the Temporal adapter returns rather than raising an `ApplicationFailure`, and the Workflow Execution shows as Completed. What changes is the run's own status, so an operator can tell "the graph ran" from "the graph ran everything it was supposed to".
 
@@ -168,6 +168,7 @@ It is deliberately **not** a failure. Nothing threw, so the engine closes the ru
 | A decision node with no outgoing edges at all               | **incomplete**                                                            |
 | An `'errorRoute'` failure with no `'errorRoute'` edge       | **incomplete**                                                            |
 | A plain leaf (returns no `nextPort`)                        | completed                                                                 |
+| A leaf whose `nextPort` is `''` (or otherwise falsy)        | completed — falsy means "no port", same as the router                     |
 | A decision routes to a wired handle; other branches pruned  | completed, others `node_skipped`                                          |
 | A successful node whose only outgoing edges are error edges | completed — `nextPort` is undefined, so the success path is simply a leaf |
 | A `'continue'` failure on a leaf                            | completed                                                                 |

--- a/packages/execution-core/README.md
+++ b/packages/execution-core/README.md
@@ -134,7 +134,7 @@ const node: MyNode = {
 };
 ```
 
-If a node with `'errorRoute'` policy fails but has no outgoing edge tagged `'errorRoute'`, the run completes cleanly — the failure is recorded as `node_failed`, and the success branch it pruned reports `node_skipped` (see [Skipped nodes](#skipped-nodes)). Nothing else fires. That makes `'errorRoute'` usable as a silent DLQ when paired with downstream observability on `node_failed` events.
+If a node with `'errorRoute'` policy fails but has no outgoing edge tagged `'errorRoute'`, the failure is recorded as `node_failed`, any regular branch it pruned reports `node_skipped` (see [Skipped nodes](#skipped-nodes)), and the run ends **incomplete** — the policy named a port and nothing was wired to it. See [Incomplete runs](#incomplete-runs). For deliberate absorption, use `'continue'` on a node with no downstream edges: it records `node_failed` and ends the branch without claiming a route it does not have.
 
 ## Skipped nodes
 
@@ -155,6 +155,27 @@ Events are emitted once the whole wave has propagated, after that wave's `node_c
 A wave that contains a fatal (`'fail'`) failure still emits the skips its surviving siblings produced, before the terminal `execution_failed` — a failed run is where the "never taken" / "never reached" distinction matters most. Nodes downstream of the fatal node itself emit nothing: they were never resolved, which is not the same as being skipped.
 
 A `node_skipped` emit that exhausts its retries is swallowed and the run carries on. The event is advisory — a node that was never going to execute must not be able to abort an otherwise healthy run — and the sequence number the failed emit consumed leaves a gap the backend drain steps over.
+
+## Incomplete runs
+
+A run is **incomplete** when a node returned an explicit `nextPort` and no outgoing edge went live. Each occurrence is a _dead end_, recorded as `{ nodeId, port }`; the run finishes everything else it can reach, then emits a single terminal `execution_incomplete` event naming every one of them, sets the execution status to `'incomplete'`, and returns `{ status: 'incomplete', deadEnds }`.
+
+It is deliberately **not** a failure. Nothing threw, so the engine closes the run normally — the Temporal adapter returns rather than raising an `ApplicationFailure`, and the Workflow Execution shows as Completed. What changes is the run's own status, so an operator can tell "the graph ran" from "the graph ran everything it was supposed to".
+
+| Shape                                                       | Outcome                                                                   |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------- |
+| A decision routes to a handle no edge carries               | **incomplete**                                                            |
+| A decision node with no outgoing edges at all               | **incomplete**                                                            |
+| An `'errorRoute'` failure with no `'errorRoute'` edge       | **incomplete**                                                            |
+| A plain leaf (returns no `nextPort`)                        | completed                                                                 |
+| A decision routes to a wired handle; other branches pruned  | completed, others `node_skipped`                                          |
+| A successful node whose only outgoing edges are error edges | completed — `nextPort` is undefined, so the success path is simply a leaf |
+| A `'continue'` failure on a leaf                            | completed                                                                 |
+| Nodes that never became ready (a cycle)                     | **failed** — see below                                                    |
+
+Failure always wins. An unhandled node failure returns before the terminal check, and the stall check runs ahead of it, so a run reports incomplete only where it would otherwise have reported completed.
+
+`Workflow stalled: nodes never became ready` stays a **failure** and keeps its own name. A stall is the scheduler genuinely unable to proceed — a cycle, or a dangling-edge bug — where an incomplete run has finished and simply did not reach everything. Two different conditions, two different words.
 
 ## Template references
 
@@ -191,7 +212,7 @@ In practice this means:
 - **Positional `Promise.all`.** Concurrent waves use `Promise.all`, which resolves with results in input order regardless of completion order. The runner reads positionally and never branches on which promise finished first; `Promise.race` and `Promise.any` are not used.
 - **No top-level side effects.** `graph-runner.ts` only exports function declarations. Nothing reads the environment or instantiates dated objects at import time.
 
-A regression test (`graph-runner.replay-determinism.test.ts`) runs each canonical topology (linear, fan-out, diamond, decision, failure, stall) ten times against an identical deterministic port mock and asserts the resulting sequence of `EventEmitterPort` calls, statuses, and activity invocations is byte-equivalent across runs.
+A regression test (`graph-runner.replay-determinism.test.ts`) runs each canonical topology (linear, fan-out, diamond, decision, skip, dead end, failure, stall) ten times against an identical deterministic port mock and asserts the resulting sequence of `EventEmitterPort` calls, statuses, and activity invocations is byte-equivalent across runs.
 
 A full audit — every potential source of non-determinism enumerated with a verdict, plus maintenance rules for future contributors — lives in [`replay-audit.md`](./replay-audit.md). Read it before adding code that runs inside `runGraph`.
 
@@ -213,7 +234,7 @@ export interface LoggerPort {
 
 ### Where logger lives
 
-`LoggerPort` is **not** passed into `runGraph`, and `runGraph` does **not** import it. The runner is re-exported from the sandbox-safe entry (`@workflow-builder/execution-core/workflow`) and runs inside Temporal's V8 workflow context, where every call to `new Date()` poisons history replay. Lifecycle signals (`execution_started/completed/failed`, `node_started/completed/failed`, `node_skipped`) already flow through `EventEmitterPort` — operators tail those for run-time observability of a workflow.
+`LoggerPort` is **not** passed into `runGraph`, and `runGraph` does **not** import it. The runner is re-exported from the sandbox-safe entry (`@workflow-builder/execution-core/workflow`) and runs inside Temporal's V8 workflow context, where every call to `new Date()` poisons history replay. Lifecycle signals (`execution_started/completed/incomplete/failed`, `node_started/completed/failed`, `node_skipped`) already flow through `EventEmitterPort` — operators tail those for run-time observability of a workflow.
 
 Use `LoggerPort` outside the sandbox — in HTTP routes, in activity executors (LLM calls, HTTP retries), at app startup.
 

--- a/packages/execution-core/src/graph-runner.replay-determinism.test.ts
+++ b/packages/execution-core/src/graph-runner.replay-determinism.test.ts
@@ -232,6 +232,35 @@ describe('runGraph — replay determinism (re-execution equivalence)', () => {
     expect(records[0]!.statuses.at(-1)?.status).toBe('failed');
   });
 
+  it('dead ends — the terminal incomplete payload is identical across runs', async () => {
+    // `deadEnds` accumulates across waves in propagation order, then ships as one payload.
+    // An accidental Set, or emitting per-wave instead of once at the end, would re-order
+    // the list without changing any other recorded call.
+    const input = makeInput(
+      [start('S'), trigger('D1'), trigger('D2'), trigger('Live')],
+      [edge('e1', 'S', 'D1'), edge('e2', 'S', 'D2'), edge('e3', 'S', 'Live')],
+    );
+
+    const records = await runNTimes(
+      input,
+      { D1: { output: 'd1', nextPort: 'gone-1' }, D2: { output: 'd2', nextPort: 'gone-2' } },
+      RUNS,
+    );
+    expectAllRunsIdentical(records);
+
+    expect(records[0]!.events.at(-1)).toEqual({
+      type: 'execution_incomplete',
+      nodeId: undefined,
+      payload: {
+        deadEnds: [
+          { nodeId: 'D1', port: 'gone-1' },
+          { nodeId: 'D2', port: 'gone-2' },
+        ],
+      },
+    });
+    expect(records[0]!.statuses.at(-1)?.status).toBe('incomplete');
+  });
+
   it('node failure — failure path is deterministic too (same error code, same event sequence)', async () => {
     // The catch branch builds errorPayload from the thrown error. Across
     // replays the activity returns the same error (cached in history), so

--- a/packages/execution-core/src/graph-runner.test.ts
+++ b/packages/execution-core/src/graph-runner.test.ts
@@ -1181,8 +1181,12 @@ describe('runGraph — node_skipped emit failures', () => {
 
 describe('runGraph — incomplete runs (dead ends)', () => {
   it('decision routes to an unwired handle — run ends incomplete and names the node and port', async () => {
-    // The motivating case: the edge for branch 'Y' was deleted, but the decision still
-    // picks 'Y'. Previously the run closed as completed with a chunk of graph never run.
+    // The motivating case: the decision picks 'Y' but no edge carries that handle — the
+    // branch was renamed in config while the edge kept the old name, or was never wired.
+    // Previously the run closed as completed with a chunk of graph never run. (Deleting
+    // a node's sole incoming edge is a different shape, caught earlier as an
+    // orphaned-nodes failure; the deletion shape that reaches this rule is the join
+    // test below.)
     const runner = makeRunner({ D: { output: { matchedBranch: 'Y' }, nextPort: 'Y' } });
     const events = makeEvents();
 
@@ -1210,6 +1214,28 @@ describe('runGraph — incomplete runs (dead ends)', () => {
     const outcome = await runGraph(makeInput([start('D')], []), runner.port, events.port);
 
     expect(outcome).toEqual({ status: 'incomplete', deadEnds: [{ nodeId: 'D', port: 'X' }] });
+  });
+
+  it('edge deleted from a join — dead end recorded while the join still runs via its other input', async () => {
+    // The genuine-deletion shape that reaches the rule: D's 'Y' edge was removed, but
+    // its former target J keeps another input (S→J), so the orphan check never fires.
+    // D still picks 'Y' — a dead end — D's surviving 'X' edge is pruned, and J runs
+    // through S with only that live input.
+    const runner = makeRunner({ D: { output: 'd', nextPort: 'Y' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput(
+        [start('S'), trigger('D'), trigger('J')],
+        [edge('e1', 'S', 'D'), edge('e2', 'S', 'J'), edge('e3', 'D', 'J', 'X')],
+      ),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['S', 'D', 'J']);
+    expect(outcome).toEqual({ status: 'incomplete', deadEnds: [{ nodeId: 'D', port: 'Y' }] });
+    expect(skipsFrom(events.events)).toEqual([]);
   });
 
   it('plain leaf returns no port — still a completed run', async () => {

--- a/packages/execution-core/src/graph-runner.test.ts
+++ b/packages/execution-core/src/graph-runner.test.ts
@@ -978,17 +978,19 @@ describe('runGraph — errorPolicy', () => {
     expect(events.statuses.at(-1)).toEqual({ status: 'failed', errorMessage: 'hard' });
   });
 
-  it("'errorRoute' with no 'errorRoute' edge — workflow completes as a silent DLQ", async () => {
-    // No outgoing edge with sourceHandle 'errorRoute' means routing has nowhere to
-    // go. The runner emits node_failed and ends the run cleanly — useful when
-    // the caller just wants the failure recorded.
+  it("'errorRoute' with no 'errorRoute' edge — run ends incomplete, not as a silent DLQ", async () => {
+    // Behaviour reversal: this used to end the run cleanly, documented as a silent DLQ.
+    // The policy names a port, so 'errorRoute' with nothing wired to it is the same
+    // broken promise as a decision routing to a handle nobody connected. Deliberate
+    // absorption is what 'continue' is for.
     const runner = makeRunner({ A: { throws: 'boom' } });
     const events = makeEvents();
 
-    await runGraph(makeInput([start('A', 'errorRoute')], []), runner.port, events.port);
+    const outcome = await runGraph(makeInput([start('A', 'errorRoute')], []), runner.port, events.port);
 
     expect(events.events.some((event) => event.type === 'node_failed' && event.nodeId === 'A')).toBe(true);
-    expect(events.statuses.at(-1)?.status).toBe('completed');
+    expect(outcome).toEqual({ status: 'incomplete', deadEnds: [{ nodeId: 'A', port: 'errorRoute' }] });
+    expect(events.statuses.at(-1)?.status).toBe('incomplete');
   });
 
   it("'continue' does not fire edges tagged with the reserved 'errorRoute' source handle", async () => {
@@ -1174,5 +1176,156 @@ describe('runGraph — node_skipped emit failures', () => {
     expect(events.events.at(-1)?.type).toBe('execution_failed');
     expect(outcome).toEqual({ status: 'failed', error: { message: 'hard' } });
     expect(events.statuses.at(-1)).toEqual({ status: 'failed', errorMessage: 'hard' });
+  });
+});
+
+describe('runGraph — incomplete runs (dead ends)', () => {
+  it('decision routes to an unwired handle — run ends incomplete and names the node and port', async () => {
+    // The motivating case: the edge for branch 'Y' was deleted, but the decision still
+    // picks 'Y'. Previously the run closed as completed with a chunk of graph never run.
+    const runner = makeRunner({ D: { output: { matchedBranch: 'Y' }, nextPort: 'Y' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput([start('D'), trigger('B')], [edge('e1', 'D', 'B', 'X')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['D']);
+    expect(outcome).toEqual({ status: 'incomplete', deadEnds: [{ nodeId: 'D', port: 'Y' }] });
+    expect(events.events.at(-1)).toEqual({
+      type: 'execution_incomplete',
+      nodeId: undefined,
+      payload: { deadEnds: [{ nodeId: 'D', port: 'Y' }] },
+    });
+    expect(events.events.some((event) => event.type === 'execution_completed')).toBe(false);
+    expect(events.statuses.at(-1)).toEqual({ status: 'incomplete', errorMessage: undefined });
+  });
+
+  it('decision with no outgoing edges at all — same rule, no special case', async () => {
+    const runner = makeRunner({ D: { output: 'd', nextPort: 'X' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(makeInput([start('D')], []), runner.port, events.port);
+
+    expect(outcome).toEqual({ status: 'incomplete', deadEnds: [{ nodeId: 'D', port: 'X' }] });
+  });
+
+  it('plain leaf returns no port — still a completed run', async () => {
+    // The negative case the rule hinges on: a branch that simply ends is not a dead end.
+    const runner = makeRunner();
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput([start('A'), trigger('B')], [edge('e1', 'A', 'B')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(outcome).toEqual({ status: 'completed' });
+    expect(events.events.some((event) => event.type === 'execution_incomplete')).toBe(false);
+  });
+
+  it('successful node whose only outgoing edges are error edges — still completed', async () => {
+    // A success with an unconnected error branch is a leaf as far as the success path is
+    // concerned: `nextPort` is undefined, so the rule must not fire. The case most likely
+    // to break under a careless refactor of the dead-end check.
+    const runner = makeRunner();
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput([start('A'), trigger('Recovery')], [edge('e1', 'A', 'Recovery', 'errorRoute')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['A']);
+    expect(outcome).toEqual({ status: 'completed' });
+  });
+
+  it('a dead end does not stop the rest of the graph', async () => {
+    // Two legs off the start. Leg 1 dead-ends at D; leg 2 must still run to completion,
+    // and the run reports incomplete only at the end.
+    const runner = makeRunner({ D: { output: 'd', nextPort: 'gone' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput(
+        [start('S'), trigger('D'), trigger('Leg2'), trigger('Leg2Prime')],
+        [edge('e1', 'S', 'D'), edge('e2', 'S', 'Leg2'), edge('e3', 'Leg2', 'Leg2Prime')],
+      ),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['S', 'D', 'Leg2', 'Leg2Prime']);
+    expect(outcome).toEqual({ status: 'incomplete', deadEnds: [{ nodeId: 'D', port: 'gone' }] });
+  });
+
+  it('several dead ends in one run are all collected', async () => {
+    // Both decisions DO have an outgoing edge — just on a handle neither of them picked,
+    // so X is pruned and skipped while both routes are recorded as dead ends.
+    const runner = makeRunner({
+      D1: { output: 'd1', nextPort: 'gone-1' },
+      D2: { output: 'd2', nextPort: 'gone-2' },
+    });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput(
+        [start('S'), trigger('D1'), trigger('D2'), trigger('X')],
+        [edge('e1', 'S', 'D1'), edge('e2', 'S', 'D2'), edge('e3', 'D1', 'X', 'other'), edge('e4', 'D2', 'X', 'other')],
+      ),
+      runner.port,
+      events.port,
+    );
+
+    expect(outcome).toEqual({
+      status: 'incomplete',
+      deadEnds: [
+        { nodeId: 'D1', port: 'gone-1' },
+        { nodeId: 'D2', port: 'gone-2' },
+      ],
+    });
+  });
+
+  it('a fatal node failure takes precedence over a dead end', async () => {
+    // Both happen in the same wave. Failure returns early, so the run never reaches the
+    // terminal incomplete check and no execution_incomplete is emitted.
+    const runner = makeRunner({
+      D: { output: 'd', nextPort: 'gone' },
+      Boom: { throws: 'boom' },
+    });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput([start('S'), trigger('D'), trigger('Boom')], [edge('e1', 'S', 'D'), edge('e2', 'S', 'Boom')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(outcome).toEqual({ status: 'failed', error: { message: 'boom' } });
+    expect(events.events.some((event) => event.type === 'execution_incomplete')).toBe(false);
+    expect(events.statuses.at(-1)?.status).toBe('failed');
+  });
+
+  it('a cycle still fails rather than reporting incomplete', async () => {
+    // 'stalled' keeps meaning exactly one thing: nodes that never became ready. That is a
+    // genuine stall and stays a failure, deliberately not folded into 'incomplete'.
+    const runner = makeRunner({ D: { output: 'd', nextPort: 'gone' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput(
+        [start('S'), trigger('D'), trigger('B'), trigger('C')],
+        [edge('e1', 'S', 'D'), edge('e2', 'S', 'B'), edge('e3', 'B', 'C'), edge('e4', 'C', 'B')],
+      ),
+      runner.port,
+      events.port,
+    );
+
+    expect(outcome.status).toBe('failed');
+    expect(events.events.some((event) => event.type === 'execution_incomplete')).toBe(false);
   });
 });

--- a/packages/execution-core/src/graph-runner.test.ts
+++ b/packages/execution-core/src/graph-runner.test.ts
@@ -1244,6 +1244,47 @@ describe('runGraph — incomplete runs (dead ends)', () => {
     expect(outcome).toEqual({ status: 'completed' });
   });
 
+  it('an empty-string nextPort on a leaf is not a dead end — falsy means no port', async () => {
+    // The router (`isEdgeLive`) treats a falsy nextPort as "no restriction", so the
+    // dead-end rule must agree: '' promised nothing, the node is a plain leaf.
+    const runner = makeRunner({ D: { output: 'd', nextPort: '' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(makeInput([start('D')], []), runner.port, events.port);
+
+    expect(outcome).toEqual({ status: 'completed' });
+    expect(events.events.some((event) => event.type === 'execution_incomplete')).toBe(false);
+  });
+
+  it('an empty-string nextPort with a regular edge routes like no port — every edge fires', async () => {
+    // The router half of the same contract: '' does not restrict routing, so B runs.
+    // If this and the leaf case above ever disagree, one value has two meanings again.
+    const runner = makeRunner({ D: { output: 'd', nextPort: '' } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(
+      makeInput([start('D'), trigger('B')], [edge('e1', 'D', 'B')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(runner.callOrder).toEqual(['D', 'B']);
+    expect(outcome).toEqual({ status: 'completed' });
+  });
+
+  it('a null nextPort smuggled through unvalidated config is not a dead end', async () => {
+    // Config reaches the runner as z.unknown(), and executeDecision returns
+    // branch.sourceHandle verbatim — so null arrives at runtime despite the string
+    // typing. It must not end up in the `port: string` payload field.
+    const runner = makeRunner({ D: { output: 'd', nextPort: null as unknown as string } });
+    const events = makeEvents();
+
+    const outcome = await runGraph(makeInput([start('D')], []), runner.port, events.port);
+
+    expect(outcome).toEqual({ status: 'completed' });
+    expect(events.events.some((event) => event.type === 'execution_incomplete')).toBe(false);
+  });
+
   it('a dead end does not stop the rest of the graph', async () => {
     // Two legs off the start. Leg 1 dead-ends at D; leg 2 must still run to completion,
     // and the run reports incomplete only at the end.

--- a/packages/execution-core/src/graph-runner.ts
+++ b/packages/execution-core/src/graph-runner.ts
@@ -117,12 +117,14 @@ export async function runGraph<TNode extends BaseNode>(
         nodeOutputs[result.node.id] = errorOutput;
         state.status.set(result.node.id, 'completed');
         const nextPort = policy === 'errorRoute' ? RESERVED_ERROR_HANDLE : undefined;
-        propagate(result.node.id, nextPort, true, state, newlyReady, skipped, deadEnds);
+        const deadEnd = propagate(result.node.id, nextPort, true, state, newlyReady, skipped);
+        if (deadEnd) deadEnds.push(deadEnd);
         continue;
       }
       nodeOutputs[result.node.id] = result.output;
       state.status.set(result.node.id, 'completed');
-      propagate(result.node.id, result.nextPort, true, state, newlyReady, skipped, deadEnds);
+      const deadEnd = propagate(result.node.id, result.nextPort, true, state, newlyReady, skipped);
+      if (deadEnd) deadEnds.push(deadEnd);
     }
 
     // Emitted once the whole wave has propagated, so a skip reads as a consequence of
@@ -218,9 +220,10 @@ type SkippedNode = { id: string; reason: NodeSkipReason };
 // don't stall downstream join points and deep dead-branch chains can't blow the
 // call stack.
 //
-// Newly ready nodes land in `out`, newly skipped ones in `skippedOut`, and a root that
-// routed nowhere in `deadEndOut`; all three are appended in traversal order and none are
-// emitted from here, so the caller keeps control of event ordering.
+// Newly ready nodes land in `out`, newly skipped ones in `skippedOut`; both are
+// appended in traversal order and neither is emitted from here, so the caller keeps
+// control of event ordering. The return value is a single post-loop verdict about the
+// root — it named a port and nothing went live through it — or `undefined`.
 function propagate<TNode extends BaseNode>(
   rootId: string,
   rootNextPort: string | undefined,
@@ -228,21 +231,21 @@ function propagate<TNode extends BaseNode>(
   state: SchedulerState<TNode>,
   out: TNode[],
   skippedOut: SkippedNode[],
-  deadEndOut: DeadEnd[],
-): void {
-  // `isRoot` rather than comparing against `rootId`: a cycle can walk back into the root
-  // during skip propagation, and those entries carry `sourceLive: false`, so counting
-  // them would report a live root as a dead end.
-  const queue: { fromId: string; nextPort: string | undefined; sourceLive: boolean; isRoot: boolean }[] = [
-    { fromId: rootId, nextPort: rootNextPort, sourceLive: rootSourceLive, isRoot: true },
+): DeadEnd | undefined {
+  // Root liveness is static — adjacency never mutates and isEdgeLive reads no
+  // scheduler state — so it is computed upfront rather than tracked in the loop.
+  const rootRoutedSomewhere = (state.adjacency.get(rootId) ?? []).some(({ sourceHandle }) =>
+    isEdgeLive(rootSourceLive, rootNextPort, sourceHandle),
+  );
+
+  const queue: { fromId: string; nextPort: string | undefined; sourceLive: boolean }[] = [
+    { fromId: rootId, nextPort: rootNextPort, sourceLive: rootSourceLive },
   ];
-  let rootRoutedSomewhere = false;
   while (queue.length > 0) {
-    const { fromId, nextPort, sourceLive, isRoot } = queue.shift()!;
+    const { fromId, nextPort, sourceLive } = queue.shift()!;
     const successors = state.adjacency.get(fromId) ?? [];
     for (const { node: target, sourceHandle } of successors) {
       const edgeLive = isEdgeLive(sourceLive, nextPort, sourceHandle);
-      if (isRoot && edgeLive) rootRoutedSomewhere = true;
       state.pendingPredecessors.set(target.id, (state.pendingPredecessors.get(target.id) ?? 0) - 1);
       if (edgeLive) {
         state.liveIncoming.set(target.id, (state.liveIncoming.get(target.id) ?? 0) + 1);
@@ -259,7 +262,7 @@ function propagate<TNode extends BaseNode>(
         } else {
           state.status.set(target.id, 'skipped');
           skippedOut.push({ id: target.id, reason: skipReason(state.livePruneKind.get(target.id)) });
-          queue.push({ fromId: target.id, nextPort: undefined, sourceLive: false, isRoot: false });
+          queue.push({ fromId: target.id, nextPort: undefined, sourceLive: false });
         }
       }
     }
@@ -270,8 +273,9 @@ function propagate<TNode extends BaseNode>(
   // unvalidated, and a falsy port ('' or a smuggled null) routes as "no port" there,
   // so it must not read as a promised route here.
   if (rootNextPort && !rootRoutedSomewhere) {
-    deadEndOut.push({ nodeId: rootId, port: rootNextPort });
+    return { nodeId: rootId, port: rootNextPort };
   }
+  return undefined;
 }
 
 function skipReason(kind: LivePruneKind | undefined): NodeSkipReason {

--- a/packages/execution-core/src/graph-runner.ts
+++ b/packages/execution-core/src/graph-runner.ts
@@ -1,4 +1,4 @@
-import type { NodeSkipReason } from '@workflow-builder/types/workflow-execution/execution-events';
+import type { DeadEnd, NodeSkipReason } from '@workflow-builder/types/workflow-execution/execution-events';
 import type {
   BaseNode,
   NodeErrorPolicy,
@@ -22,13 +22,18 @@ import { resolveStartNode } from './resolve-start-node';
 const RESERVED_ERROR_HANDLE = 'errorRoute';
 
 // How the run ended. Returned rather than thrown so `runGraph` stays engine-agnostic:
-// each engine adapter decides how a failed outcome maps onto its own vocabulary (the
-// Temporal adapter raises an ApplicationFailure so the Workflow Execution shows as
-// Failed rather than Completed). Note a node failing under errorPolicy 'continue' or
-// 'errorRoute' is absorbed by the graph and still yields `{ status: 'completed' }` —
-// only an unhandled node failure, a stall, or a malformed start (missing, duplicated,
-// or with orphaned nodes alongside it) fails the run.
-export type RunGraphOutcome = { status: 'completed' } | { status: 'failed'; error: { message: string; code?: string } };
+// each engine adapter decides how an outcome maps onto its own vocabulary (the
+// Temporal adapter raises an ApplicationFailure for 'failed' so the Workflow Execution
+// shows as Failed rather than Completed; 'incomplete' closes normally, since nothing
+// went wrong). Note a node failing under errorPolicy 'continue' is absorbed by the graph
+// and still yields `{ status: 'completed' }` — only an unhandled node failure, a stall,
+// or a malformed start (missing, duplicated, or with orphaned nodes alongside it) fails
+// the run. 'incomplete' means every route the graph took was followed to its end, but at
+// least one of them led nowhere — see `deadEnds`.
+export type RunGraphOutcome =
+  | { status: 'completed' }
+  | { status: 'incomplete'; deadEnds: DeadEnd[] }
+  | { status: 'failed'; error: { message: string; code?: string } };
 
 // Topological scheduler. A node becomes ready only when ALL of its incoming
 // edges are resolved (predecessor either completed via a live route, or was
@@ -39,7 +44,7 @@ export type RunGraphOutcome = { status: 'completed' } | { status: 'failed'; erro
 // sandbox-safe entry (`./workflow`) and therefore runs inside Temporal's
 // V8 workflow context, where every call to `new Date()`, `Math.random()`,
 // or other non-deterministic source poisons history replay. Lifecycle
-// signals (execution_started/completed/failed, node_started/completed/failed,
+// signals (execution_started/completed/incomplete/failed, node_started/completed/failed,
 // node_skipped) already flow through EventEmitterPort — operators tail those for run-time
 // observability. Activity executors that need real-time logs (LLM failures,
 // HTTP retries) hold their own LoggerPort outside the sandbox.
@@ -73,6 +78,7 @@ export async function runGraph<TNode extends BaseNode>(
 
   let ready: TNode[] = [startNode];
   const nodeOutputs: Record<string, unknown> = {};
+  const deadEnds: DeadEnd[] = [];
 
   while (ready.length > 0) {
     const context: ExecutionContext = {
@@ -111,12 +117,12 @@ export async function runGraph<TNode extends BaseNode>(
         nodeOutputs[result.node.id] = errorOutput;
         state.status.set(result.node.id, 'completed');
         const nextPort = policy === 'errorRoute' ? RESERVED_ERROR_HANDLE : undefined;
-        propagate(result.node.id, nextPort, true, state, newlyReady, skipped);
+        propagate(result.node.id, nextPort, true, state, newlyReady, skipped, deadEnds);
         continue;
       }
       nodeOutputs[result.node.id] = result.output;
       state.status.set(result.node.id, 'completed');
-      propagate(result.node.id, result.nextPort, true, state, newlyReady, skipped);
+      propagate(result.node.id, result.nextPort, true, state, newlyReady, skipped, deadEnds);
     }
 
     // Emitted once the whole wave has propagated, so a skip reads as a consequence of
@@ -152,6 +158,12 @@ export async function runGraph<TNode extends BaseNode>(
   if (stalled.length > 0) {
     const message = `Workflow stalled: nodes never became ready: ${stalled.join(', ')}`;
     return await failExecution(input.executionId, events, { message });
+  }
+
+  if (deadEnds.length > 0) {
+    await events.emitEvent(input.executionId, 'execution_incomplete', { deadEnds });
+    await events.updateStatus(input.executionId, 'incomplete');
+    return { status: 'incomplete', deadEnds };
   }
 
   await events.emitEvent(input.executionId, 'execution_completed');
@@ -206,9 +218,9 @@ type SkippedNode = { id: string; reason: NodeSkipReason };
 // don't stall downstream join points and deep dead-branch chains can't blow the
 // call stack.
 //
-// Newly ready nodes land in `out`, newly skipped ones in `skippedOut`; both are
-// appended in traversal order and neither is emitted from here, so the caller
-// keeps control of event ordering.
+// Newly ready nodes land in `out`, newly skipped ones in `skippedOut`, and a root that
+// routed nowhere in `deadEndOut`; all three are appended in traversal order and none are
+// emitted from here, so the caller keeps control of event ordering.
 function propagate<TNode extends BaseNode>(
   rootId: string,
   rootNextPort: string | undefined,
@@ -216,15 +228,21 @@ function propagate<TNode extends BaseNode>(
   state: SchedulerState<TNode>,
   out: TNode[],
   skippedOut: SkippedNode[],
+  deadEndOut: DeadEnd[],
 ): void {
-  const queue: { fromId: string; nextPort: string | undefined; sourceLive: boolean }[] = [
-    { fromId: rootId, nextPort: rootNextPort, sourceLive: rootSourceLive },
+  // `isRoot` rather than comparing against `rootId`: a cycle can walk back into the root
+  // during skip propagation, and those entries carry `sourceLive: false`, so counting
+  // them would report a live root as a dead end.
+  const queue: { fromId: string; nextPort: string | undefined; sourceLive: boolean; isRoot: boolean }[] = [
+    { fromId: rootId, nextPort: rootNextPort, sourceLive: rootSourceLive, isRoot: true },
   ];
+  let rootRoutedSomewhere = false;
   while (queue.length > 0) {
-    const { fromId, nextPort, sourceLive } = queue.shift()!;
+    const { fromId, nextPort, sourceLive, isRoot } = queue.shift()!;
     const successors = state.adjacency.get(fromId) ?? [];
     for (const { node: target, sourceHandle } of successors) {
       const edgeLive = isEdgeLive(sourceLive, nextPort, sourceHandle);
+      if (isRoot && edgeLive) rootRoutedSomewhere = true;
       state.pendingPredecessors.set(target.id, (state.pendingPredecessors.get(target.id) ?? 0) - 1);
       if (edgeLive) {
         state.liveIncoming.set(target.id, (state.liveIncoming.get(target.id) ?? 0) + 1);
@@ -241,10 +259,17 @@ function propagate<TNode extends BaseNode>(
         } else {
           state.status.set(target.id, 'skipped');
           skippedOut.push({ id: target.id, reason: skipReason(state.livePruneKind.get(target.id)) });
-          queue.push({ fromId: target.id, nextPort: undefined, sourceLive: false });
+          queue.push({ fromId: target.id, nextPort: undefined, sourceLive: false, isRoot: false });
         }
       }
     }
+  }
+
+  // A node that named a port but reached nothing through it. Only an explicit port
+  // counts: a plain leaf returns none and is a legitimate end of a branch, whereas a
+  // decision that picked a branch — or an 'errorRoute' failure — promised a route.
+  if (rootNextPort !== undefined && !rootRoutedSomewhere) {
+    deadEndOut.push({ nodeId: rootId, port: rootNextPort });
   }
 }
 

--- a/packages/execution-core/src/graph-runner.ts
+++ b/packages/execution-core/src/graph-runner.ts
@@ -265,10 +265,11 @@ function propagate<TNode extends BaseNode>(
     }
   }
 
-  // A node that named a port but reached nothing through it. Only an explicit port
-  // counts: a plain leaf returns none and is a legitimate end of a branch, whereas a
-  // decision that picked a branch — or an 'errorRoute' failure — promised a route.
-  if (rootNextPort !== undefined && !rootRoutedSomewhere) {
+  // A node that named a port but reached nothing through it. Only a non-empty port
+  // counts — truthiness, to mirror `isEdgeLive`'s `!nextPort`: config arrives
+  // unvalidated, and a falsy port ('' or a smuggled null) routes as "no port" there,
+  // so it must not read as a promised route here.
+  if (rootNextPort && !rootRoutedSomewhere) {
     deadEndOut.push({ nodeId: rootId, port: rootNextPort });
   }
 }

--- a/packages/execution-core/src/ports/activity-runner.port.ts
+++ b/packages/execution-core/src/ports/activity-runner.port.ts
@@ -4,6 +4,9 @@ import type { ExecutionContext } from '../execution-context';
 
 export type NodeExecutionResult = {
   output: unknown;
+  // Naming a port promises a live route: if no outgoing edge goes live for it, the run
+  // ends incomplete with `{ nodeId, port }`. Falsy ('' or a smuggled null) means "no
+  // port", mirroring the router. 'errorRoute' is reserved for the error policy.
   nextPort?: string;
 };
 

--- a/packages/execution-core/terminal-states.decision-log.md
+++ b/packages/execution-core/terminal-states.decision-log.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-A graph could route itself into nothing and report success. `executeDecision` returns `nextPort = branch.sourceHandle`; if no edge carries that handle — the edge was deleted, the branch was renamed in config while the edge kept the old handle, or the branch was never wired — every outgoing edge is pruned. The runner had nothing left to schedule, fell out of the wave loop, emitted `execution_completed`, and Temporal closed the Workflow Execution as Completed.
+A graph could route itself into nothing and report success. `executeDecision` returns `nextPort = branch.sourceHandle`; if no edge carries that handle — an edge removed from a join (its target keeps another input) or removed together with its target node, a branch renamed in config while the edge kept the old handle, or a branch never wired — every outgoing edge is pruned. The runner had nothing left to schedule, fell out of the wave loop, emitted `execution_completed`, and Temporal closed the Workflow Execution as Completed. Deleting a node's sole incoming edge is a different shape: it orphans the target and is caught before any node runs, as the orphaned-nodes failure in `resolve-start-node.ts`.
 
 This is the same class of bug as the missing start node (F3), one layer down: the run looks like it worked, and the work that never happened is invisible unless you count nodes by hand. `node_skipped` (F1) made the downstream nodes visible, but reports them as `branch_not_taken` — "the decision chose elsewhere". It didn't. It chose a branch that does not exist.
 

--- a/packages/execution-core/terminal-states.decision-log.md
+++ b/packages/execution-core/terminal-states.decision-log.md
@@ -1,0 +1,56 @@
+### Title: `incomplete` as a third terminal state, distinct from `failed` and from a stall
+
+### Proposed by: Dawid Aksamski
+
+### Date: 24.08.2026
+
+## Context
+
+A graph could route itself into nothing and report success. `executeDecision` returns `nextPort = branch.sourceHandle`; if no edge carries that handle — the edge was deleted, the branch was renamed in config while the edge kept the old handle, or the branch was never wired — every outgoing edge is pruned. The runner had nothing left to schedule, fell out of the wave loop, emitted `execution_completed`, and Temporal closed the Workflow Execution as Completed.
+
+This is the same class of bug as the missing start node (F3), one layer down: the run looks like it worked, and the work that never happened is invisible unless you count nodes by hand. `node_skipped` (F1) made the downstream nodes visible, but reports them as `branch_not_taken` — "the decision chose elsewhere". It didn't. It chose a branch that does not exist.
+
+Two things had to be settled: what to call the state, and how far the blast radius goes.
+
+## Decision
+
+A third terminal state — event `execution_incomplete`, status `'incomplete'`, and a third `RunGraphOutcome` member `{ status: 'incomplete'; deadEnds: DeadEnd[] }`.
+
+**The rule is one sentence:** a node returned an explicit `nextPort` and no outgoing edge went live. Each occurrence is a _dead end_, recorded as `{ nodeId, port }`. A plain leaf returns no port, so it never trips.
+
+**Named `incomplete`, not `stalled`.** The run is over, not wedged. "Stalled" implies stuck — possibly waiting, possibly resumable if unblocked — which is the opposite of a run the engine closes normally. `'incomplete'` is also the natural sibling of `'completed'` in a status union whose members all answer "where is this run". A UI badge reading "stalled" invites the user to wait it out or cancel, when there is nothing left to wait for.
+
+Keeping the word free matters as much as picking the right one: `Workflow stalled: nodes never became ready` already existed for the cycle check, that condition genuinely _is_ a stall, and it genuinely _is_ a failure. Naming the new state `stalled` would have forced a reword and left two conditions sharing vocabulary anyway.
+
+**Not a failure.** `run-workflow.ts` throws only on `outcome.status === 'failed'`, so `'incomplete'` falls through and Temporal closes the run as Completed. Nothing errored; what changed is the run's own status.
+
+**`errorRoute` with no `errorRoute` edge now counts.** The runner synthesises `nextPort = 'errorRoute'`, so the general rule already covers it — excluding it would mean carving out `RESERVED_ERROR_HANDLE`. This reverses documented behaviour: the README described that shape as a usable "silent DLQ". The policy names a port; nothing wired to it is the same broken promise as a decision routing to an unconnected handle. Deliberate absorption is what `'continue'` is for, and that idiom is now what the README points at.
+
+**A dead end does not stop the run.** Dead ends are collected run-scoped and reported once at the end, so parallel branches still deliver their work — including LLM calls already paid for — and the terminal event names every dead end rather than just the first. Aborting mid-wave would also require cancelling in-flight activities to actually stop anything.
+
+**Failure keeps precedence.** An unhandled node failure returns through `failExecution` before the terminal check, and the stall check runs ahead of it. A run reports incomplete only where it would otherwise have reported completed.
+
+## Alternative Options Considered
+
+- **`execution_stalled`** — rejected on the naming argument above.
+- **Fold the cycle check in** — rejected. A cycle is the scheduler unable to proceed and should stay a failure; an incomplete run finished and simply did not reach everything. Two conditions, two words.
+- **Abort at the first dead end** — rejected. Discards useful work in unrelated branches, and would need activity cancellation to stop anything already in flight.
+- **A per-dead-end event plus a terminal one** — rejected. Two new contract members where one does the job; the surrounding `node_completed` / `node_skipped` events already place the dead end in the timeline.
+- **A new `NodeSkipReason` instead of a run-level state** — rejected. It would describe the downstream nodes accurately but leave the run itself still reporting `completed`, which is the actual bug.
+- **Publish-time validation instead of a runtime state** (F7: every decision handle wired, reachability, terminal leaves) — out of scope and not a substitute: a draft can be executed before it is ever published, and handles can drift after publication.
+
+## Consequences
+
+- **Pros**
+  - A run that did not reach everything says so, in the event stream, the DB status, and the UI.
+  - The rule is one sentence with no special cases, and the `errorRoute` shape falls out of it for free.
+  - `stalled` keeps exactly one meaning, so the existing cycle message needed no rewording.
+  - Temporal still reports Completed, so nothing that watches for Failed Workflow Executions starts alarming on a misconfigured graph.
+
+- **Cons**
+  - Six separate places enumerate terminal states (worker `database.ts`, backend `drain-events.ts` and `routes/executions.ts`, ai-studio stream adapter, store, and controls). All six had to change together; missing one hangs an SSE stream, leaves `finished_at` null, or strands the UI mid-run. There is no single source of truth for "terminal" — worth consolidating if a fourth state ever appears.
+  - The `errorRoute` reversal is a behaviour change for anyone who relied on the silent-DLQ shape. They now get `'incomplete'` where they got `'completed'`; the migration is to switch those nodes to `'continue'`.
+
+## Status
+
+Accepted

--- a/packages/execution-core/terminal-states.decision-log.md
+++ b/packages/execution-core/terminal-states.decision-log.md
@@ -48,7 +48,7 @@ Keeping the word free matters as much as picking the right one: `Workflow stalle
   - Temporal still reports Completed, so nothing that watches for Failed Workflow Executions starts alarming on a misconfigured graph.
 
 - **Cons**
-  - Six separate places enumerate terminal states (worker `database.ts`, backend `drain-events.ts` and `routes/executions.ts`, ai-studio stream adapter, store, and controls). All six had to change together; missing one hangs an SSE stream, leaves `finished_at` null, or strands the UI mid-run. There is no single source of truth for "terminal" — worth consolidating if a fourth state ever appears.
+  - Six separate places enumerate terminal states (worker `database.ts`, backend `drain-events.ts` and `routes/executions.ts`, ai-studio stream adapter, store, and controls). All six had to change together; missing one hangs an SSE stream, leaves `finished_at` null, or strands the UI mid-run. There is no single source of truth for "terminal" — worth consolidating if a fourth state ever appears. (Consolidated since: `TERMINAL_EXECUTION_STATUSES` / `TERMINAL_EXECUTION_EVENT_TYPES` / `TERMINAL_EVENT_TO_STATUS` in `packages/types` are now the source; the enumeration sites derive from them.)
   - The `errorRoute` reversal is a behaviour change for anyone who relied on the silent-DLQ shape. They now get `'incomplete'` where they got `'completed'`; the migration is to switch those nodes to `'continue'`.
 
 ## Status

--- a/packages/types/src/workflow-execution/execution-events.ts
+++ b/packages/types/src/workflow-execution/execution-events.ts
@@ -8,6 +8,7 @@ export type ExecutionEventType =
   | 'branch_spawned'
   | 'branches_joined'
   | 'execution_completed'
+  | 'execution_incomplete'
   | 'execution_failed'
   | 'execution_cancelled';
 
@@ -51,6 +52,15 @@ export type ExecutionCompletedPayload = {
 
 export type ExecutionCancelledPayload = {
   reason?: string;
+};
+
+export type DeadEnd = {
+  nodeId: string;
+  port: string;
+};
+
+export type ExecutionIncompletePayload = {
+  deadEnds: DeadEnd[];
 };
 
 type BaseEvent = {
@@ -108,6 +118,11 @@ export type ExecutionCompletedEvent = BaseEvent & {
   payload?: ExecutionCompletedPayload;
 };
 
+export type ExecutionIncompleteEvent = BaseEvent & {
+  type: 'execution_incomplete';
+  payload: ExecutionIncompletePayload;
+};
+
 export type ExecutionFailedEvent = BaseEvent & {
   type: 'execution_failed';
   payload: ExecutionErrorPayload;
@@ -128,6 +143,7 @@ export type ExecutionEvent =
   | BranchSpawnedEvent
   | BranchesJoinedEvent
   | ExecutionCompletedEvent
+  | ExecutionIncompleteEvent
   | ExecutionFailedEvent
   | ExecutionCancelledEvent;
 
@@ -138,4 +154,11 @@ export type ExecutionSnapshot = {
   events: ExecutionEvent[];
 };
 
-export type ExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelling' | 'cancelled';
+export type ExecutionStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'incomplete'
+  | 'failed'
+  | 'cancelling'
+  | 'cancelled';

--- a/packages/types/src/workflow-execution/execution-events.ts
+++ b/packages/types/src/workflow-execution/execution-events.ts
@@ -1,3 +1,31 @@
+// Single source of truth for "the run is over" — the worker derives its terminal
+// SQL guard, the backend its stream-close gates, and ai-studio its EventSource
+// close conditions from these tuples. Adding a terminal state is a one-line change
+// here; the literal types update automatically via `(typeof …)[number]`, and the
+// unions below are composed from them so the lists cannot drift apart.
+export const TERMINAL_EXECUTION_STATUSES = ['completed', 'incomplete', 'failed', 'cancelled'] as const;
+
+export type TerminalExecutionStatus = (typeof TERMINAL_EXECUTION_STATUSES)[number];
+
+export const TERMINAL_EXECUTION_EVENT_TYPES = [
+  'execution_completed',
+  'execution_incomplete',
+  'execution_failed',
+  'execution_cancelled',
+] as const;
+
+export type TerminalExecutionEventType = (typeof TERMINAL_EXECUTION_EVENT_TYPES)[number];
+
+// A terminal event is the durable fact; the status row is derived state that can lag
+// it (the worker writes them in two separate activities). This map is the one place
+// that correspondence is written down; `satisfies` keeps it total over the tuple.
+export const TERMINAL_EVENT_TO_STATUS = {
+  execution_completed: 'completed',
+  execution_incomplete: 'incomplete',
+  execution_failed: 'failed',
+  execution_cancelled: 'cancelled',
+} as const satisfies Record<TerminalExecutionEventType, TerminalExecutionStatus>;
+
 export type ExecutionEventType =
   | 'execution_started'
   | 'node_started'
@@ -7,10 +35,7 @@ export type ExecutionEventType =
   | 'node_skipped'
   | 'branch_spawned'
   | 'branches_joined'
-  | 'execution_completed'
-  | 'execution_incomplete'
-  | 'execution_failed'
-  | 'execution_cancelled';
+  | TerminalExecutionEventType;
 
 export type ExecutionStartedPayload = {
   workflowId: string;
@@ -154,11 +179,4 @@ export type ExecutionSnapshot = {
   events: ExecutionEvent[];
 };
 
-export type ExecutionStatus =
-  | 'pending'
-  | 'running'
-  | 'completed'
-  | 'incomplete'
-  | 'failed'
-  | 'cancelling'
-  | 'cancelled';
+export type ExecutionStatus = 'pending' | 'running' | 'cancelling' | TerminalExecutionStatus;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
       '@workflow-builder/execution-core':
         specifier: workspace:*
         version: link:../../packages/execution-core
+      '@workflow-builder/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       ai:
         specifier: ^6.0.0
         version: 6.0.168(zod@4.3.6)


### PR DESCRIPTION
## What

A graph could route itself into nothing and report success. When a decision returns a
`nextPort` no edge carries — deleted edge, renamed branch, never wired — every outgoing
edge is pruned and the run closed as `completed` with part of the graph never run.

`runGraph` now records each dead end as `{ nodeId, port }` and, if any were found, emits a
terminal `execution_incomplete` event in place of `execution_completed` and writes the
`'incomplete'` status. Not a failure — nothing threw, so Temporal still closes the Workflow
Execution as Completed. Failure keeps precedence, and the cycle check stays a failure with
its own "stalled" wording.

Dead ends don't stop the run: they're collected run-scoped and reported once at the end, so
parallel branches still deliver their work.

## ⚠️ Behaviour change

An `'errorRoute'` failure with no `'errorRoute'` edge now ends the run incomplete — it was
previously documented as a usable silent DLQ. The general rule covers it (the policy names a
port, nothing was wired to it), and excluding it would mean carving out
`RESERVED_ERROR_HANDLE`. Deliberate absorption is what `'continue'` is for; the README now
says so. The test asserting the old behaviour was rewritten, not deleted.

## Worth a look in review

Six separate places enumerate terminal states — worker `database.ts`, backend
`drain-events.ts` and `routes/executions.ts`, ai-studio stream adapter, store, and controls.
All six change here; missing one hangs an SSE stream, leaves `finished_at` null, or strands
the UI mid-run. `run-workflow.ts` is a comment-only change: its guard is `=== 'failed'`, so
the new state correctly falls through.

Naming (`incomplete` over `stalled`), why the cycle check stays separate, and the
`errorRoute` reversal are written up in
`packages/execution-core/terminal-states.decision-log.md`.

<img width="2560" height="1191" alt="Zrzut ekranu 2026-08-24 o 15 21 04" src="https://github.com/user-attachments/assets/572abf56-8cf5-4696-9786-1f23cdf15038" />