### PR TITLE
fix(execution-core): register the wait before announcing it

### DIFF
--- a/packages/execution-core/src/graph-runner.test.ts
+++ b/packages/execution-core/src/graph-runner.test.ts
@@ -51,8 +51,10 @@ function makeRunner(behaviors: Record<string, NodeBehavior> = {}): {
   };
 }
 
+type PendingWait = { resolve: (completion: CompletedNodeExecution) => void; reject: (error: unknown) => void };
+
 // makeRunner plus an `awaitResolution` port: observe parks via `whenParked`,
-// deliver verdicts via `resolveGate`.
+// deliver verdicts via `resolveGate`. Registers synchronously, as the port requires.
 function makeGatedRunner(behaviors: Record<string, NodeBehavior> = {}): {
   port: ActivityRunnerPort<TestNode>;
   callOrder: string[];
@@ -60,9 +62,10 @@ function makeGatedRunner(behaviors: Record<string, NodeBehavior> = {}): {
   parkedIds: () => string[];
   whenParked: (count: number) => Promise<void>;
   resolveGate: (nodeId: string, completion: CompletedNodeExecution) => void;
+  rejectWait: (nodeId: string, error: unknown) => void;
 } {
   const base = makeRunner(behaviors);
-  const pending = new Map<string, (completion: CompletedNodeExecution) => void>();
+  const pending = new Map<string, PendingWait>();
   const watchers = new Set<{ count: number; notify: () => void }>();
   return {
     callOrder: base.callOrder,
@@ -70,8 +73,8 @@ function makeGatedRunner(behaviors: Record<string, NodeBehavior> = {}): {
     port: {
       executeNode: base.port.executeNode,
       awaitResolution(nodeId) {
-        return new Promise((resolve) => {
-          pending.set(nodeId, resolve);
+        return new Promise((resolve, reject) => {
+          pending.set(nodeId, { resolve, reject });
           for (const watcher of watchers) {
             if (pending.size >= watcher.count) {
               watchers.delete(watcher);
@@ -82,17 +85,25 @@ function makeGatedRunner(behaviors: Record<string, NodeBehavior> = {}): {
       },
     },
     parkedIds: () => [...pending.keys()],
-    whenParked(count) {
-      return new Promise((notify) => {
+    // Registered and announced: the node_waiting emit and the status write have settled too.
+    async whenParked(count) {
+      await new Promise<void>((notify) => {
         if (pending.size >= count) notify();
         else watchers.add({ count, notify });
       });
+      await flush();
     },
     resolveGate(nodeId, completion) {
-      const resolve = pending.get(nodeId);
-      if (!resolve) throw new Error(`no parked gate for ${nodeId}`);
+      const wait = pending.get(nodeId);
+      if (!wait) throw new Error(`no registered wait for ${nodeId}`);
       pending.delete(nodeId);
-      resolve(completion);
+      wait.resolve(completion);
+    },
+    rejectWait(nodeId, error) {
+      const wait = pending.get(nodeId);
+      if (!wait) throw new Error(`no registered wait for ${nodeId}`);
+      pending.delete(nodeId);
+      wait.reject(error);
     },
   };
 }
@@ -1747,5 +1758,78 @@ describe('runGraph — waiting results', () => {
       { status: 'running' },
       { status: 'failed', errorMessage: 'boom' },
     ]);
+  });
+
+  it('registers the wait before announcing it: the node is parked when node_waiting is emitted', async () => {
+    const runner = makeGatedRunner({ A: { waits: true } });
+    const events = makeEvents();
+    const parkedAtAnnouncement: string[][] = [];
+    const observing: EventEmitterPort = {
+      emitEvent(executionId, type, payload, nodeId) {
+        if (type === 'node_waiting') parkedAtAnnouncement.push(runner.parkedIds());
+        return events.port.emitEvent(executionId, type, payload, nodeId);
+      },
+      updateStatus(executionId, status, errorMessage) {
+        if (status === 'waiting') parkedAtAnnouncement.push(runner.parkedIds());
+        return events.port.updateStatus(executionId, status, errorMessage);
+      },
+    };
+
+    const run = runGraph(makeInput([start('A'), trigger('B')], [edge('e1', 'A', 'B')]), runner.port, observing);
+    await runner.whenParked(1);
+    runner.resolveGate('A', { output: 'approved' });
+    await run;
+
+    // Once for the event, once for the status; the node was registered both times.
+    expect(parkedAtAnnouncement).toEqual([['A'], ['A']]);
+  });
+
+  it('an abandoned wait rejecting later is not an unhandled rejection', async () => {
+    const runner = makeGatedRunner({ A: { waits: true } });
+    const events = makeEvents({ type: 'node_waiting', nodeId: 'A', message: 'db down' });
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      const outcome = await runGraph(
+        makeInput([start('A'), trigger('B')], [edge('e1', 'A', 'B')]),
+        runner.port,
+        events.port,
+      );
+
+      expect(outcome).toEqual({ status: 'failed', error: { message: 'db down' } });
+      expect(runner.parkedIds()).toEqual(['A']);
+
+      runner.rejectWait('A', new Error('cancelled after abandonment'));
+      await flush();
+
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+
+  it('a failed announcement fails the node through errorPolicy and leaves the registration behind', async () => {
+    const runner = makeGatedRunner({ A: { waits: true } });
+    const events = makeEvents({ type: 'node_waiting', nodeId: 'A', message: 'db down' });
+
+    const outcome = await runGraph(
+      makeInput([start('A', 'continue'), trigger('B')], [edge('e1', 'A', 'B')]),
+      runner.port,
+      events.port,
+    );
+
+    expect(outcome).toEqual({ status: 'completed' });
+    expect(runner.callOrder).toEqual(['A', 'B']);
+    expect(runner.contexts.B).toEqual({ A: { error: { message: 'db down' } } });
+    expect(events.events.filter((event) => event.nodeId === 'A').map((event) => event.type)).toEqual([
+      'node_started',
+      'node_waiting',
+      'node_failed',
+    ]);
+    // The park never counted, so no waiting/running pair was written.
+    expect(events.statuses).toEqual([{ status: 'completed' }]);
+    // Known gap (durable-pause decision log): the registration outlives the failed node.
+    expect(runner.parkedIds()).toEqual(['A']);
   });
 });

--- a/packages/execution-core/src/graph-runner.ts
+++ b/packages/execution-core/src/graph-runner.ts
@@ -354,6 +354,10 @@ async function parkUntilResolved(
   executionId: string,
   parked: { count: number },
 ): Promise<CompletedNodeExecution> {
+  // Registered before it is announced, so a verdict sent on seeing node_waiting is never early.
+  const resolution = awaitResolution(nodeId);
+  // Abandoned if the announcement throws; an unhandled rejection would fail the workflow task.
+  resolution.catch(() => {});
   await events.emitEvent(executionId, 'node_waiting', undefined, nodeId);
   parked.count += 1;
   try {
@@ -362,7 +366,7 @@ async function parkUntilResolved(
     }
     // Awaited here, so the caller's wave slot stays pending and the barrier holds
     // itself: the wave completes only once every parked node has resolved.
-    return await awaitResolution(nodeId);
+    return await resolution;
   } finally {
     // On rejection too: a failure absorbed by 'continue' must not strand the run in 'waiting'.
     parked.count -= 1;

--- a/packages/execution-core/src/ports/activity-runner.port.ts
+++ b/packages/execution-core/src/ports/activity-runner.port.ts
@@ -23,6 +23,7 @@ export type NodeExecutionResult = CompletedNodeExecution | WaitingNodeExecution;
 export interface ActivityRunnerPort<TNode extends BaseNode> {
   executeNode(node: TNode, context: ExecutionContext): Promise<NodeExecutionResult>;
   // Resolves with the verdict's completion. Engines without gate support omit it;
-  // a waiting result then fails the run.
+  // a waiting result then fails the run. Must record the wait before its first await;
+  // the runner announces it only afterwards.
   awaitResolution?(nodeId: string): Promise<CompletedNodeExecution>;
 }

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -203,7 +203,7 @@ const plugin = new WorkflowBuilderPlugin({
 });
 ```
 
-While parked, the store sees a `node_waiting` event for the node and the run status moves to `waiting`. It returns to `running` once the last waiting node has resolved, so two nodes parked at once produce a single `waiting`/`running` transition.
+While parked, the store sees a `node_waiting` event for the node and the run status moves to `waiting`. It returns to `running` once the last waiting node has resolved, so two nodes parked at once produce a single `waiting`/`running` transition. Both are written after the workflow has started accepting a verdict for that node, so acting on either is never too early.
 
 The verdict arrives as a Workflow Update, `resolveNodeUpdate`:
 
@@ -219,7 +219,7 @@ await handle.executeUpdate(resolveNodeUpdate, {
 
 The `resolution` is the completion the node finishes with, exactly as if its executor had returned it: `output` becomes the node's output for everything downstream, and `nextPort` routes the graph. This package passes it through untouched. What a verdict contains, and who may deliver one, is your application's contract.
 
-Because this is an Update and not a signal, the caller gets a synchronous answer, and the update is validated before it is accepted, so a rejected verdict leaves no trace in the run. The rejections, each an `ApplicationFailure` with a stable type: a malformed envelope is `verdict_malformed` (the envelope is an object carrying at most `output` and `nextPort`; `nextPort` must not be the reserved `errorRoute`, and a missing `output` is read as `undefined`, which is what the default JSON payload converter turns `output: undefined` into), a node id that is not in the graph is `verdict_for_unknown_node`, a node that is not currently waiting is `node_not_waiting` (also possible for a verdict racing the parking moment, so treat it as retryable), and a second verdict for the same node is `verdict_already_delivered`: the first one wins. A verdict for a run that has already closed fails at the server. Cancelling a parked run closes it as `cancelled`, with `execution_cancelled` following the node's `node_waiting` and no `node_failed` recorded for the node that was waiting.
+Because this is an Update and not a signal, the caller gets a synchronous answer, and the update is validated before it is accepted, so a rejected verdict leaves no trace in the run. The rejections, each an `ApplicationFailure` with a stable type: a malformed envelope is `verdict_malformed` (the envelope is an object carrying at most `output` and `nextPort`; `nextPort` must not be the reserved `errorRoute`, and a missing `output` is read as `undefined`, which is what the default JSON payload converter turns `output: undefined` into), a node id that is not in the graph is `verdict_for_unknown_node`, a node that is not currently waiting is `node_not_waiting` (final: it has not parked, or its wait was cancelled), and a second verdict for the same node is `verdict_already_delivered`: the first one wins. A verdict for a run that has already closed fails at the server. Cancelling a parked run closes it as `cancelled`, with `execution_cancelled` following the node's `node_waiting` and no `node_failed` recorded for the node that was waiting.
 
 ### Wave-barrier limitations (deliberate)
 

--- a/packages/temporal/src/workflow/durable-pause.decision-log.md
+++ b/packages/temporal/src/workflow/durable-pause.decision-log.md
@@ -38,10 +38,21 @@ verdict carries. This file records the decisions behind the Temporal side of the
   validator throw runs before acceptance instead — the update is rejected, the task is
   safe, nothing reaches history, and replay skips validators. Three invariants only:
   the update cannot kill the run, success means it landed on a waiting node, a verdict
-  cannot do what an executor could not. Consequence: a verdict racing the parking
-  activation is rejected `node_not_waiting` (updates are processed before workflow
-  code continues); truthful at validation time, and retryable. Verdict meaning and
-  authorship stay with the decision-endpoint and claim work.
+  cannot do what an executor could not. Verdict meaning and authorship stay with the
+  decision-endpoint and claim work.
+- **The wait is registered before it is announced.** `parkUntilResolved` calls
+  `awaitResolution` first, then emits `node_waiting` and writes the status. Both are
+  activities, so a verdict sent on seeing either can never be ahead of the state the
+  validator reads: `node_not_waiting` is a final answer, not a race to retry.
+  Registration is state, not a command, so the committed parked history replays
+  unchanged. The registered promise carries a no-op `catch`: abandoned when the
+  announcement throws, its rejection on cancellation would otherwise fail the workflow
+  task.
+- **Known gap, accepted.** A `node_waiting` emit that fails after every retry leaves the
+  `waiting` entry registered while the node fails through `errorPolicy`; a blind verdict
+  for it would be accepted with no effect. A real outage fails the `node_failed` emit too
+  and ends the run, so the gap needs the database to recover between two consecutive
+  emits.
 - **Names.** Update `resolveNode`, input `{ nodeId, resolution }`. The verdict content
   is opaque here: `resolution` is a `CompletedNodeExecution` passed to the parked node
   untouched. Giving it a domain shape belongs to the decision-contract work.

--- a/packages/temporal/test/durable-pause.test.ts
+++ b/packages/temporal/test/durable-pause.test.ts
@@ -22,6 +22,7 @@ import {
   SINGLE_GATE_GRAPH,
   TWO_GATES_GRAPH,
   createPauseExecutors,
+  holdAnnouncement,
 } from './fixtures/pause-graph';
 
 function eventTypes(store: RecordingStore, nodeId?: string): string[] {
@@ -205,29 +206,42 @@ describe('durable pause', () => {
   it('rejects a verdict before the node parks, and accepts one the instant node_waiting is announced', async () => {
     const taskQueue = 'pause-held';
     const store = createRecordingStore();
+    const announcement = holdAnnouncement(store, 'gate');
     const harness = createPauseExecutors({ holdWaiting: true });
     const handle = await startRun(taskQueue, 'pause-held-execution', SINGLE_GATE_GRAPH);
 
-    const worker = await createWorker(taskQueue, store, harness);
+    const worker = await createWorker(taskQueue, announcement.store, harness);
     await worker.runUntil(async () => {
-      await waitUntil(() => eventTypes(store, 'gate').includes('node_started'), 'node_started for the waiting node');
-      await expectRejected(
-        handle.executeUpdate('resolveNode', {
-          args: [{ nodeId: 'gate', resolution: { output: 'too early' } }],
-          updateId: 'verdict-before-parking',
-        }),
-        'node_not_waiting',
-      );
+      // Shutdown waits for held activities, so a failed assertion here must still release both.
+      try {
+        await waitUntil(() => eventTypes(store, 'gate').includes('node_started'), 'node_started for the waiting node');
+        await expectRejected(
+          handle.executeUpdate('resolveNode', {
+            args: [{ nodeId: 'gate', resolution: { output: 'too early' } }],
+            updateId: 'verdict-before-parking',
+          }),
+          'node_not_waiting',
+        );
 
-      harness.release();
-      await whenAnnounced(store, 'gate');
-      await handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] });
+        harness.release();
+        await whenAnnounced(store, 'gate');
+        await handle.executeUpdate(resolveNodeUpdate, {
+          args: [{ nodeId: 'gate', resolution: { output: 'approved' } }],
+        });
+        // Accepted while the announcing activity is still in flight: the status write comes after it.
+        expect(store.statuses).toEqual([]);
+      } finally {
+        harness.release();
+        announcement.release();
+      }
+
       await handle.result();
     });
 
     expect(harness.executed).toEqual(['start', 'gate', 'after']);
     expect(harness.inputsSeen.after.gate).toBe('approved');
     expect(eventTypes(store, 'gate')).toEqual(['node_started', 'node_waiting', 'node_completed']);
+    expect(store.statuses.map((entry) => entry.status)).toEqual(['waiting', 'running', 'completed']);
     expect(acceptedUpdateIds(await handle.fetchHistory())).not.toContain('verdict-before-parking');
   }, 120_000);
 

--- a/packages/temporal/test/durable-pause.test.ts
+++ b/packages/temporal/test/durable-pause.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../src/index';
 import { resolveNodeUpdate } from '../src/workflow/index';
 import { type RecordingStore, createRecordingStore } from './fixtures/graph';
-import { acceptedUpdateIds, executeVerdictWithRetry, waitUntil } from './fixtures/helpers';
+import { acceptedUpdateIds, waitUntil } from './fixtures/helpers';
 import {
   PORT_ROUTED_GRAPH,
   type PauseHarness,
@@ -26,6 +26,11 @@ import {
 
 function eventTypes(store: RecordingStore, nodeId?: string): string[] {
   return store.events.filter((event) => nodeId === undefined || event.nodeId === nodeId).map((event) => event.type);
+}
+
+// The earliest observable moment; delivering right here is the claim under test.
+function whenAnnounced(store: RecordingStore, nodeId: string): Promise<void> {
+  return waitUntil(() => eventTypes(store, nodeId).includes('node_waiting'), `node_waiting for ${nodeId}`);
 }
 
 async function expectRejected(update: Promise<unknown>, code: string): Promise<void> {
@@ -96,9 +101,7 @@ describe('durable pause', () => {
 
     const worker2 = await createWorker(taskQueue, store, harness);
     await worker2.runUntil(async () => {
-      await executeVerdictWithRetry(() =>
-        handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] }),
-      );
+      await handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] });
       await handle.result();
     });
 
@@ -118,24 +121,17 @@ describe('durable pause', () => {
 
     const worker = await createWorker(taskQueue, store, harness);
     await worker.runUntil(async () => {
-      await waitUntil(
-        () =>
-          eventTypes(store).filter((type) => type === 'node_waiting').length === 2 &&
-          store.statuses.some((entry) => entry.status === 'waiting'),
-        'both gates to park',
-      );
+      await Promise.all([whenAnnounced(store, 'gate-a'), whenAnnounced(store, 'gate-b')]);
 
-      await executeVerdictWithRetry(() =>
-        handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate-a', resolution: { output: 'first' } }] }),
-      );
+      await handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate-a', resolution: { output: 'first' } }] });
       const rejection: unknown = await handle
         .executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate-a', resolution: { output: 'second' } }] })
         .catch((error: unknown) => error);
       expect(rejection).toBeInstanceOf(WorkflowUpdateFailedError);
       expect((rejection as WorkflowUpdateFailedError).cause).toMatchObject({ type: 'verdict_already_delivered' });
-      await executeVerdictWithRetry(() =>
-        handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate-b', resolution: { output: 'b-verdict' } }] }),
-      );
+      await handle.executeUpdate(resolveNodeUpdate, {
+        args: [{ nodeId: 'gate-b', resolution: { output: 'b-verdict' } }],
+      });
       await handle.result();
     });
 
@@ -153,7 +149,7 @@ describe('durable pause', () => {
 
     const worker = await createWorker(taskQueue, store, harness);
     await worker.runUntil(async () => {
-      await waitUntil(() => store.statuses.some((entry) => entry.status === 'waiting'), 'the waiting status');
+      await whenAnnounced(store, 'gate');
 
       // Rejection classes live in verdict-validation.test.ts; this pins the
       // end-to-end property: a rejected update leaves the parked run resolvable.
@@ -169,9 +165,7 @@ describe('durable pause', () => {
         'verdict_for_unknown_node',
       );
 
-      await executeVerdictWithRetry(() =>
-        handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] }),
-      );
+      await handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] });
       await handle.result();
     });
 
@@ -194,12 +188,10 @@ describe('durable pause', () => {
 
     const worker = await createWorker(taskQueue, store, harness);
     await worker.runUntil(async () => {
-      await waitUntil(() => store.statuses.some((entry) => entry.status === 'waiting'), 'the waiting status');
-      await executeVerdictWithRetry(() =>
-        handle.executeUpdate(resolveNodeUpdate, {
-          args: [{ nodeId: 'gate', resolution: { output: undefined, nextPort: 'approved' } }],
-        }),
-      );
+      await whenAnnounced(store, 'gate');
+      await handle.executeUpdate(resolveNodeUpdate, {
+        args: [{ nodeId: 'gate', resolution: { output: undefined, nextPort: 'approved' } }],
+      });
       await handle.result();
     });
 
@@ -208,6 +200,35 @@ describe('durable pause', () => {
     expect(harness.inputsSeen.after).toEqual({ start: { visited: 'start' } });
     expect(eventTypes(store, 'gate')).toEqual(['node_started', 'node_waiting', 'node_completed']);
     expect(store.statuses.map((entry) => entry.status)).toEqual(['waiting', 'running', 'completed']);
+  }, 120_000);
+
+  it('rejects a verdict before the node parks, and accepts one the instant node_waiting is announced', async () => {
+    const taskQueue = 'pause-held';
+    const store = createRecordingStore();
+    const harness = createPauseExecutors({ holdWaiting: true });
+    const handle = await startRun(taskQueue, 'pause-held-execution', SINGLE_GATE_GRAPH);
+
+    const worker = await createWorker(taskQueue, store, harness);
+    await worker.runUntil(async () => {
+      await waitUntil(() => eventTypes(store, 'gate').includes('node_started'), 'node_started for the waiting node');
+      await expectRejected(
+        handle.executeUpdate('resolveNode', {
+          args: [{ nodeId: 'gate', resolution: { output: 'too early' } }],
+          updateId: 'verdict-before-parking',
+        }),
+        'node_not_waiting',
+      );
+
+      harness.release();
+      await whenAnnounced(store, 'gate');
+      await handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] });
+      await handle.result();
+    });
+
+    expect(harness.executed).toEqual(['start', 'gate', 'after']);
+    expect(harness.inputsSeen.after.gate).toBe('approved');
+    expect(eventTypes(store, 'gate')).toEqual(['node_started', 'node_waiting', 'node_completed']);
+    expect(acceptedUpdateIds(await handle.fetchHistory())).not.toContain('verdict-before-parking');
   }, 120_000);
 
   it('cancel while waiting closes the run as cancelled, with no node_failed for the gate', async () => {

--- a/packages/temporal/test/fixtures/helpers.ts
+++ b/packages/temporal/test/fixtures/helpers.ts
@@ -1,4 +1,3 @@
-import { WorkflowUpdateFailedError } from '@temporalio/client';
 import type { History } from '@temporalio/common/lib/proto-utils';
 
 export async function waitUntil(check: () => boolean, what: string, timeoutMs = 30_000): Promise<void> {
@@ -6,23 +5,6 @@ export async function waitUntil(check: () => boolean, what: string, timeoutMs = 
   while (!check()) {
     if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
     await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-}
-
-// node_not_waiting is retryable by contract: a verdict can race the parking
-// activation (see the decision log). Tests deliver verdicts the way callers should.
-export async function executeVerdictWithRetry(send: () => Promise<unknown>): Promise<void> {
-  for (let attempt = 1; ; attempt += 1) {
-    try {
-      await send();
-      return;
-    } catch (error) {
-      const racingPark =
-        error instanceof WorkflowUpdateFailedError &&
-        (error.cause as { type?: string } | undefined)?.type === 'node_not_waiting';
-      if (!racingPark || attempt >= 40) throw error;
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
   }
 }
 

--- a/packages/temporal/test/fixtures/pause-graph.ts
+++ b/packages/temporal/test/fixtures/pause-graph.ts
@@ -1,6 +1,7 @@
 // Gate fixtures for the durable-pause tests. Executors record every invocation so
 // the restart scenario can assert "downstream runs exactly once" across workers.
 import type { BaseNode, NodeExecutorRegistry, WorkflowDefinition } from '../../src/index';
+import type { RecordingStore } from './graph';
 
 export type PauseTestNode = (BaseNode & { type: 'test/step' }) | (BaseNode & { type: 'test/gate' });
 
@@ -87,6 +88,28 @@ export function createPauseExecutors(options: { holdWaiting?: boolean } = {}): P
         executed.push(node.id);
         await held;
         return { waiting: true };
+      },
+    },
+  };
+}
+
+export type HeldAnnouncement = { store: RecordingStore; release: () => void };
+
+// Keeps the node_waiting activity in flight after the event is recorded, until `release()`,
+// so a verdict can reach the workflow before that activity has returned.
+export function holdAnnouncement(store: RecordingStore, nodeId: string): HeldAnnouncement {
+  let release: () => void = noop;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    release: () => release(),
+    store: {
+      ...store,
+      async emitExecutionEvent(executionId, sequence, type, payload, eventNodeId) {
+        await store.emitExecutionEvent(executionId, sequence, type, payload, eventNodeId);
+        if (type === 'node_waiting' && eventNodeId === nodeId) await held;
       },
     },
   };

--- a/packages/temporal/test/fixtures/pause-graph.ts
+++ b/packages/temporal/test/fixtures/pause-graph.ts
@@ -53,27 +53,39 @@ export const TWO_GATES_GRAPH: WorkflowDefinition<PauseTestNode> = {
   ],
 };
 
+function noop(): void {}
+
 export type PauseHarness = {
   executors: NodeExecutorRegistry<PauseTestNode>;
   executed: string[];
   inputsSeen: Record<string, Record<string, unknown>>;
+  release: () => void;
 };
 
-export function createPauseExecutors(): PauseHarness {
+// `holdWaiting` keeps the waiting executor in flight until `release()`.
+export function createPauseExecutors(options: { holdWaiting?: boolean } = {}): PauseHarness {
   const executed: string[] = [];
   const inputsSeen: PauseHarness['inputsSeen'] = {};
+  let release: () => void = noop;
+  const held = options.holdWaiting
+    ? new Promise<void>((resolve) => {
+        release = resolve;
+      })
+    : Promise.resolve();
 
   return {
     executed,
     inputsSeen,
+    release: () => release(),
     executors: {
       'test/step': (node, context) => {
         executed.push(node.id);
         inputsSeen[node.id] = { ...context.nodeOutputs };
         return { output: { visited: node.id } };
       },
-      'test/gate': (node) => {
+      'test/gate': async (node) => {
         executed.push(node.id);
+        await held;
         return { waiting: true };
       },
     },

--- a/packages/temporal/test/replay/parked-gate-replay.test.ts
+++ b/packages/temporal/test/replay/parked-gate-replay.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../src/index';
 import { resolveNodeUpdate } from '../../src/workflow/index';
 import { type RecordingStore, createRecordingStore } from '../fixtures/graph';
-import { countScheduledActivities, executeVerdictWithRetry, waitUntil } from '../fixtures/helpers';
+import { countScheduledActivities, waitUntil } from '../fixtures/helpers';
 import { type PauseTestNode, SINGLE_GATE_GRAPH, createPauseExecutors } from '../fixtures/pause-graph';
 
 const EXECUTION_ID = 'parked-gate-replay-execution';
@@ -77,9 +77,7 @@ describe('replay — parked gate', () => {
 
     await worker.runUntil(async () => {
       await waitUntil(() => store.statuses.some((entry) => entry.status === 'waiting'), 'the waiting status');
-      await executeVerdictWithRetry(() =>
-        handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] }),
-      );
+      await handle.executeUpdate(resolveNodeUpdate, { args: [{ nodeId: 'gate', resolution: { output: 'approved' } }] });
       await handle.result();
     });
 


### PR DESCRIPTION
## What

`parkUntilResolved` now calls `awaitResolution` before it emits `node_waiting` and writes the `waiting` status. The adapter registers the wait synchronously, so both announcements reach the store only after the workflow has started accepting a verdict for that node. `node_not_waiting` becomes a final answer; the harness no longer needs `executeVerdictWithRetry`, and neither will the decision endpoint.

## Why

The announcements were written first and the wait registered last, one activity round trip later. A caller reacting to the event was told `node_not_waiting` by a workflow one step away from waiting. With the runner in its previous order, 4 of the 6 harness tests in `durable-pause.test.ts` fail with that code on one machine: the race was systematic.

## Replay

Registration is state, not a command. The command sequence is unchanged and both committed histories in `test/replay/histories/` replay as they are, no re-recording.

## Known gap (accepted, in the decision log)

A `node_waiting` emit that fails after every retry leaves the wait registered while the node fails through `errorPolicy`. A real outage fails the `node_failed` emit the same way and ends the run; the gap needs the database to recover between two consecutive emits.