### PR TITLE
[CI] Gate workflow execution pipeline tests

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,8 +1,11 @@
 name: PR Check
 
 # Runs on every PR to give reviewers fast feedback on whether the change
-# is safe to merge. Focus on the published packages @workflowbuilder/sdk and
-# @workflowbuilder/ui (plus its private @workflowbuilder/ui-tokens build) +
+# is safe to merge. Two things are gated here: the published packages
+# @workflowbuilder/sdk and @workflowbuilder/ui (plus its private
+# @workflowbuilder/ui-tokens build), and the execution pipeline
+# (execution-core, backend, execution-worker) — whose determinism tests guard
+# Temporal replay safety and so must not be able to regress silently. Plus
 # global format consistency. apps/docs has its own path-filtered workflow
 # (pr-check-docs.yml); demo and ai-studio are not checked here — they're
 # internal and have their own broken-state tolerances.
@@ -145,3 +148,39 @@ jobs:
         # build:ui builds @workflowbuilder/ui-tokens first, then ui, then runs
         # the check:built-css guard.
         run: pnpm build:ui
+
+  execution:
+    name: Execution pipeline lint + typecheck + test
+    runs-on: ubuntu-latest
+    # No `services:` block: all three suites are pure unit tests against
+    # in-memory fakes — no Postgres, no Temporal, no API keys. If a suite here
+    # ever needs real infra, give it its own job rather than adding services
+    # to this one.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable Corepack
+        run: npm i -g corepack@latest
+
+      - name: Install pnpm
+        run: corepack prepare
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm --filter @workflow-builder/execution-core --filter @workflow-builder/backend --filter @workflow-builder/execution-worker lint
+
+      - name: Typecheck
+        run: pnpm --filter @workflow-builder/execution-core --filter @workflow-builder/backend --filter @workflow-builder/execution-worker typecheck
+
+      - name: Test
+        run: pnpm --filter @workflow-builder/execution-core --filter @workflow-builder/backend --filter @workflow-builder/execution-worker test

--- a/apps/execution-worker/package.json
+++ b/apps/execution-worker/package.json
@@ -10,8 +10,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest --passWithNoTests"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@openrouter/ai-sdk-provider": "^2.5.0",


### PR DESCRIPTION
`pr-check` ran only `sdk` / `ui` / `tokens` / `format`. execution-core,
backend and execution-worker had no CI gate at all — 176 tests could
regress silently, including the replay-determinism tests that back
`replay-audit.md`.

## Changes

- **`.github/workflows/pr-check.yml`** — new `execution` job running lint +
  typecheck + test across execution-core, backend and execution-worker. All
  three are pure unit tests against in-memory fakes, so no `services:` block
  and no secrets. Runs in parallel with the existing jobs, so PR wall-clock
  is unchanged.
- **`apps/execution-worker/package.json`** — dropped `--passWithNoTests`.
  It dates from when the suite was empty; there are 14 tests now, and the
  flag would hide the suite disappearing.
- Header comment updated — its "focus on the published packages" framing is
  what let the execution pipeline fall through the gap.

## Verification

Each CI command run verbatim with `DATABASE_URL`, `TEMPORAL_ADDRESS`,
`OPENROUTER_API_KEY`, `TAVILY_API_KEY` and `AI_MODEL` unset — lint,
typecheck and test all exit 0, scope `3 of 13 workspace projects`.
Gate confirmed to block: a deliberately broken assertion in
`graph-runner.replay-determinism.test.ts` fails the job.

Tests now gated: execution-core 81 (7 replay-determinism), backend 81,
worker 14.

## Out of scope

- WB-528 floats an optional pinned-vs-latest `@temporalio/*` smoke job. It
  would have no signal today — neither worker test imports Temporal. It
  becomes meaningful after WB-527 lands the `@temporalio/testing` harness.
- pnpm-store caching + a shared composite action: the corepack setup block
  is duplicated 9× across 6 workflows, but store caching doesn't skip the
  ~57s of `prepare` builds and needs a size measurement to justify itself.
  Separate PR.