### PR TITLE
[DS 2.0] Design parity check: built CSS geometry vs Figma masters

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,10 +26,12 @@
     "url": "https://github.com/synergycodes/workflowbuilder/issues"
   },
   "scripts": {
-    "build": "vite build && pnpm check:built-css && pnpm publint",
+    "build": "vite build && pnpm check:built-css && pnpm check:design-parity && pnpm publint",
     "dev": "vite build --watch",
     "prepare": "pnpm build",
     "check:built-css": "tsx ./scripts/check-built-css.ts",
+    "check:design-parity": "tsx ./scripts/check-design-parity.ts",
+    "design-parity:fetch": "tsx ./scripts/design-parity/fetch-expectations.ts",
     "publint": "publint",
     "lint": "eslint",
     "lint:fix": "eslint --fix",

--- a/packages/ui/scripts/check-design-parity.ts
+++ b/packages/ui/scripts/check-design-parity.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import postcss from 'postcss';
+
+type Check = { name: string; node: string; figma: string; css: Array<[string, number]> };
+type Expectations = { fileName: string; fileLastModified: string; nodes: Record<string, Record<string, unknown>> };
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(directory, '..');
+const parityDirectory = path.join(directory, 'design-parity');
+const expectations = JSON.parse(readFileSync(path.join(parityDirectory, 'expectations.json'), 'utf8')) as Expectations;
+const checks = JSON.parse(readFileSync(path.join(parityDirectory, 'checks.json'), 'utf8')) as Check[];
+const ROOT_FONT_SIZE = 16;
+const TOLERANCE = 0.5;
+
+const declarations = new Map<string, string>();
+for (const file of ['dist/tokens.css', 'dist/index.css']) {
+  const css = postcss.parse(readFileSync(path.join(root, file), 'utf8'));
+  css.walkRules((rule) => {
+    if (/dark/.test(rule.selector)) return;
+    rule.walkDecls(/^--/, (declaration) => declarations.set(declaration.prop, declaration.value.trim()));
+  });
+}
+
+function resolve(name: string, seen = new Set<string>()): string {
+  if (seen.has(name)) throw new Error(`Circular custom property chain at ${name}`);
+  seen.add(name);
+  const value = declarations.get(name);
+  if (value === undefined) throw new Error(`${name} is not declared in the built CSS`);
+  const alias = /^var\((--[\w-]+)(?:,\s*([^)]+))?\)$/.exec(value);
+  if (!alias) return value;
+  return declarations.has(alias[1]) || !alias[2] ? resolve(alias[1], seen) : alias[2].trim();
+}
+
+function toPx(value: string, name: string): number {
+  const match = /^(-?\d*\.?\d+)(px|rem)?$/.exec(value);
+  if (!match) throw new Error(`${name} resolves to "${value}", which is not a plain px/rem length`);
+  return match[2] === 'rem' ? Number(match[1]) * ROOT_FONT_SIZE : Number(match[1]);
+}
+
+function figmaValue(node: Record<string, unknown>, figmaPath: string): number {
+  const value = figmaPath.split('.').reduce<unknown>((current, key) => {
+    if (current === null || current === undefined) return current;
+    return (current as Record<string, unknown>)[key];
+  }, node);
+  if (typeof value !== 'number') throw new Error(`Figma node has no numeric "${figmaPath}"`);
+  return value;
+}
+
+let failures = 0;
+console.log(`Design parity against Figma file "${expectations.fileName}" (modified ${expectations.fileLastModified})`);
+for (const check of checks) {
+  const node = expectations.nodes[check.node];
+  try {
+    const expected = figmaValue(node, check.figma);
+    const actual = check.css.reduce((sum, [name, factor]) => sum + toPx(resolve(name), name) * factor, 0);
+    const ok = Math.abs(actual - expected) <= TOLERANCE;
+    if (!ok) failures += 1;
+    const formula = check.css.map(([name, factor]) => (factor === 1 ? name : `${factor} * ${name}`)).join(' + ');
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${check.name}: figma ${expected}px, css ${actual}px  (${formula})`);
+  } catch (error) {
+    failures += 1;
+    console.log(`FAIL  ${check.name}: ${(error as Error).message}`);
+  }
+}
+
+if (failures > 0) {
+  throw new Error(`${failures} design parity check(s) failed.`);
+}
+console.log(`\nAll ${checks.length} design parity checks passed.`);

--- a/packages/ui/scripts/design-parity/README.md
+++ b/packages/ui/scripts/design-parity/README.md
@@ -1,0 +1,34 @@
+# Design parity checks
+
+Deterministic comparison of the built component CSS against the geometry of the Design System 2.0
+masters in Figma. No browser, no screenshots: both sides are numbers.
+
+## How it works
+
+1. `nodes.json` lists the Figma nodes that act as sources (file key + node id + description).
+2. `pnpm design-parity:fetch` (needs `FIGMA_TOKEN`, a personal access token with file read scope)
+   reads those nodes through the Figma REST API and writes `expectations.json`: size, padding, item
+   spacing, corner radius, stroke weight and the `boundVariables` ids per node. The snapshot is
+   committed so the check runs offline and CI does not need a Figma token; refresh it whenever the
+   masters change (the file's `lastModified` is recorded).
+3. `checks.json` maps each Figma value to a sum of resolved CSS custom properties from
+   `dist/tokens.css` and `dist/index.css` (`var()` chains are followed, `rem` is converted at 16px).
+4. `pnpm check:design-parity` compares them with a 0.5px tolerance and fails the run on any mismatch.
+
+Run `pnpm build` first: the check reads the built package, like `check:built-css`.
+
+## Adding a check
+
+Add the node to `nodes.json`, refresh the snapshot, then add a row to `checks.json`: `figma` is a
+dot path into the node record (`width`, `paddingLeft`, `itemSpacing`, `cornerRadius`,
+`strokeWeight`, `children.0.strokeWeight`, ...), `css` is a list of `[customProperty, factor]` pairs
+that are summed (for example the port outer size is `size + 2 * border`).
+
+## Limits
+
+- Geometry only. `boundVariables` carries Figma variable ids, not names; mapping ids to token names
+  needs the variable export from the WB Audit Figma plugin (the Variables REST API is not available
+  on this plan). A binding-level check ("this part is bound to this token") is the next step once
+  that export lives next to `expectations.json`.
+- Values are compared at the root font size of 16px. A public variable overridden by a consumer is
+  outside the scope of the check.

--- a/packages/ui/scripts/design-parity/checks.json
+++ b/packages/ui/scripts/design-parity/checks.json
@@ -1,0 +1,57 @@
+[
+  { "name": "node shell width", "node": "node-shell", "figma": "width", "css": [["--wb-public-node-width", 1]] },
+  {
+    "name": "node shell horizontal padding",
+    "node": "node-shell",
+    "figma": "paddingLeft",
+    "css": [["--wb-public-node-padding", 1]]
+  },
+  {
+    "name": "node shell vertical padding",
+    "node": "node-shell",
+    "figma": "paddingTop",
+    "css": [["--wb-public-node-padding", 1]]
+  },
+  {
+    "name": "node shell vertical gap",
+    "node": "node-shell",
+    "figma": "itemSpacing",
+    "css": [["--wb-public-node-gap", 1]]
+  },
+  {
+    "name": "node shell corner radius",
+    "node": "node-shell",
+    "figma": "cornerRadius",
+    "css": [["--wb-public-node-border-radius", 1]]
+  },
+  {
+    "name": "node shell stroke",
+    "node": "node-shell",
+    "figma": "strokeWeight",
+    "css": [["--wb-public-node-border-size", 1]]
+  },
+  {
+    "name": "port default outer size",
+    "node": "port-default",
+    "figma": "width",
+    "css": [
+      ["--wb-public-node-port-size", 1],
+      ["--wb-public-node-port-border-size", 2]
+    ]
+  },
+  {
+    "name": "port hover outer size",
+    "node": "port-hover",
+    "figma": "width",
+    "css": [
+      ["--wb-public-node-port-size-hover", 1],
+      ["--wb-public-node-port-border-size", 2]
+    ]
+  },
+  {
+    "name": "port stroke",
+    "node": "port-default",
+    "figma": "children.0.strokeWeight",
+    "css": [["--wb-public-node-port-border-size", 1]]
+  }
+]

--- a/packages/ui/scripts/design-parity/expectations.json
+++ b/packages/ui/scripts/design-parity/expectations.json
@@ -1,0 +1,216 @@
+{
+  "fileKey": "hfT6zrYS948n8LrEK9y3Wh",
+  "fileName": "WB 2.0 - UI - Design System",
+  "fileLastModified": "2026-09-08T12:23:45Z",
+  "fetchedAt": "2026-09-09T18:29:14.361Z",
+  "nodes": {
+    "node-shell": {
+      "id": "9859:4113",
+      "description": "Node shell frame (Trigger master, State=Default)",
+      "name": "Frame 26085813",
+      "type": "FRAME",
+      "width": 241,
+      "height": 60,
+      "paddingLeft": 8,
+      "paddingRight": 8,
+      "paddingTop": 8,
+      "paddingBottom": 8,
+      "itemSpacing": 8,
+      "cornerRadius": 12,
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "boundVariables": {
+        "itemSpacing": {
+          "type": "VARIABLE_ALIAS",
+          "id": "VariableID:7389:22"
+        },
+        "paddingLeft": {
+          "type": "VARIABLE_ALIAS",
+          "id": "VariableID:7389:20"
+        },
+        "paddingTop": {
+          "type": "VARIABLE_ALIAS",
+          "id": "VariableID:7389:21"
+        },
+        "paddingRight": {
+          "type": "VARIABLE_ALIAS",
+          "id": "VariableID:7389:20"
+        },
+        "paddingBottom": {
+          "type": "VARIABLE_ALIAS",
+          "id": "VariableID:7389:21"
+        },
+        "rectangleCornerRadii": {
+          "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+            "type": "VARIABLE_ALIAS",
+            "id": "VariableID:9114:20"
+          },
+          "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+            "type": "VARIABLE_ALIAS",
+            "id": "VariableID:9114:20"
+          },
+          "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+            "type": "VARIABLE_ALIAS",
+            "id": "VariableID:9114:20"
+          },
+          "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+            "type": "VARIABLE_ALIAS",
+            "id": "VariableID:9114:20"
+          }
+        },
+        "fills": [
+          {
+            "type": "VARIABLE_ALIAS",
+            "id": "VariableID:9184:20"
+          }
+        ],
+        "strokes": [
+          {
+            "type": "VARIABLE_ALIAS",
+            "id": "VariableID:9184:25"
+          }
+        ]
+      },
+      "children": [
+        {
+          "name": "Frame 26085816",
+          "type": "FRAME",
+          "width": 225,
+          "height": 44,
+          "strokeWeight": 1,
+          "strokeAlign": "INSIDE",
+          "boundVariables": {
+            "itemSpacing": {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:7264:24"
+            }
+          }
+        },
+        {
+          "name": "Node / Content / Placeholder",
+          "type": "INSTANCE",
+          "width": 225,
+          "height": 128,
+          "strokeWeight": 1,
+          "strokeAlign": "INSIDE",
+          "boundVariables": {
+            "itemSpacing": {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:7264:24"
+            },
+            "paddingLeft": {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:7264:28"
+            },
+            "paddingTop": {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:7264:28"
+            },
+            "paddingRight": {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:7264:28"
+            },
+            "paddingBottom": {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:7264:28"
+            },
+            "fills": [
+              {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:763:53144"
+              }
+            ],
+            "strokes": [
+              {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:17:383"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "port-default": {
+      "id": "2668:3395",
+      "description": "Node / Port, State=Default",
+      "name": "State=Default",
+      "type": "COMPONENT",
+      "width": 8,
+      "height": 8,
+      "paddingLeft": null,
+      "paddingRight": null,
+      "paddingTop": null,
+      "paddingBottom": null,
+      "itemSpacing": null,
+      "cornerRadius": null,
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "boundVariables": {},
+      "children": [
+        {
+          "name": "Ellipse 2008",
+          "type": "ELLIPSE",
+          "width": 8,
+          "height": 8,
+          "strokeWeight": 2,
+          "strokeAlign": "INSIDE",
+          "boundVariables": {
+            "fills": [
+              {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:9184:29"
+              }
+            ],
+            "strokes": [
+              {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:9184:31"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "port-hover": {
+      "id": "2668:3393",
+      "description": "Node / Port, State=Hover",
+      "name": "State=Hover",
+      "type": "COMPONENT",
+      "width": 16,
+      "height": 16,
+      "paddingLeft": null,
+      "paddingRight": null,
+      "paddingTop": null,
+      "paddingBottom": null,
+      "itemSpacing": null,
+      "cornerRadius": null,
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "boundVariables": {},
+      "children": [
+        {
+          "name": "Ellipse 2009",
+          "type": "ELLIPSE",
+          "width": 16,
+          "height": 16,
+          "strokeWeight": 2,
+          "strokeAlign": "INSIDE",
+          "boundVariables": {
+            "fills": [
+              {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:9184:30"
+              }
+            ],
+            "strokes": [
+              {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:9184:32"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/ui/scripts/design-parity/fetch-expectations.ts
+++ b/packages/ui/scripts/design-parity/fetch-expectations.ts
@@ -1,0 +1,95 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type NodesConfig = {
+  fileKey: string;
+  nodes: Record<string, { id: string; description: string }>;
+};
+
+type FigmaNode = {
+  name: string;
+  type: string;
+  absoluteBoundingBox?: { width: number; height: number };
+  paddingLeft?: number;
+  paddingRight?: number;
+  paddingTop?: number;
+  paddingBottom?: number;
+  itemSpacing?: number;
+  cornerRadius?: number;
+  strokeWeight?: number;
+  strokeAlign?: string;
+  boundVariables?: Record<string, unknown>;
+  children?: FigmaNode[];
+};
+
+type FigmaNodesResponse = {
+  name: string;
+  lastModified: string;
+  nodes: Record<string, { document: FigmaNode }>;
+};
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const config = JSON.parse(readFileSync(path.join(directory, 'nodes.json'), 'utf8')) as NodesConfig;
+const token = process.env.FIGMA_TOKEN;
+
+if (!token) {
+  throw new Error('FIGMA_TOKEN is required (a personal access token with file read scope).');
+}
+
+const ids = Object.values(config.nodes).map((node) => node.id.replace(':', '-'));
+const response = await fetch(
+  `https://api.figma.com/v1/files/${config.fileKey}/nodes?ids=${ids.join(',')}&geometry=paths`,
+  { headers: { 'X-Figma-Token': token } },
+);
+
+if (!response.ok) {
+  throw new Error(`Figma API responded ${response.status} ${response.statusText}`);
+}
+
+const payload = (await response.json()) as FigmaNodesResponse;
+
+const pickChild = (child: FigmaNode) => ({
+  name: child.name,
+  type: child.type,
+  width: child.absoluteBoundingBox?.width ?? null,
+  height: child.absoluteBoundingBox?.height ?? null,
+  strokeWeight: child.strokeWeight ?? null,
+  strokeAlign: child.strokeAlign ?? null,
+  boundVariables: child.boundVariables ?? {},
+});
+
+const pick = (node: FigmaNode) => ({
+  name: node.name,
+  type: node.type,
+  width: node.absoluteBoundingBox?.width ?? null,
+  height: node.absoluteBoundingBox?.height ?? null,
+  paddingLeft: node.paddingLeft ?? null,
+  paddingRight: node.paddingRight ?? null,
+  paddingTop: node.paddingTop ?? null,
+  paddingBottom: node.paddingBottom ?? null,
+  itemSpacing: node.itemSpacing ?? null,
+  cornerRadius: node.cornerRadius ?? null,
+  strokeWeight: node.strokeWeight ?? null,
+  strokeAlign: node.strokeAlign ?? null,
+  boundVariables: node.boundVariables ?? {},
+  children: (node.children ?? []).map(pickChild),
+});
+
+const expectations = {
+  fileKey: config.fileKey,
+  fileName: payload.name,
+  fileLastModified: payload.lastModified,
+  fetchedAt: new Date().toISOString(),
+  nodes: Object.fromEntries(
+    Object.entries(config.nodes).map(([key, { id, description }]) => [
+      key,
+      { id, description, ...pick(payload.nodes[id].document) },
+    ]),
+  ),
+};
+
+writeFileSync(path.join(directory, 'expectations.json'), `${JSON.stringify(expectations, null, 2)}\n`);
+console.log(
+  `Wrote expectations for ${Object.keys(expectations.nodes).length} nodes (file modified ${payload.lastModified}).`,
+);

--- a/packages/ui/scripts/design-parity/nodes.json
+++ b/packages/ui/scripts/design-parity/nodes.json
@@ -1,0 +1,8 @@
+{
+  "fileKey": "hfT6zrYS948n8LrEK9y3Wh",
+  "nodes": {
+    "node-shell": { "id": "9859:4113", "description": "Node shell frame (Trigger master, State=Default)" },
+    "port-default": { "id": "2668:3395", "description": "Node / Port, State=Default" },
+    "port-hover": { "id": "2668:3393", "description": "Node / Port, State=Hover" }
+  }
+}


### PR DESCRIPTION
Proof of concept for automated design-to-code parity, deterministic and browser-free.

## What it does

- `packages/ui/scripts/design-parity/nodes.json` lists the Figma masters used as sources (node shell frame, port Default and Hover).
- `pnpm design-parity:fetch` (needs `FIGMA_TOKEN`) reads them through the Figma REST API and writes a committed `expectations.json` snapshot: size, padding, item spacing, corner radius, stroke weight and `boundVariables` ids, plus the file's `lastModified`.
- `checks.json` maps each Figma value to a sum of built CSS custom properties (`var()` chains resolved through `dist/tokens.css` and `dist/index.css`, `rem` at 16px).
- `pnpm check:design-parity` compares with a 0.5px tolerance; wired into the ui `build` after `check:built-css`, so the existing CI build job runs it without a Figma token.

## Current checks (9, all passing against the file as of 2026-09-08)

Node shell: width 241, horizontal and vertical padding 8, gap 8, corner radius 12, stroke 1. Port: default outer size 8 (`size + 2 * border`), hover outer size 16, stroke 2. Reverting the shell width to the pre-DS 2.0 258px makes the first check fail (verified locally).

## Limits and next steps

- Geometry only. The snapshot carries variable ids, not names (Variables REST API is not available on this plan); a binding-level check needs the id-to-name export from the WB Audit Figma plugin next to the snapshot.
- A browser-level geometry test (measured layout of the rendered component, Vitest browser mode) would add a second layer but needs new dependencies (Playwright provider) - proposed as a separate decision.
- No changeset: developer tooling, nothing ships in `dist/`.