### PR TITLE
fix(execution-worker): disable LLM client-side retries

### DIFF
--- a/apps/backend/src/routes/visualize.ts
+++ b/apps/backend/src/routes/visualize.ts
@@ -62,6 +62,8 @@ export function createVisualizeRoutes(
 
     try {
       const openrouter = createOpenRouter({ apiKey: env.OPENROUTER_API_KEY });
+      // Unlike the worker's AI agent activity, this route has no outer retry
+      // policy, so the SDK's default retries stay on.
       const result = await generateText({
         model: openrouter.chat(env.AI_MODEL),
         system: FORMAT_PROMPTS[format],

--- a/apps/execution-worker/src/activities/ai-agent.test.ts
+++ b/apps/execution-worker/src/activities/ai-agent.test.ts
@@ -1,0 +1,66 @@
+import { APICallError } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { describe, expect, it } from 'vitest';
+
+import type { ExecutionContext } from '@workflow-builder/execution-core';
+
+import type { AiAgentNode } from '../domain/ai-studio-nodes';
+import { executeAiAgent } from './ai-agent';
+
+function context(): ExecutionContext {
+  return {
+    workflowId: 'wf',
+    executionId: 'exec',
+    triggerPayload: {},
+    nodeOutputs: {},
+    variables: {},
+    global: {},
+  };
+}
+
+function aiAgentNode(): AiAgentNode {
+  return {
+    id: 'agent1',
+    type: 'ai-studio/ai-agent',
+    config: { systemPrompt: 'You are a test agent.' },
+  };
+}
+
+describe('executeAiAgent', () => {
+  it('returns the model text as the node output', async () => {
+    const model = new MockLanguageModelV3({
+      doGenerate: {
+        content: [{ type: 'text', text: 'final answer' }],
+        finishReason: { unified: 'stop', raw: undefined },
+        usage: {
+          inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+        },
+        warnings: [],
+      },
+    });
+
+    const result = await executeAiAgent(aiAgentNode(), context(), { model });
+
+    expect(result).toEqual({ output: { response: 'final answer' } });
+  });
+
+  it('calls the model exactly once on a retryable failure (retries belong to the Temporal activity policy)', async () => {
+    const model = new MockLanguageModelV3({
+      doGenerate: () => {
+        // statusCode 500 makes isRetryable default to true — the error must be one
+        // the SDK would retry, or this test passes even with retries enabled.
+        throw new APICallError({
+          message: 'Internal Server Error',
+          url: 'https://model.invalid/chat/completions',
+          requestBodyValues: {},
+          statusCode: 500,
+        });
+      },
+    });
+
+    await expect(executeAiAgent(aiAgentNode(), context(), { model })).rejects.toThrow(APICallError);
+
+    expect(model.doGenerateCalls).toHaveLength(1);
+  });
+});

--- a/apps/execution-worker/src/activities/ai-agent.ts
+++ b/apps/execution-worker/src/activities/ai-agent.ts
@@ -47,6 +47,9 @@ export async function executeAiAgent(node: AiAgentNode, context: ExecutionContex
   try {
     const result = await generateText({
       model: deps.model,
+      // Temporal's activity retry policy owns retries; SDK retries on top would
+      // multiply model calls (up to 3x per activity attempt).
+      maxRetries: 0,
       system: resolvedPrompt,
       prompt: userPrompt,
       // The AI SDK runs the tool call/execute/continue loop internally up to this many steps.


### PR DESCRIPTION
### Problem

The AI SDK's `generateText` silently retries a failed model call twice by default
(3 HTTP attempts total), and Temporal retries the node activity on top of that
(`DEFAULT_NODE_ACTIVITY_PROFILE`, `maximumAttempts: 2`) — so one logical failure
could cost up to 6 model calls. The Temporal integration guidance is to disable
retries on the LLM side and let the activity retry policy own them. Audit blocker.

### Change

- `maxRetries: 0` on the `generateText` call in the AI agent activity. Retry
  ownership stays solely with Temporal's activity policy, which is **unchanged**
  (2 attempts, still pinned by `packages/temporal/test/api-surface.test.ts`).
- The backend `/adapt` route keeps the SDK's default retries, now with a comment
  making that an explicit decision — it has no outer retry policy behind it, so
  disabling SDK retries there would only reduce resilience.
- New unit test `apps/execution-worker/src/activities/ai-agent.test.ts`: a
  `MockLanguageModelV3` throws a *retryable* `APICallError` (HTTP 500) and the
  test asserts exactly one `doGenerate` invocation. Seen red first: against the
  unfixed code it times out mid-backoff while the SDK silently retries (2s/4s).

### Verification (ticket's "Verify by")

Counted real HTTP requests by pointing an actual OpenRouter provider at a local
stub that always returns 500 and calling `executeAiAgent`:

| Configuration            | Model HTTP requests per activity attempt |
| ------------------------ | ---------------------------------------- |
| SDK defaults (before)    | 3 (1 + 2 silent retries)                 |
| `maxRetries: 0` (after)  | 1                                        |

With Temporal's 2 activity attempts, total model invocations per logical
failure = **2, not 6**.