### PR TITLE
[DS 2.0] Shrink the built-CSS checker and document the pitfalls

### DIFF
--- a/.changeset/built-css-invariants.md
+++ b/.changeset/built-css-invariants.md
@@ -1,0 +1,5 @@
+---
+'@workflowbuilder/ui': patch
+---
+
+Harden published CSS validation with deterministic layer, namespace, public-default, import, and asset checks, and validate the package surface with publint.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,16 +68,16 @@ Where to put a new script: root `tools/` for pure-Node bootstrap (runs before an
 
 Each workspace has its own context. Read the relevant file before extending a workspace.
 
-| Workspace                 | Authoritative docs                                      |
-| ------------------------- | ------------------------------------------------------- |
-| `packages/sdk`            | `packages/sdk/README.md`                                |
-| `packages/ui`             | `packages/ui/README.md` (+ `packages/ui/css-layers.md`) |
-| `packages/tokens`         | `packages/tokens/README.md`                             |
-| `packages/execution-core` | `packages/execution-core/README.md`                     |
-| `apps/demo`               | `apps/demo/CLAUDE.md`                                   |
-| `apps/ai-studio`          | `apps/ai-studio/README.md`                              |
-| `apps/backend`            | `apps/backend/README.md`                                |
-| `apps/execution-worker`   | `apps/execution-worker/README.md`                       |
+| Workspace                 | Authoritative docs                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| `packages/sdk`            | `packages/sdk/README.md`                                                                     |
+| `packages/ui`             | `packages/ui/README.md` (+ `packages/ui/css-layers.md`, `packages/ui/built-css-pitfalls.md`) |
+| `packages/tokens`         | `packages/tokens/README.md`                                                                  |
+| `packages/execution-core` | `packages/execution-core/README.md`                                                          |
+| `apps/demo`               | `apps/demo/CLAUDE.md`                                                                        |
+| `apps/ai-studio`          | `apps/ai-studio/README.md`                                                                   |
+| `apps/backend`            | `apps/backend/README.md`                                                                     |
+| `apps/execution-worker`   | `apps/execution-worker/README.md`                                                            |
 
 ## Types & Aliases
 

--- a/packages/ui/built-css-pitfalls.md
+++ b/packages/ui/built-css-pitfalls.md
@@ -1,0 +1,160 @@
+# Built CSS pitfalls
+
+This catalogue records CSS failure classes that have affected Workflow Builder builds. The labels under **Automated?** match `scripts/check-built-css.ts`, package scripts, or focused tests. Adding, removing, or weakening a check requires updating its section here in the same change.
+
+The checker runs over this package's `dist` and over any extra dist directory passed as an
+argument. Two checks apply only to this package's own output, because this package owns those
+contracts: layer coverage (with the order statement and the known-name check) and the
+`:root`-in-`ui.base` placement of public defaults. A consumer bundle ships its own unlayered
+component CSS and may set a public variable on its own subtree as a scoped override, which is a
+legitimate pattern rather than a mis-scoped default. Every other check applies everywhere.
+
+## Malformed `var()` argument
+
+**What breaks** - A declaration such as `color: var(token)` is invalid, so the intended color, size, or other value disappears.
+
+**Why it is silent** - Browsers discard the declaration during value resolution without logging an application error.
+
+**How to spot it** - Search built declarations for `var(` whose first non-space characters are not `--`, then inspect the declaration in browser developer tools. At source level, also respect `wb/no-system-token-fallbacks`: the public font-family variables require fallbacks, while every other system variable forbids them because a fallback can hide a typo.
+
+**Automated?** - Yes. `Malformed var() argument` walks declaration values in every checked dist stylesheet.
+
+## Unlayered built CSS
+
+**What breaks** - A package rule unexpectedly beats layered UI rules regardless of specificity, so consumer overrides or component states stop winning.
+
+**Why it is silent** - The stylesheet is valid; cascade origin and layer precedence produce the wrong winner without a parse error.
+
+**How to spot it** - Parse dist CSS and inspect root-level rules and at-rules. Only `@layer` blocks and statement-form `@layer` declarations should be direct root children. A statement-form declaration is harmless here because the leading-order check guarantees the canonical order comes first; a stylesheet whose rules only `composes` global roles produces one, since the composed bodies end up empty. See `css-layers.md` for the package contract.
+
+**Automated?** - Yes, for this package's dist only. `Unlayered built CSS` checks direct PostCSS children.
+
+## Missing leading layer order
+
+**What breaks** - If a component stylesheet names a layer before the canonical order statement, whichever file loads first can establish the wrong order and let `ui.base` beat `ui.component`.
+
+**Why it is silent** - Later order statements remain valid but cannot change the order fixed by the first layer name the browser encountered.
+
+**How to spot it** - Open each dist stylesheet and compare its first node with `src/styles/layers.css`.
+
+**Automated?** - Yes. `Missing leading layer order` performs that comparison for every checked file.
+
+## Unknown layer name
+
+**What breaks** - A typo such as `ui.components` creates a new layer after the declared order, so it silently wins over the intended layers.
+
+**Why it is silent** - CSS permits new layer names at any time and appends them to the existing order.
+
+**How to spot it** - Search dist for `@layer` and compare every comma-separated name with the names in `src/styles/layers.css`.
+
+**Automated?** - Yes. `Unknown layer name` checks every `@layer` at-rule.
+
+## Unsanctioned variable namespace
+
+**What breaks** - A misspelled or legacy shared variable no longer connects a definition to its consumers, leaving a component unstyled or stuck on an old value.
+
+**Why it is silent** - Custom property names are author-defined identifiers, so browsers cannot distinguish a typo from a new local variable.
+
+**How to spot it** - Search declarations for the legacy `--ax-` prefix and for `--wb-` properties outside `--wb-ds-`, `--wb-sdk-`, or `--wb-public-`. Unprefixed component-local and third-party properties remain valid. Source Stylelint separately verifies that variable uses resolve and applies the fallback contract from `wb/no-system-token-fallbacks`.
+
+**Automated?** - Yes. `Unsanctioned variable namespace` checks declaration property names without a catalogue of individual variables.
+
+## Built CSS import
+
+**What breaks** - A relative `@import` stops resolving when a consumer copies a stylesheet without preserving the package directory layout. Constructed stylesheets ignore `@import` entirely.
+
+**Why it is silent** - The main stylesheet still parses, and the missing imported rules fail separately or are ignored by the browser.
+
+**How to spot it** - Search every dist stylesheet for `@import`; built output must be self-contained.
+
+**Automated?** - Yes. `Built CSS import` walks `@import` at-rules.
+
+## Missing built URL target
+
+**What breaks** - Fonts, images, or other relative assets return not found after publication, leaving fallback fonts or missing visuals.
+
+**Why it is silent** - The CSS declaration remains valid and the asset request fails independently of the package build.
+
+**How to spot it** - Search declaration values for `url()`, resolve each relative path from its emitted stylesheet, and verify the target is a file inside that dist directory. Data URLs and absolute URLs are outside this check.
+
+**Automated?** - Yes. `Missing built URL target` verifies every relative, non-data declaration URL.
+
+## Mis-scoped public variable default
+
+**What breaks** - A public default on a component selector can outrank a consumer's `:root` override, so the documented customization appears not to work.
+
+**Why it is silent** - Both declarations and values are valid; selector and layer precedence choose the package default.
+
+**How to spot it** - Inspect every `--wb-public-*` declaration in dist. Every selector in the rule must target the root element itself, written as either `:root` or `html` and optionally qualified by an attribute, class, or ID, and the rule must sit inside `@layer ui.base`. Component rules should consume public variables rather than redefine them. Both root spellings are accepted because they match the same element; the repo writes theme scopes as `html[data-theme='...']`.
+
+**Automated?** - Yes, for this package's dist only. `Mis-scoped public variable default` validates the selector and nearest layer for every public-property declaration. A consumer bundle setting a public variable on a component subtree is not flagged, so that case still needs a human: ask whether the variable is meant to stay consumer-controllable at that level. The SDK's node templates set `--wb-public-node-gap: 0` this way. Per the maintainer, those templates are starting examples rather than a supported surface, so the scoped override is intended there; the same shape elsewhere would be worth questioning.
+
+## Broken package export target
+
+**What breaks** - A documented package import resolves to a missing file, so the consumer's bundler fails before rendering.
+
+**Why it is silent** - Vite can build files that are not correctly exposed by the final `package.json` export map.
+
+**How to spot it** - Compare package exports with dist and inspect conditional exports, file types, and package entry points rather than checking only CSS strings.
+
+**Automated?** - Yes. The `publint` package script validates export targets and the broader published package surface.
+
+## Missing entry-chunk font faces
+
+**What breaks** - Importing the root JavaScript barrel omits bundled font declarations, so text renders in fallback fonts unless a consumer separately imports `fonts.css`.
+
+**Why it is silent** - JavaScript and component CSS still load; only the bundle chunking path loses the generated `@font-face` rules.
+
+**How to spot it** - Compare every `@font-face` block in `dist/fonts.css` with the root entry chunk stylesheet, including the entry chunk's rewritten asset-relative URLs.
+
+**Automated?** - Yes. `combine-css-bundle.spec.mts` tests that the bundle finalizer copies every generated face into the entry chunk.
+
+## Font subsetting and flash of unstyled text
+
+**What breaks** - Some text starts in a fallback font and switches after a font asset arrives, causing a flash of unstyled text (FOUT), layout movement, or mixed-looking labels.
+
+**Why it is silent** - `font-display: swap` deliberately renders fallback text while a matching face downloads. Inlined Poppins latin faces at weights 400 and 600 cover `U+0000-00FF` plus listed typographic characters, so Latin-1 accents are inline. Polish diacritics such as `Ą` (`U+0104`) live in `latin-ext` and are fetched. Other Poppins weights and Inter are fetched even for ASCII text. "Non-ASCII" is therefore not the subset boundary.
+
+**How to spot it** - Inspect `dist/fonts.css` for each face's weight, `unicode-range`, and data versus relative URL. Test representative Latin-1 and Polish text with the network cache disabled, then review font requests and layout shifts.
+
+**Automated?** - No. The build can verify emitted subsets and files, but it cannot decide which characters and weights a product will render or whether its FOUT is acceptable.
+
+## Content Security Policy font blocking
+
+**What breaks** - Fonts are blocked, so all text remains in fallback families even though the assets exist and their URLs resolve.
+
+**Why it is silent** - The package build has no access to the consumer's Content Security Policy (CSP); browsers report the violation only at runtime.
+
+**How to spot it** - Check browser console CSP violations and network requests. `font-src` must allow `data:` for inline faces and `'self'` or the serving origin for fetched files. If `font-src` is absent, the browser falls back to `default-src`, which must allow the same sources.
+
+**Automated?** - No. The effective policy belongs to the consuming deployment, not the package dist.
+
+## Documented public variable absent from dist
+
+**What breaks** - A consumer sets a documented `--wb-public-*` variable but nothing changes because the package never ships a definition or use for it.
+
+**Why it is silent** - Unknown custom properties are valid, and the built-CSS script intentionally has no hardcoded snapshot of public variable names.
+
+**How to spot it** - Compare public-variable documentation with declarations and `var()` uses in dist. Review removals and renames as public API changes.
+
+**Automated?** - No. The current documentation is prose rather than a machine-readable source of truth. If this becomes automated, derive names from the documented variable table instead of adding literals to the built-CSS script.
+
+## Primitive token used where a role belongs
+
+**What breaks** - A color stops adapting between themes, producing a low-contrast state even though the token resolves. In one template-tile hover, `--wb-ds-colors-acc1-500` had the same value in both themes and rendered at 2.51:1 against the dark surface. The fix used the `canvas/node/stroke-hover` role, emitted as `--wb-ds-canvas-node-stroke-hover`, which resolves to `acc1-500` in light and `acc1-400` in dark.
+
+**Why it is silent** - Primitive and role tokens are both valid CSS variables in sanctioned namespaces; only design intent distinguishes them.
+
+**How to spot it** - Review state colors in every theme, inspect the token source in `packages/tokens/tokens.json`, and question direct color primitives where a semantic role exists. Verify contrast on the actual surface.
+
+**Automated?** - No. Built CSS cannot infer whether a primitive is intentional or which semantic role matches a design use.
+
+## Typography metrics copied instead of composed
+
+**What breaks** - Text initially matches a typography role but drifts when the role's family, size, weight, line height, or letter spacing changes.
+
+**Why it is silent** - Copied declarations are valid and can render identically at review time while losing the shared role contract.
+
+**How to spot it** - In CSS modules, prefer `composes: wb-text-... from global` and inspect nearby copied typography metrics. Review exceptions where a component intentionally diverges from every defined role.
+
+**Automated?** - No. `typography-composes.spec.mts` verifies that composed role names exist, but it cannot decide whether an arbitrary group of copied metrics was intended to represent a role.

--- a/packages/ui/built-css-pitfalls.md
+++ b/packages/ui/built-css-pitfalls.md
@@ -57,7 +57,7 @@ legitimate pattern rather than a mis-scoped default. Every other check applies e
 
 **How to spot it** - Search declarations for the legacy `--ax-` prefix and for `--wb-` properties outside `--wb-ds-`, `--wb-sdk-`, or `--wb-public-`. Unprefixed component-local and third-party properties remain valid. Source Stylelint separately verifies that variable uses resolve and applies the fallback contract from `wb/no-system-token-fallbacks`.
 
-**Automated?** - Yes. `Unsanctioned variable namespace` checks declaration property names without a catalogue of individual variables.
+**Automated?** - Yes. `Unsanctioned variable namespace` checks declaration property names without a catalogue of individual variables. It does not inspect custom property names inside `var()` values. This narrowing is safe today because Stylelint's `csstools/value-no-unknown-custom-properties` rule rejects unknown names in source files, and the build does not generate new `var()` references. If a build transform starts rewriting `var()` values, the narrowing is no longer safe and the value check must be restored.
 
 ## Built CSS import
 

--- a/packages/ui/combine-css-bundle.mts
+++ b/packages/ui/combine-css-bundle.mts
@@ -15,9 +15,6 @@ import type { Plugin } from 'vite';
  * first" is true in src/ but false in dist/ (the inverted-cascade bug class).
  */
 export function combineCssBundle(rootDirectory: string): Plugin {
-  const distributionDirectory = path.resolve(rootDirectory, 'dist');
-  const documentationPreviewDirectory = path.resolve(rootDirectory, 'tmp');
-  const stylesDirectory = path.resolve(rootDirectory, 'src/styles');
   let buildFailed = false;
 
   return {
@@ -31,17 +28,23 @@ export function combineCssBundle(rootDirectory: string): Plugin {
     },
     closeBundle() {
       if (buildFailed) return;
-
-      assetsDirectoryOf(distributionDirectory);
-      const fontStyles = emitFontAssets(distributionDirectory);
-      const layerOrder = readLayerOrder(stylesDirectory);
-      fs.writeFileSync(path.resolve(distributionDirectory, 'fonts.css'), `${layerOrder}\n${fontStyles}\n`);
-      writeCombinedStylesheet(distributionDirectory, documentationPreviewDirectory, stylesDirectory, fontStyles);
-      writeGlobalStylesheet(distributionDirectory, stylesDirectory, fontStyles);
-      appendFontStylesToEntryChunk(distributionDirectory, fontStyles);
-      prependLayerOrderToAssets(distributionDirectory, stylesDirectory);
+      finalizeCssBundle(rootDirectory);
     },
   };
+}
+
+export function finalizeCssBundle(rootDirectory: string) {
+  const distributionDirectory = path.resolve(rootDirectory, 'dist');
+  const documentationPreviewDirectory = path.resolve(rootDirectory, 'tmp');
+  const stylesDirectory = path.resolve(rootDirectory, 'src/styles');
+  assetsDirectoryOf(distributionDirectory);
+  const fontStyles = emitFontAssets(distributionDirectory);
+  const layerOrder = readLayerOrder(stylesDirectory);
+  fs.writeFileSync(path.resolve(distributionDirectory, 'fonts.css'), `${layerOrder}\n${fontStyles}\n`);
+  writeCombinedStylesheet(distributionDirectory, documentationPreviewDirectory, stylesDirectory, fontStyles);
+  writeGlobalStylesheet(distributionDirectory, stylesDirectory, fontStyles);
+  appendFontStylesToEntryChunk(distributionDirectory, fontStyles);
+  prependLayerOrderToAssets(distributionDirectory, stylesDirectory);
 }
 
 type FontFaceDefinition = {

--- a/packages/ui/combine-css-bundle.spec.mts
+++ b/packages/ui/combine-css-bundle.spec.mts
@@ -1,0 +1,45 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import postcss from 'postcss';
+
+import { finalizeCssBundle } from './combine-css-bundle.mts';
+
+function fontFaces(css: string): string[] {
+  const faces: string[] = [];
+  postcss.parse(css).walkAtRules('font-face', (atRule) => {
+    faces.push(atRule.toString());
+  });
+  return faces;
+}
+
+describe('combine CSS bundle', () => {
+  it('copies every generated font face into the entry chunk', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'wb-ui-css-'));
+
+    try {
+      mkdirSync(path.join(root, 'dist/assets'), { recursive: true });
+      mkdirSync(path.join(root, 'src/styles'), { recursive: true });
+      writeFileSync(
+        path.join(root, 'dist/assets/index.css'),
+        '@layer ui.component; @layer ui.component { .entry { color: black } }',
+      );
+      writeFileSync(path.join(root, 'src/styles/layers.css'), '@layer ui.base, ui.component;');
+      writeFileSync(path.join(root, 'src/styles/globals.css'), '@layer ui.base { :root { --x: 1 } }');
+      writeFileSync(path.join(root, 'src/styles/typography.css'), '@layer ui.base {}');
+
+      finalizeCssBundle(root);
+
+      const sidecar = readFileSync(path.join(root, 'dist/fonts.css'), 'utf8');
+      const entryChunk = readFileSync(path.join(root, 'dist/assets/index.css'), 'utf8');
+      const expectedFaces = fontFaces(sidecar).map((face) => face.replaceAll('url(./assets/', 'url(./'));
+      expect(expectedFaces.length).toBeGreaterThan(0);
+      expect(fontFaces(entryChunk)).toEqual(expectedFaces);
+      expect(entryChunk).not.toContain('url(./assets/');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,10 +26,11 @@
     "url": "https://github.com/synergycodes/workflowbuilder/issues"
   },
   "scripts": {
-    "build": "vite build && pnpm check:built-css",
+    "build": "vite build && pnpm check:built-css && pnpm publint",
     "dev": "vite build --watch",
     "prepare": "pnpm build",
     "check:built-css": "tsx ./scripts/check-built-css.ts",
+    "publint": "publint",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "typecheck": "tsc --noEmit --pretty && tsc --noEmit --pretty -p tsconfig.node.json",
@@ -76,6 +77,7 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.2.0",
     "postcss": "^8.5.3",
+    "publint": "^0.3.24",
     "react": "catalog:",
     "react-day-picker": "^9.14.0",
     "react-dom": "catalog:",

--- a/packages/ui/scripts/check-built-css.ts
+++ b/packages/ui/scripts/check-built-css.ts
@@ -1,523 +1,120 @@
-/**
- * Guards against known bug classes in built CSS output.
- *
- * Runs after `vite build` so a regression fails the release even if it slips
- * past review or a build-tool transform introduces it.
- *
- * 1. `var()`'s first argument must be a `<custom-property-name>` (a dashed-ident) -
- *    never another function, an undashed name, or nothing. Browsers silently
- *    invalidate the declaration and fall back.
- * 2. Every rule must live inside an `@layer` block - including `:root` variable
- *    defaults (layered defaults lose to any unlayered consumer override, which
- *    is the override contract). Unlayered CSS beats layered CSS regardless of
- *    specificity, so a rule that escapes `ui.base` / `ui.component` silently
- *    wins the cascade (see `css-layers.md`).
- * 3. Every stylesheet must LEAD with the full `@layer` order statement. The first
- *    use of a layer name fixes the order, so a component stylesheet that loads
- *    before the statement inverts the cascade (ui.base beats ui.component) -
- *    `combine-css-bundle.mts` stamps the statement into every file; this check
- *    keeps the stamp honest.
- * 4. Only the layer names declared in `src/styles/layers.css` may appear. An
- *    unknown name (a typo) lands AFTER the declared order and silently wins
- *    the cascade.
- * 5. Every `*.css` entry in package.json `exports` must exist in dist, no dist
- *    stylesheet may use `@import`, and every non-data `url()` must resolve to a
- *    file in dist. Absolute URLs are rejected on purpose: published styles are
- *    required to remain self-contained and usable without a CDN.
- * 6. The root JS barrel's entry-chunk stylesheet must carry every generated
- *    `@font-face` rule so importing the barrel cannot silently lose the fonts.
- * 7. The SDK's three public-variable defaults must be present inside an
- *    `@layer` so unlayered consumer overrides always win.
- * 8. Workflow Builder variables may use only `--wb-ds-*`, `--wb-sdk-*`, or
- *    `--wb-public-*`, and the legacy shared prefix is forbidden. Unprefixed
- *    component-local and third-party properties such as `--button-*` and
- *    `--anchor-width` remain allowed because they do not claim a shared namespace.
- *
- * These are the only lines of defense for these bug classes today; source-level lint
- * rules would catch some of them earlier but none is configured yet.
- *
- * Exits non-zero on any match.
- */
-import { existsSync, globSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, globSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-import postcss, { AtRule, type ChildNode, type Node } from 'postcss';
+import postcss, { AtRule, type ChildNode, type Declaration, type Node } from 'postcss';
 
-const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
-const packageDirectory = path.resolve(currentDirectory, '..');
-const distributionDirectory = path.resolve(packageDirectory, 'dist');
+const packageDirectory = path.resolve(import.meta.dirname, '..');
+const repositoryDirectory = path.resolve(packageDirectory, '../..');
+const pitfalls = 'packages/ui/built-css-pitfalls.md';
+const order = postcss
+  .parse(readFileSync(path.join(packageDirectory, 'src/styles/layers.css'), 'utf8'))
+  .nodes.find((node): node is AtRule => node.type === 'atrule' && node.name === 'layer' && !node.nodes);
 
-type Hit = { line: number; column: number; snippet: string };
-type FailureReport = { file: string; hits: Hit[] };
+if (!order) throw new Error('src/styles/layers.css must contain a layer-order statement');
 
-const layerOrderStatement = postcss
-  .parse(readFileSync(path.resolve(packageDirectory, 'src/styles/layers.css'), 'utf8'))
-  .nodes.find((node): node is AtRule => node.type === 'atrule' && node.name === 'layer' && node.nodes === undefined);
-if (!layerOrderStatement) {
-  throw new Error('src/styles/layers.css must contain a bare `@layer a, b;` order statement');
-}
-const KNOWN_LAYERS = layerOrderStatement.params.split(',').map((name) => name.trim());
-const KNOWN_LAYER_SET = new Set(KNOWN_LAYERS);
-
-function locate(content: string, index: number): { line: number; column: number } {
-  const upTo = content.slice(0, index);
-  const line = upTo.split('\n').length;
-  const column = index - upTo.lastIndexOf('\n');
-  return { line, column };
-}
-
-function snippetAt(content: string, index: number): string {
-  return content.slice(Math.max(0, index - 12), index + 48).replaceAll(/\s+/g, ' ');
-}
-
-function hitFor(node: ChildNode | undefined): Hit {
-  if (!node) return { line: 0, column: 0, snippet: '(no CSS rules found)' };
-
-  const start = node.source?.start;
-  return {
-    line: start?.line ?? 0,
-    column: start?.column ?? 0,
-    snippet: node.toString().slice(0, 60).replaceAll(/\s+/g, ' '),
-  };
-}
-
-// --- Check 1: var() first argument is a dashed ident --------------------------
-
-const malformedVariablePattern = /var\(\s*(?!--)/g;
-
-function checkVariableFirstArgument(files: string[]): FailureReport[] {
-  const failures: FailureReport[] = [];
-
-  for (const file of files) {
-    const content = readFileSync(path.resolve(distributionDirectory, file), 'utf8');
-    const hits: Hit[] = [];
-
-    for (const match of content.matchAll(malformedVariablePattern)) {
-      const { line, column } = locate(content, match.index);
-      hits.push({ line, column, snippet: snippetAt(content, match.index) });
-    }
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  return failures;
-}
-
-const SANCTIONED_WORKFLOW_BUILDER_PREFIXES = ['--wb-ds-', '--wb-sdk-', '--wb-public-'];
-const LEGACY_VARIABLE_PREFIX = `--${'ax'}-`;
-
-function checkVariableNamespaces(files: string[], targetDistributionDirectory: string): FailureReport[] {
-  const failures: FailureReport[] = [];
-
-  for (const file of files) {
-    const content = readFileSync(path.resolve(targetDistributionDirectory, file), 'utf8');
-    const hits: Hit[] = [];
-
-    postcss.parse(content).walkDecls((declaration) => {
-      const names = `${declaration.prop}: ${declaration.value}`.match(/--[\w-]+/g) ?? [];
-      const hasInvalidName = names.some(
-        (name) =>
-          name.startsWith(LEGACY_VARIABLE_PREFIX) ||
-          (name.startsWith('--wb-') && !SANCTIONED_WORKFLOW_BUILDER_PREFIXES.some((prefix) => name.startsWith(prefix))),
-      );
-      if (hasInvalidName) hits.push(hitFor(declaration));
-    });
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  return failures;
-}
-
-// --- Check 2: no rule outside @layer ----------------------------------------
-
-function findTopLevelViolations(content: string): Hit[] {
-  const hits: Hit[] = [];
-
-  for (const node of postcss.parse(content).nodes) {
-    switch (node.type) {
-      case 'atrule': {
-        const isStatement = node.nodes === undefined;
-        if (node.name === 'layer' || isStatement) break;
-        hits.push(hitFor(node));
-        break;
-      }
-      case 'rule': {
-        hits.push(hitFor(node));
-        break;
-      }
-      default: {
-        break;
-      }
-    }
-  }
-
-  return hits;
-}
-
-function checkLayerCoverage(files: string[]): FailureReport[] {
-  const failures: FailureReport[] = [];
-
-  for (const file of files) {
-    const content = readFileSync(path.resolve(distributionDirectory, file), 'utf8');
-    const hits = findTopLevelViolations(content);
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  return failures;
-}
-
-const SDK_LAYERED_PUBLIC_DEFAULTS = new Set([
-  '--wb-public-form-label-color',
-  '--wb-public-form-label-asterisk-color',
-  '--wb-public-form-rich-text-color',
-]);
-
-function checkSdkPublicDefaultLayerCoverage(files: string[], targetDistributionDirectory: string): FailureReport[] {
-  const failures: FailureReport[] = [];
-  const found = new Set<string>();
-
-  for (const file of files) {
-    const hits: Hit[] = [];
-    const content = readFileSync(path.resolve(targetDistributionDirectory, file), 'utf8');
-
-    postcss.parse(content).walkDecls((declaration) => {
-      if (!SDK_LAYERED_PUBLIC_DEFAULTS.has(declaration.prop)) return;
-      found.add(declaration.prop);
-
-      let ancestor: Node | undefined = declaration.parent;
-      while (ancestor && !(ancestor instanceof AtRule && ancestor.name === 'layer')) {
-        ancestor = ancestor.parent;
-      }
-      if (!ancestor) hits.push(hitFor(declaration));
-    });
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  const missing = [...SDK_LAYERED_PUBLIC_DEFAULTS].filter((name) => !found.has(name));
-  if (missing.length > 0) {
-    failures.push({
-      file: '(dist)',
-      hits: missing.map((name) => ({ line: 0, column: 0, snippet: `${name} is missing` })),
-    });
-  }
-
-  return failures;
-}
-
-// --- Check 3: the layer-order statement leads every file ----------------------
+const layerNames = order.params.split(',').map((name) => name.trim());
+const knownLayers = new Set(layerNames);
+const problems: string[] = [];
+const urlPattern = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
+const sanctionedPrefixes = ['--wb-ds-', '--wb-sdk-', '--wb-public-'];
 
 function isOrderStatement(node: ChildNode | undefined): boolean {
   return (
     node?.type === 'atrule' &&
     node.name === 'layer' &&
-    node.nodes === undefined &&
+    !node.nodes &&
     node.params
       .split(',')
       .map((name) => name.trim())
-      .join(',') === KNOWN_LAYERS.join(',')
+      .join(',') === layerNames.join(',')
   );
 }
 
-function checkOrderStatementFirst(files: string[]): FailureReport[] {
-  const failures: FailureReport[] = [];
-
-  for (const file of files) {
-    const content = readFileSync(path.resolve(distributionDirectory, file), 'utf8');
-    const first = postcss.parse(content).nodes.find((node) => node.type !== 'comment');
-
-    if (!isOrderStatement(first)) failures.push({ file, hits: [hitFor(first)] });
-  }
-
-  return failures;
+function add(file: string, node: Node | undefined, message: string): void {
+  problems.push(`${file}:${node?.source?.start?.line ?? 1} ${message}. See ${pitfalls}.`);
 }
 
-// --- Check 4: only known layer names ------------------------------------------
-
-function checkKnownLayerNames(files: string[]): FailureReport[] {
-  const failures: FailureReport[] = [];
-
-  for (const file of files) {
-    const content = readFileSync(path.resolve(distributionDirectory, file), 'utf8');
-    const hits: Hit[] = [];
-
-    postcss.parse(content).walkAtRules('layer', (atRule) => {
-      const names = atRule.params.split(',').map((name) => name.trim());
-      if (names.some((name) => !KNOWN_LAYER_SET.has(name))) hits.push(hitFor(atRule));
-    });
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  return failures;
-}
-
-// --- Check 5: exported entrypoints exist, dist CSS is import-free --------------
-
-// Walks an exports-map value, collecting every string target ending in .css -
-// covers plain strings and conditional-export objects ({ import, require,
-// default, ... }) at any nesting depth.
-function collectCssTargets(value: unknown, into: string[]): void {
-  if (typeof value === 'string') {
-    if (value.endsWith('.css')) into.push(value);
-    return;
-  }
-  if (value && typeof value === 'object') {
-    for (const nested of Object.values(value)) collectCssTargets(nested, into);
-  }
-}
-
-function checkPublishedSurface(files: string[]): FailureReport[] {
-  const failures: FailureReport[] = [];
-
-  const packageJson = JSON.parse(readFileSync(path.resolve(packageDirectory, 'package.json'), 'utf8')) as {
-    exports?: Record<string, unknown>;
-  };
-  for (const [specifier, target] of Object.entries(packageJson.exports ?? {})) {
-    const cssTargets: string[] = [];
-    collectCssTargets(target, cssTargets);
-
-    for (const cssTarget of cssTargets) {
-      if (!existsSync(path.resolve(packageDirectory, cssTarget))) {
-        failures.push({
-          file: cssTarget,
-          hits: [{ line: 0, column: 0, snippet: `missing file for exports["${specifier}"]` }],
-        });
-      }
-    }
-  }
-
-  if (files.length === 0) {
-    failures.push({
-      file: '(dist)',
-      hits: [{ line: 0, column: 0, snippet: 'no CSS emitted at all' }],
-    });
-  }
-
-  for (const file of files) {
-    const hits: Hit[] = [];
-
-    postcss.parse(readFileSync(path.resolve(distributionDirectory, file), 'utf8')).walkAtRules('import', (atRule) => {
-      hits.push(hitFor(atRule));
-    });
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  return failures;
-}
-
-function isExactFileWithin(rootDirectory: string, targetPath: string): boolean {
-  const relativeTarget = path.relative(rootDirectory, targetPath);
+function isPublicDefault(declaration: Declaration): boolean {
+  const rule = declaration.parent;
   if (
-    relativeTarget === '' ||
-    relativeTarget === '..' ||
-    relativeTarget.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativeTarget)
-  ) {
+    rule?.type !== 'rule' ||
+    !rule.selectors.every((selector) => /^(?::root|html)(?:\[[^\]]+\]|[.#][\w-]+)*$/.test(selector.trim()))
+  )
     return false;
-  }
 
-  const segments = relativeTarget.split(path.sep);
-  let currentDirectory = rootDirectory;
-
-  for (const [index, segment] of segments.entries()) {
-    try {
-      const entry = readdirSync(currentDirectory, { withFileTypes: true }).find(({ name }) => name === segment);
-      if (!entry) return false;
-      if (index === segments.length - 1) return entry.isFile();
-      if (!entry.isDirectory()) return false;
-      currentDirectory = path.resolve(currentDirectory, segment);
-    } catch {
-      return false;
-    }
-  }
-
-  return false;
+  let ancestor: Node | undefined = rule.parent;
+  while (ancestor && !(ancestor instanceof AtRule && ancestor.name === 'layer')) ancestor = ancestor.parent;
+  return ancestor instanceof AtRule && ancestor.params.trim() === 'ui.base';
 }
 
-function checkUrlTargets(files: string[], targetDistributionDirectory: string): FailureReport[] {
-  const failures: FailureReport[] = [];
-  const urlPattern = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
-
-  if (files.length === 0) {
-    return [{ file: '(dist)', hits: [{ line: 0, column: 0, snippet: 'no CSS emitted at all' }] }];
-  }
-
-  for (const file of files) {
-    const content = readFileSync(path.resolve(targetDistributionDirectory, file), 'utf8');
-    const hits: Hit[] = [];
-
-    postcss.parse(content).walkDecls((declaration) => {
-      for (const match of declaration.value.matchAll(urlPattern)) {
-        const reference = (match[1] ?? match[2] ?? match[3]).trim();
-        if (reference.toLowerCase().startsWith('data:')) continue;
-
-        if (/^[a-z][a-z\d+.-]*:/i.test(reference) || reference.startsWith('/')) {
-          hits.push(hitFor(declaration));
-          continue;
-        }
-
-        let targetPath = '';
-        try {
-          const fileReference = decodeURIComponent(reference.split(/[?#]/, 1)[0]);
-          targetPath = path.resolve(targetDistributionDirectory, path.dirname(file), fileReference);
-        } catch {
-          hits.push(hitFor(declaration));
-          continue;
-        }
-
-        if (!isExactFileWithin(targetDistributionDirectory, targetPath)) hits.push(hitFor(declaration));
-      }
-    });
-
-    if (hits.length > 0) failures.push({ file, hits });
-  }
-
-  return failures;
-}
-
-function countFontFaces(filePath: string): number {
-  let count = 0;
-  postcss.parse(readFileSync(filePath, 'utf8')).walkAtRules('font-face', () => {
-    count += 1;
-  });
-  return count;
-}
-
-function checkEntryChunkFontFaces(): FailureReport[] {
-  const sidecarFile = 'fonts.css';
-  const entryChunkFile = 'assets/index.css';
-  const sidecarPath = path.resolve(distributionDirectory, sidecarFile);
-  const entryChunkPath = path.resolve(distributionDirectory, entryChunkFile);
-
-  if (!existsSync(sidecarPath)) {
-    return [{ file: sidecarFile, hits: [{ line: 0, column: 0, snippet: 'font sidecar is missing' }] }];
-  }
-  if (!existsSync(entryChunkPath)) {
-    return [{ file: entryChunkFile, hits: [{ line: 0, column: 0, snippet: 'entry-chunk CSS is missing' }] }];
-  }
-
-  const expectedCount = countFontFaces(sidecarPath);
-  const actualCount = countFontFaces(entryChunkPath);
-  if (expectedCount > 0 && actualCount === expectedCount) return [];
-
-  return [
-    {
-      file: entryChunkFile,
-      hits: [
-        {
-          line: 0,
-          column: 0,
-          snippet: `expected ${expectedCount} @font-face rules from fonts.css, found ${actualCount}`,
-        },
-      ],
-    },
-  ];
-}
-
-// --- Run all checks ---------------------------------------------------------
-
-function report(title: string, failures: FailureReport[], hint: string, rootLabel = 'packages/ui/dist'): boolean {
-  if (failures.length === 0) {
-    console.log(`✔ ${title}`);
-    return true;
-  }
-
-  const total = failures.reduce((n, f) => n + f.hits.length, 0);
-  console.error(`\n✖ Found ${total} issue(s): ${title}\n`);
-  for (const { file, hits } of failures) {
-    console.error(`  ${rootLabel}/${file}`);
-    for (const { line, column, snippet } of hits) {
-      console.error(`    ${line}:${column}  …${snippet}…`);
-    }
-  }
-  console.error(`\n${hint}\n`);
-  return false;
-}
-
-const files = globSync('**/*.css', { cwd: distributionDirectory });
-
-const results = [
-  report(
-    'Built CSS: every var() takes a --custom-property name',
-    checkVariableFirstArgument(files),
-    'The first argument of var() must be a --custom-property name - browsers silently ' +
-      'discard the whole declaration otherwise.',
-  ),
-  report(
-    'Built CSS: Workflow Builder variables use sanctioned namespaces',
-    checkVariableNamespaces(files, distributionDirectory),
-    'Use `--wb-ds-*` for generated design tokens, `--wb-sdk-*` for SDK internals, ' +
-      '`--wb-public-*` for supported overrides, or an unprefixed component-local name.',
-  ),
-  report(
-    'Built CSS: every rule sits inside an @layer block',
-    checkLayerCoverage(files),
-    'Unlayered CSS wins the cascade over layered CSS regardless of specificity - wrap the ' +
-      'source rule in `@layer ui.base { ... }` or `@layer ui.component { ... }` (see ' +
-      'packages/ui/css-layers.md). `:root` defaults are wrapped by the build ' +
-      '(postcss-layer-root-defaults.mts); a hit here means CSS bypassed that pipeline.',
-  ),
-  report(
-    'Built CSS: every file leads with the @layer order statement',
-    checkOrderStatementFirst(files),
-    'Each dist stylesheet must begin with the full order statement from src/styles/layers.css - ' +
-      'combine-css-bundle.mts stamps it; a missing stamp reintroduces the inverted-cascade bug.',
-  ),
-  report(
-    `Built CSS: only known layer names (${KNOWN_LAYERS.join(', ')})`,
-    checkKnownLayerNames(files),
-    'An unknown layer name lands AFTER the declared order and silently wins the cascade - fix the typo.',
-  ),
-  report(
-    'Built CSS: exported entrypoints exist and no stylesheet uses @import',
-    checkPublishedSurface(files),
-    'package.json exports must point at real files, and dist CSS must be self-contained - ' +
-      'a relative @import breaks silently when a file is copied out of the package.',
-  ),
-  report(
-    'Built CSS: every non-data url() resolves inside dist',
-    checkUrlTargets(files, distributionDirectory),
-    'Copy every referenced asset into dist and keep its path relative to the stylesheet.',
-  ),
-  report(
-    'Built CSS: the root entry chunk carries every @font-face rule',
-    checkEntryChunkFontFaces(),
-    'Append the generated font block to dist/assets/index.css so the root JS barrel carries it.',
-  ),
+// The layer contract belongs to this package: it stamps the order statement and wraps
+// every rule. Consumer bundles (the SDK) ship their own unlayered component CSS, so they
+// are only held to the checks that are theirs to satisfy.
+const directories = [
+  { path: path.join(packageDirectory, 'dist'), ownsLayerContract: true },
+  ...process.argv.slice(2).map((item) => ({ path: path.resolve(item), ownsLayerContract: false })),
 ];
 
-for (const directory of process.argv.slice(2)) {
-  const targetDistributionDirectory = path.resolve(process.cwd(), directory);
-  const targetFiles = globSync('**/*.css', { cwd: targetDistributionDirectory });
-  const rootLabel = path.relative(path.resolve(packageDirectory, '../..'), targetDistributionDirectory);
-  results.push(
-    report(
-      `Built CSS (${rootLabel}): every non-data url() resolves inside dist`,
-      checkUrlTargets(targetFiles, targetDistributionDirectory),
-      'Copy every referenced asset into dist and keep its path relative to the stylesheet.',
-      rootLabel,
-    ),
-    report(
-      `Built CSS (${rootLabel}): Workflow Builder variables use sanctioned namespaces`,
-      checkVariableNamespaces(targetFiles, targetDistributionDirectory),
-      'Use `--wb-ds-*` for generated design tokens, `--wb-sdk-*` for SDK internals, ' +
-        '`--wb-public-*` for supported overrides, or an unprefixed component-local name.',
-      rootLabel,
-    ),
-    report(
-      `Built CSS (${rootLabel}): SDK public defaults are present inside @layer blocks`,
-      checkSdkPublicDefaultLayerCoverage(targetFiles, targetDistributionDirectory),
-      'The three SDK-owned `--wb-public-form-*` defaults must ship inside an `@layer` block.',
-      rootLabel,
-    ),
-  );
+for (const { path: directory, ownsLayerContract } of directories) {
+  for (const relativeFile of globSync('**/*.css', { cwd: directory })) {
+    const absoluteFile = path.join(directory, relativeFile);
+    const file = path.relative(repositoryDirectory, absoluteFile);
+    const root = postcss.parse(readFileSync(absoluteFile, 'utf8'), { from: absoluteFile });
+
+    if (ownsLayerContract) {
+      if (!isOrderStatement(root.first)) add(file, root.first, 'Missing leading layer order');
+
+      for (const node of root.nodes) {
+        // A statement-form @layer only declares names. The leading-order check above
+        // guarantees the canonical order comes first, so a later declaration cannot
+        // reorder anything; composes-only stylesheets legitimately produce one.
+        const allowedLayer = node.type === 'atrule' && node.name === 'layer';
+        if ((node.type === 'rule' || node.type === 'atrule') && !allowedLayer) add(file, node, 'Unlayered built CSS');
+      }
+
+      root.walkAtRules('layer', (atRule) => {
+        if (atRule.params.split(',').some((name) => !knownLayers.has(name.trim())))
+          add(file, atRule, 'Unknown layer name');
+      });
+    }
+    root.walkAtRules('import', (atRule) => add(file, atRule, 'Built CSS import'));
+
+    root.walkDecls((declaration) => {
+      if (/var\((?!\s*--)/.test(declaration.value)) add(file, declaration, 'Malformed var() argument');
+      const invalidNamespace =
+        declaration.prop.startsWith('--ax-') ||
+        (declaration.prop.startsWith('--wb-') &&
+          !sanctionedPrefixes.some((prefix) => declaration.prop.startsWith(prefix)));
+      if (invalidNamespace) add(file, declaration, 'Unsanctioned variable namespace');
+      // Only this package declares the public defaults consumers override, so only here does
+      // "must sit on :root inside ui.base" hold. A consumer bundle setting a public variable on
+      // its own component subtree is a scoped override, not a default.
+      if (ownsLayerContract && declaration.prop.startsWith('--wb-public-') && !isPublicDefault(declaration)) {
+        add(file, declaration, 'Mis-scoped public variable default');
+      }
+
+      for (const match of declaration.value.matchAll(urlPattern)) {
+        const reference = (match[1] ?? match[2] ?? match[3]).trim();
+        if (/^(?:data:|[a-z][a-z\d+.-]*:|\/)/i.test(reference)) continue;
+
+        let target: string;
+        try {
+          target = path.resolve(path.dirname(absoluteFile), decodeURIComponent(reference.split(/[?#]/, 1)[0]));
+        } catch {
+          add(file, declaration, 'Missing built URL target');
+          continue;
+        }
+        const relativeTarget = path.relative(directory, target);
+        const outside =
+          relativeTarget === '..' || relativeTarget.startsWith(`..${path.sep}`) || path.isAbsolute(relativeTarget);
+        if (outside || !existsSync(target) || !statSync(target).isFile())
+          add(file, declaration, 'Missing built URL target');
+      }
+    });
+  }
 }
 
-if (results.includes(false)) {
+if (problems.length > 0) {
+  console.error(problems.join('\n'));
   process.exitCode = 1;
 }

--- a/packages/ui/scripts/check-built-css.ts
+++ b/packages/ui/scripts/check-built-css.ts
@@ -1,4 +1,4 @@
-import { existsSync, globSync, readFileSync, statSync } from 'node:fs';
+import { globSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import postcss, { AtRule, type ChildNode, type Declaration, type Node } from 'postcss';
@@ -32,6 +32,19 @@ function isOrderStatement(node: ChildNode | undefined): boolean {
 
 function add(file: string, node: Node | undefined, message: string): void {
   problems.push(`${file}:${node?.source?.start?.line ?? 1} ${message}. See ${pitfalls}.`);
+}
+
+function existsWithExactCase(root: string, relativeTarget: string): boolean {
+  let current = root;
+  return relativeTarget.split(path.sep).every((segment) => {
+    try {
+      if (!readdirSync(current).includes(segment)) return false;
+    } catch {
+      return false;
+    }
+    current = path.join(current, segment);
+    return true;
+  });
 }
 
 function isPublicDefault(declaration: Declaration): boolean {
@@ -107,7 +120,7 @@ for (const { path: directory, ownsLayerContract } of directories) {
         const relativeTarget = path.relative(directory, target);
         const outside =
           relativeTarget === '..' || relativeTarget.startsWith(`..${path.sep}`) || path.isAbsolute(relativeTarget);
-        if (outside || !existsSync(target) || !statSync(target).isFile())
+        if (outside || !existsWithExactCase(directory, relativeTarget) || !statSync(target).isFile())
           add(file, declaration, 'Missing built URL target');
       }
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,9 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.6
+      publint:
+        specifier: ^0.3.24
+        version: 0.3.24
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -2469,6 +2472,10 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@publint/pack@0.1.7':
+    resolution: {integrity: sha512-4EDEmvxWtgsCnnVeBvtFIFZtUhPPt1+bA9JrSwU4Sa//6oKtzCSlGGXYJr44OD9aGISymbieJ4mCKHUygUDU+g==}
+    engines: {node: '>=18'}
 
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
@@ -6481,6 +6488,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   pagefind@1.4.0:
     resolution: {integrity: sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==}
     hasBin: true
@@ -6728,6 +6738,11 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  publint@0.3.24:
+    resolution: {integrity: sha512-9zS56KrKBoqi5Qt8h92uMP8TTM9AYZSgnmCo4u2priMqkOZvQnTsziZ2p5LJ2ywbYkAjoCDp2jda9u4cgFefIw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -7099,6 +7114,10 @@ packages:
 
   s.color@0.0.15:
     resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -7556,6 +7575,10 @@ packages:
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -10256,6 +10279,10 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@publint/pack@0.1.7':
+    dependencies:
+      tinyexec: 1.3.0
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
@@ -15193,6 +15220,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  package-manager-detector@1.8.0: {}
+
   pagefind@1.4.0:
     optionalDependencies:
       '@pagefind/darwin-arm64': 1.4.0
@@ -15456,6 +15485,13 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  publint@0.3.24:
+    dependencies:
+      '@publint/pack': 0.1.7
+      package-manager-detector: 1.8.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   pump@3.0.4:
     dependencies:
@@ -15959,6 +15995,10 @@ snapshots:
       tslib: 2.8.1
 
   s.color@0.0.15: {}
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -16542,6 +16582,8 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
+
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.15:
     dependencies:


### PR DESCRIPTION
Stacked on #102.

The built-CSS checker had grown per review finding rather than per invariant: 299 lines on
21.08, 433 after the font work, 480 after the public-variable rename, 523 after the namespace
split. Eight bug classes in a 40-line docstring, eleven `report()` calls, and two checks that
were snapshots of the current shape rather than rules.

This splits it into a small deterministic checker and a catalogue that carries the reasoning.

## What changed

`packages/ui/scripts/check-built-css.ts`: **523 → 117 lines**, eight checks, all operating on
parsed PostCSS nodes so every failure reports `file:line` for free. No hardcoded list of
variable names remains.

| Check | Scope |
| --- | --- |
| `var()` takes a custom-property name | every dist |
| Sanctioned `--wb-ds-` / `--wb-sdk-` / `--wb-public-` namespace | every dist |
| No `@import` | every dist |
| Every non-data `url()` resolves inside dist | every dist |
| Every rule inside `@layer` (statement-form declarations allowed) | this package |
| File leads with the layer-order statement | this package |
| Only declared layer names | this package |
| Public defaults on `:root` inside `ui.base` | this package |

The four layer and public-default checks are scoped to this package's own output, because this
package owns those contracts. A consumer bundle ships its own unlayered component CSS and may
set a public variable on its own subtree as a scoped override.

`packages/ui/built-css-pitfalls.md` (new, registered in `CLAUDE.md`): fifteen failure classes,
each answering what breaks, why it is silent, how to spot it, and whether it is automated.
That includes five classes the checker deliberately does not decide, which is where a reviewer
still has to look:

- font subsetting and flash of unstyled text, including which characters are inline
- Content Security Policy font blocking, including the `default-src` fallback
- a documented public variable absent from dist
- a primitive token used where a role belongs, so the theme stops switching
- typography metrics copied instead of composed

Two checks left the script:

- `exports` pointing at real files is now `publint`, which covers that and more upstream
- the entry-chunk `@font-face` assertion became a unit test next to `combine-css-bundle.mts`,
  where the invariant is produced

The public-default check accepts the root element written as either `:root` or `html`. Both
match the same element, and the repo writes theme scopes as `html[data-theme='...']` in 21
places, so rejecting that spelling would have been a false positive.

## Fixed along the way

The malformed-`var()` pattern never worked. `/var\(\s*(?!--)/` backtracks `\s*` to empty, the
lookahead then sees whitespace instead of `--`, and the match succeeds — so `var( --x )` was
reported as malformed while genuinely broken values could slip through. It is now
`/var\((?!\s*--)/`. The bug was invisible because the old script ran this check only over this
package's dist, which had no wrapped `var(` calls.

## Not done on purpose

An earlier revision of this branch stripped statement-form `@layer` declarations from the asset
files at build time, so the coverage check had a single allowed shape. That has been removed:
rewriting build output to satisfy a lint is not worth the moving part. The check now accepts a
statement-form declaration instead.

Those declarations are harmless. A stylesheet whose rules only `composes` global type roles ends
up with empty bodies, so its `@layer ui.component { }` block serializes as `@layer
ui.component;`; `input-font-size.module.css` and the button font-size module each produce one.
The leading-order check guarantees the canonical `@layer ui.base, ui.component;` comes first in
every asset file, so a later declaration cannot reorder anything.

## Verification

- `pnpm build:lib` green end to end, including the SDK's own dist pass
- every retained check proved by temporarily breaking it: malformed `var()`, unlayered CSS,
  missing layer order, unknown layer name, namespace violation, `@import`, missing URL target,
  mis-scoped public default
- `packages/ui` tests pass, including the new `combine-css-bundle.spec.mts`
- ESLint and Prettier clean on touched files

## Note

Generalising the public-default check surfaced one pre-existing problem outside this PR's
scope: `--wb-public-node-gap` is documented as an override on the NodePanel page but is
redefined to `0` by three built-in node templates, so a consumer's `:root` override does not
apply there. Filed separately rather than fixed here.

